### PR TITLE
c# Nullable to YQL Option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Test
         run: | 
           cd src
-          dotnet test
+          dotnet test --filter "Category=Unit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+- Add methods for castion to c# nullable to YQL Optional 
+- Add explicit cast operator for some types
+- Tests refactoring

--- a/src/Ydb.Sdk/src/Value/YdbValueBuilder.cs
+++ b/src/Ydb.Sdk/src/Value/YdbValueBuilder.cs
@@ -218,10 +218,10 @@ namespace Ydb.Sdk.Value
         public static YdbValue MakeOptional(YdbValue value)
         {
             return new YdbValue(
-                new Ydb.Type { OptionalType = new OptionalType { Item = value._protoType }},
+                new Ydb.Type { OptionalType = new OptionalType { Item = value._protoType } },
                 value.TypeId != YdbTypeId.OptionalType
                     ? value._protoValue
-                    : new Ydb.Value { NestedValue = value._protoValue});
+                    : new Ydb.Value { NestedValue = value._protoValue });
         }
 
         // TODO: MakeEmptyList with complex types
@@ -387,6 +387,66 @@ namespace Ydb.Sdk.Value
         public static YdbValue MakeOptionalInterval(TimeSpan? value)
         {
             return MakeOptionalOf(value, YdbTypeId.Interval, MakeInterval);
+        }
+
+        public static YdbValue MakeOptionalString(byte[]? value)
+        {
+            if (value is null)
+            {
+                return MakeEmptyOptional(YdbTypeId.String);
+            }
+            else
+            {
+                return MakeOptional(MakeString(value));
+            }
+        }
+
+        public static YdbValue MakeOptionalUtf8(string? value)
+        {
+            if (value is null)
+            {
+                return MakeEmptyOptional(YdbTypeId.Utf8);
+            }
+            else
+            {
+                return MakeOptional(MakeUtf8(value));
+            }
+        }
+
+        public static YdbValue MakeOptionalYson(byte[]? value)
+        {
+            if (value is null)
+            {
+                return MakeEmptyOptional(YdbTypeId.Yson);
+            }
+            else
+            {
+                return MakeOptional(MakeYson(value));
+            }
+        }
+
+        public static YdbValue MakeOptionalJson(string? value)
+        {
+            if (value is null)
+            {
+                return MakeEmptyOptional(YdbTypeId.Json);
+            }
+            else
+            {
+                return MakeOptional(MakeJson(value));
+            }
+        }
+
+        public static YdbValue MakeOptionalJsonDocument(string? value)
+        {
+            if (value is null)
+            {
+                return MakeEmptyOptional(YdbTypeId.JsonDocument);
+            }
+            else
+            {
+                return MakeOptional(MakeJsonDocument(value));
+            }
         }
     }
 }

--- a/src/Ydb.Sdk/src/Value/YdbValueBuilder.cs
+++ b/src/Ydb.Sdk/src/Value/YdbValueBuilder.cs
@@ -304,9 +304,14 @@ namespace Ydb.Sdk.Value
 
         private static YdbValue MakeOptionalOf<T>(T? value, YdbTypeId type, Func<T, YdbValue> func) where T : struct
         {
-            return value.HasValue
-                ? MakeOptional(func(value ?? default))
-                : MakeEmptyOptional(type);
+            if (value is null)
+            {
+                return MakeEmptyOptional(type);
+            }
+            else
+            {
+                return MakeOptional(func((T)value));
+            }
         }
 
         public static YdbValue MakeOptionalBool(bool? value)

--- a/src/Ydb.Sdk/src/Value/YdbValueBuilder.cs
+++ b/src/Ydb.Sdk/src/Value/YdbValueBuilder.cs
@@ -300,5 +300,88 @@ namespace Ydb.Sdk.Value
                 throw new ArgumentException($"Complex types aren't supported in current method: {typeId}", "typeId");
             }
         }
+
+
+        private static YdbValue MakeOptionalOf<T>(T? value, YdbTypeId type, Func<T, YdbValue> func) where T : struct
+        {
+            return value.HasValue
+                ? MakeOptional(func(value ?? default))
+                : MakeEmptyOptional(type);
+        }
+
+        public static YdbValue MakeOptionalBool(bool? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Bool, MakeBool);
+        }
+
+        public static YdbValue MakeOptionalInt8(sbyte? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Int8, MakeInt8);
+        }
+
+        public static YdbValue MakeOptionalUint8(byte? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Uint8, MakeUint8);
+        }
+
+        public static YdbValue MakeOptionalInt16(short? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Int16, MakeInt16);
+        }
+
+        public static YdbValue MakeOptionalUint16(ushort? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Uint16, MakeUint16);
+        }
+
+        public static YdbValue MakeOptionalInt32(int? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Int32, MakeInt32);
+        }
+
+        public static YdbValue MakeOptionalUint32(uint? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Uint32, MakeUint32);
+        }
+
+        public static YdbValue MakeOptionalInt64(long? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Int64, MakeInt64);
+        }
+
+        public static YdbValue MakeOptionalUint64(ulong? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Uint64, MakeUint64);
+        }
+
+        public static YdbValue MakeOptionalFloat(float? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Float, MakeFloat);
+        }
+
+        public static YdbValue MakeOptionalDouble(double? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Double, MakeDouble);
+        }
+
+        public static YdbValue MakeOptionalDate(DateTime? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Date, MakeDate);
+        }
+
+        public static YdbValue MakeOptionalDatetime(DateTime? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Datetime, MakeDatetime);
+        }
+
+        public static YdbValue MakeOptionalTimestamp(DateTime? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Timestamp, MakeTimestamp);
+        }
+
+        public static YdbValue MakeOptionalInterval(TimeSpan? value)
+        {
+            return MakeOptionalOf(value, YdbTypeId.Interval, MakeInterval);
+        }
     }
 }

--- a/src/Ydb.Sdk/src/Value/YdbValueCast.cs
+++ b/src/Ydb.Sdk/src/Value/YdbValueCast.cs
@@ -187,5 +187,136 @@ namespace Ydb.Sdk.Value
 
             }
         }
+
+        public static explicit operator YdbValue(bool value)
+        {
+            return MakeBool(value);
+        }
+
+        public static explicit operator YdbValue(bool? value)
+        {
+            return MakeOptionalBool(value);
+        }
+
+        public static explicit operator YdbValue(sbyte value)
+        {
+            return MakeInt8(value);
+        }
+
+        public static explicit operator YdbValue(sbyte? value)
+        {
+            return MakeOptionalInt8(value);
+        }
+
+        public static explicit operator YdbValue(byte value)
+        {
+            return MakeUint8(value);
+        }
+
+        public static explicit operator YdbValue(byte? value)
+        {
+            return MakeOptionalUint8(value);
+        }
+
+        public static explicit operator YdbValue(short value)
+        {
+            return MakeInt16(value);
+        }
+
+        public static explicit operator YdbValue(short? value)
+        {
+            return MakeOptionalInt16(value);
+        }
+
+        public static explicit operator YdbValue(ushort value)
+        {
+            return MakeUint16(value);
+        }
+
+        public static explicit operator YdbValue(ushort? value)
+        {
+            return MakeOptionalUint16(value);
+        }
+
+        public static explicit operator YdbValue(int value)
+        {
+            return MakeInt32(value);
+        }
+
+        public static explicit operator YdbValue(int? value)
+        {
+            return MakeOptionalInt32(value);
+        }
+
+        public static explicit operator YdbValue(uint value)
+        {
+            return MakeUint32(value);
+        }
+
+        public static explicit operator YdbValue(uint? value)
+        {
+            return MakeOptionalUint32(value);
+        }
+
+        public static explicit operator YdbValue(long value)
+        {
+            return MakeInt64(value);
+        }
+
+        public static explicit operator YdbValue(long? value)
+        {
+            return MakeOptionalInt64(value);
+        }
+
+        public static explicit operator YdbValue(ulong value)
+        {
+            return MakeUint64(value);
+        }
+
+        public static explicit operator YdbValue(ulong? value)
+        {
+            return MakeOptionalUint64(value);
+        }
+
+        public static explicit operator YdbValue(float value)
+        {
+            return MakeFloat(value);
+        }
+
+        public static explicit operator YdbValue(float? value)
+        {
+            return MakeOptionalFloat(value);
+        }
+
+        public static explicit operator YdbValue(double value)
+        {
+            return MakeDouble(value);
+        }
+
+        public static explicit operator YdbValue(double? value)
+        {
+            return MakeOptionalDouble(value);
+        }
+
+
+        public static explicit operator YdbValue(DateTime value)
+        {
+            return MakeDate(value);
+        }
+
+        public static explicit operator YdbValue(DateTime? value)
+        {
+            return MakeOptionalDate(value);
+        }
+
+        public static explicit operator YdbValue(TimeSpan value)
+        {
+            return MakeInterval(value);
+        }
+
+        public static explicit operator YdbValue(TimeSpan? value)
+        {
+            return MakeOptionalInterval(value);
+        }
     }
 }

--- a/src/Ydb.Sdk/src/Value/YdbValueCast.cs
+++ b/src/Ydb.Sdk/src/Value/YdbValueCast.cs
@@ -298,17 +298,6 @@ namespace Ydb.Sdk.Value
             return MakeOptionalDouble(value);
         }
 
-
-        public static explicit operator YdbValue(DateTime value)
-        {
-            return MakeDate(value);
-        }
-
-        public static explicit operator YdbValue(DateTime? value)
-        {
-            return MakeOptionalDate(value);
-        }
-
         public static explicit operator YdbValue(TimeSpan value)
         {
             return MakeInterval(value);

--- a/src/Ydb.Sdk/src/Value/YdbValueParser.cs
+++ b/src/Ydb.Sdk/src/Value/YdbValueParser.cs
@@ -133,6 +133,12 @@ namespace Ydb.Sdk.Value
             return _protoValue.TextValue;
         }
 
+        public bool? GetOptionalBool()
+        {
+            return GetOptional()?.GetBool();
+        }
+
+
         public sbyte? GetOptionalInt8()
         {
             return GetOptional()?.GetInt8();

--- a/src/Ydb.Sdk/tests/Value/TestBasic.cs
+++ b/src/Ydb.Sdk/tests/Value/TestBasic.cs
@@ -69,8 +69,8 @@ namespace Ydb.Sdk.Value.Tests
             Assert.Equal("{type=\"yson\"}", Encoding.ASCII.GetString(elements[16].GetYson()));
             Assert.Equal("{\"type\": \"json\"}", elements[17].GetJson());
             Assert.Equal("{\"type\": \"jsondoc\"}", elements[18].GetJsonDocument());
-            Assert.Equal(true, elements[19].GetBool());
-            Assert.Equal(false, elements[20].GetBool());
+            Assert.True(elements[19].GetBool());
+            Assert.False(elements[20].GetBool());
 
             Assert.Equal(-1, (sbyte)elements[0]);
             Assert.Equal(200u, (byte)elements[1]);
@@ -91,8 +91,70 @@ namespace Ydb.Sdk.Value.Tests
             Assert.Equal("{type=\"yson\"}", Encoding.ASCII.GetString((byte[])elements[16]!));
             Assert.Equal("{\"type\": \"json\"}", (string)elements[17]!);
             Assert.Equal("{\"type\": \"jsondoc\"}", (string)elements[18]!);
-            Assert.Equal(true, (bool)elements[19]);
-            Assert.Equal(false, (bool)elements[20]);
+            Assert.True((bool)elements[19]);
+            Assert.False((bool)elements[20]);
+        }
+
+        [Fact]
+        public void OptimalPrimitiveTypes()
+        {
+            var value = YdbValue.MakeTuple(new YdbValue[] {
+                (YdbValue)(sbyte?)-1,
+                (YdbValue)(byte?)200,
+                (YdbValue)(short?)-200,
+                (YdbValue)(ushort?)40_000,
+                (YdbValue)(int?)-40000,
+                (YdbValue)(uint?)4_000_000_000,
+                (YdbValue)(long?)-4_000_000_000,
+                (YdbValue)(ulong?)10_000_000_000,
+                (YdbValue)(float?)-1.7f,
+                (YdbValue)(double?)123.45,
+                YdbValue.MakeOptionalDate(new DateTime(2021, 08, 21)),
+                YdbValue.MakeOptionalDatetime(new DateTime(2021, 08, 21, 23, 30, 47)),
+                YdbValue.MakeOptionalTimestamp(new DateTime(2021, 08, 21, 23, 30, 47, 581)),
+                YdbValue.MakeOptionalInterval(-new TimeSpan(3, 7, 40, 27, 729)),
+                (YdbValue)(bool?)true,
+                (YdbValue)(bool?)false,
+            });
+
+            _output.WriteLine(value.ToString());
+
+            var elements = value.GetTuple();
+            Assert.Equal(16, elements.Count);
+
+            Assert.Equal((sbyte?)-1, elements[0].GetOptionalInt8());
+            Assert.Equal((byte?)200, elements[1].GetOptionalUint8());
+            Assert.Equal((short?)-200, elements[2].GetOptionalInt16());
+            Assert.Equal((ushort?)40_000, elements[3].GetOptionalUint16());
+            Assert.Equal(-40_000, elements[4].GetOptionalInt32());
+            Assert.Equal(4_000_000_000, elements[5].GetOptionalUint32());
+            Assert.Equal(-4_000_000_000, elements[6].GetOptionalInt64());
+            Assert.Equal(10_000_000_000ul, elements[7].GetOptionalUint64());
+            Assert.Equal(-1.7f, elements[8].GetOptionalFloat());
+            Assert.Equal(123.45, elements[9].GetOptionalDouble());
+            Assert.Equal(new DateTime(2021, 08, 21), elements[10].GetOptionalDate());
+            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47), elements[11].GetOptionalDatetime());
+            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47, 581), elements[12].GetOptionalTimestamp());
+            Assert.Equal(-new TimeSpan(3, 7, 40, 27, 729), elements[13].GetOptionalInterval());
+            Assert.Equal(true, elements[14].GetOptionalBool());
+            Assert.Equal(false, elements[15].GetOptionalBool());
+
+            Assert.Equal((sbyte?)-1, (sbyte?)elements[0]);
+            Assert.Equal((byte?)200u, (byte?)elements[1]);
+            Assert.Equal((short?)-200, (short?)elements[2]);
+            Assert.Equal((ushort?)40_000, (ushort?) elements[3]);
+            Assert.Equal(-40_000, (int?) elements[4]);
+            Assert.Equal(4_000_000_000, (uint?)elements[5]);
+            Assert.Equal(-4_000_000_000, (long?)elements[6]);
+            Assert.Equal(10_000_000_000ul, (ulong?)elements[7]);
+            Assert.Equal(-1.7f, (float?)elements[8]);
+            Assert.Equal(123.45, (double?)elements[9]);
+            Assert.Equal(new DateTime(2021, 08, 21), (DateTime?)elements[10]);
+            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47), (DateTime?)elements[11]);
+            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47, 581), (DateTime?)elements[12]);
+            Assert.Equal(-new TimeSpan(3, 7, 40, 27, 729), (TimeSpan?)elements[13]);
+            Assert.True((bool?)elements[14]);
+            Assert.False((bool?)elements[15]);
         }
 
         [Fact]

--- a/src/Ydb.Sdk/tests/Value/TestBasicUnit.cs
+++ b/src/Ydb.Sdk/tests/Value/TestBasicUnit.cs
@@ -118,6 +118,9 @@ namespace Ydb.Sdk.Value.Tests
 
             var valueDouble = 123.45;
             Assert.Equal(valueDouble, (double)(YdbValue)valueDouble);
+
+            var valueInterval = -new TimeSpan(3, 7, 40, 27, 729);
+            Assert.Equal(valueInterval, (TimeSpan)(YdbValue)valueInterval);
         }
 
         [Fact]
@@ -241,6 +244,9 @@ namespace Ydb.Sdk.Value.Tests
             double? valueDouble = 123.45;
             Assert.Equal(valueDouble, (double?)(YdbValue)valueDouble);
 
+            TimeSpan? valueInterval = -new TimeSpan(3, 7, 40, 27, 729);
+            Assert.Equal(valueInterval, (TimeSpan?)(YdbValue)valueInterval);
+
             Assert.Null((bool?)(YdbValue)(bool?)null);
             Assert.Null((sbyte?)(YdbValue)(sbyte?)null);
             Assert.Null((byte?)(YdbValue)(byte?)null);
@@ -252,6 +258,7 @@ namespace Ydb.Sdk.Value.Tests
             Assert.Null((ulong?)(YdbValue)(ulong?)null);
             Assert.Null((float?)(YdbValue)(float?)null);
             Assert.Null((double?)(YdbValue)(double?)null);
+            Assert.Null((TimeSpan?)(YdbValue)(TimeSpan?)null);
         }
 
         [Fact]

--- a/src/Ydb.Sdk/tests/Value/TestBasicUnit.cs
+++ b/src/Ydb.Sdk/tests/Value/TestBasicUnit.cs
@@ -9,11 +9,12 @@ using Xunit.Abstractions;
 
 namespace Ydb.Sdk.Value.Tests
 {
-    public class TestBasic
+    [Trait("Category", "Unit")]
+    public class TestBasicUnit
     {
         private readonly ITestOutputHelper _output;
 
-        public TestBasic(ITestOutputHelper output)
+        public TestBasicUnit(ITestOutputHelper output)
         {
             _output = output;
         }

--- a/src/Ydb.Sdk/tests/Value/TestBasicUnit.cs
+++ b/src/Ydb.Sdk/tests/Value/TestBasicUnit.cs
@@ -20,142 +20,146 @@ namespace Ydb.Sdk.Value.Tests
         }
 
         [Fact]
-        public void PrimitiveTypes()
+        public void PrimitiveTypesMakeGet()
         {
-            var value = YdbValue.MakeTuple(new YdbValue[] {
-                YdbValue.MakeInt8(-1),
-                YdbValue.MakeUint8(200),
-                YdbValue.MakeInt16(-200),
-                YdbValue.MakeUint16(40_000),
-                YdbValue.MakeInt32(-40000),
-                YdbValue.MakeUint32(4_000_000_000),
-                YdbValue.MakeInt64(-4_000_000_000),
-                YdbValue.MakeUint64(10_000_000_000),
-                YdbValue.MakeFloat(-1.7f),
-                YdbValue.MakeDouble(123.45),
-                YdbValue.MakeDate(new DateTime(2021, 08, 21)),
-                YdbValue.MakeDatetime(new DateTime(2021, 08, 21, 23, 30, 47)),
-                YdbValue.MakeTimestamp(new DateTime(2021, 08, 21, 23, 30, 47, 581)),
-                YdbValue.MakeInterval(-new TimeSpan(3, 7, 40, 27, 729)),
-                YdbValue.MakeString(Encoding.ASCII.GetBytes("test str")),
-                YdbValue.MakeUtf8("unicode str"),
-                YdbValue.MakeYson(Encoding.ASCII.GetBytes("{type=\"yson\"}")),
-                YdbValue.MakeJson("{\"type\": \"json\"}"),
-                YdbValue.MakeJsonDocument("{\"type\": \"jsondoc\"}"),
-                YdbValue.MakeBool(true),
-                YdbValue.MakeBool(false),
-            });
+            var valueBool = true;
+            var valueInt8 = (sbyte)-1;
+            var valueUint8 = (byte)200;
+            var valueInt16 = (short)-200;
+            var valueUint16 = (ushort)40_000;
+            var valueInt32 = -40000;
+            var valueUint32 = 4_000_000_000;
+            var valueInt64 = -4_000_000_000;
+            var valueUint64 = 10_000_000_000ul;
+            var valueFloat = -1.7f;
+            var valueDouble = 123.45;
+            var valueDate = new DateTime(2021, 08, 21);
+            var valueDatetime = new DateTime(2021, 08, 21, 23, 30, 47);
+            var valueTimestamp = new DateTime(2021, 08, 21, 23, 30, 47, 581);
+            var valueInterval = -new TimeSpan(3, 7, 40, 27, 729);
+            var valueString = Encoding.ASCII.GetBytes("test str");
+            var valueUtf8 = "unicode str";
+            var valueYson = Encoding.ASCII.GetBytes("{type=\"yson\"}");
+            var valueJson = "{\"type\": \"json\"}";
+            var valueJsonDocument = "{\"type\": \"jsondoc\"}";
 
-            _output.WriteLine(value.ToString());
+            Assert.Equal(valueBool, YdbValue.MakeBool(valueBool).GetBool());
+            Assert.Equal(valueInt8, YdbValue.MakeInt8(valueInt8).GetInt8());
+            Assert.Equal(valueUint8, YdbValue.MakeUint8(valueUint8).GetUint8());
+            Assert.Equal(valueInt16, YdbValue.MakeInt16(valueInt16).GetInt16());
+            Assert.Equal(valueUint16, YdbValue.MakeUint16(valueUint16).GetUint16());
+            Assert.Equal(valueInt32, YdbValue.MakeInt32(valueInt32).GetInt32());
+            Assert.Equal(valueUint32, YdbValue.MakeUint32(valueUint32).GetUint32());
+            Assert.Equal(valueInt64, YdbValue.MakeInt64(valueInt64).GetInt64());
+            Assert.Equal(valueUint64, YdbValue.MakeUint64(valueUint64).GetUint64());
+            Assert.Equal(valueFloat, YdbValue.MakeFloat(valueFloat).GetFloat());
+            Assert.Equal(valueDouble, YdbValue.MakeDouble(valueDouble).GetDouble());
+            Assert.Equal(valueDate, YdbValue.MakeDate(valueDate).GetDate());
+            Assert.Equal(valueDatetime, YdbValue.MakeDatetime(valueDatetime).GetDatetime());
+            Assert.Equal(valueTimestamp, YdbValue.MakeTimestamp(valueTimestamp).GetTimestamp());
+            Assert.Equal(valueInterval, YdbValue.MakeInterval(valueInterval).GetInterval());
+            Assert.Equal(valueString, YdbValue.MakeString(valueString).GetString());
+            Assert.Equal(valueUtf8, YdbValue.MakeUtf8(valueUtf8).GetUtf8());
+            Assert.Equal(valueYson, YdbValue.MakeYson(valueYson).GetYson());
+            Assert.Equal(valueJson, YdbValue.MakeJson(valueJson).GetJson());
+            Assert.Equal(valueJsonDocument, YdbValue.MakeJsonDocument(valueJsonDocument).GetJsonDocument());
 
-            var elements = value.GetTuple();
-            Assert.Equal(21, elements.Count);
-
-            Assert.Equal(-1, elements[0].GetInt8());
-            Assert.Equal(200, elements[1].GetUint8());
-            Assert.Equal(-200, elements[2].GetInt16());
-            Assert.Equal(40_000, elements[3].GetUint16());
-            Assert.Equal(-40_000, elements[4].GetInt32());
-            Assert.Equal(4_000_000_000, elements[5].GetUint32());
-            Assert.Equal(-4_000_000_000, elements[6].GetInt64());
-            Assert.Equal(10_000_000_000ul, elements[7].GetUint64());
-            Assert.Equal(-1.7f, elements[8].GetFloat());
-            Assert.Equal(123.45, elements[9].GetDouble());
-            Assert.Equal(new DateTime(2021, 08, 21), elements[10].GetDate());
-            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47), elements[11].GetDatetime());
-            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47, 581), elements[12].GetTimestamp());
-            Assert.Equal(-new TimeSpan(3, 7, 40, 27, 729), elements[13].GetInterval());
-            Assert.Equal("test str", Encoding.ASCII.GetString(elements[14].GetString()));
-            Assert.Equal("unicode str", elements[15].GetUtf8());
-            Assert.Equal("{type=\"yson\"}", Encoding.ASCII.GetString(elements[16].GetYson()));
-            Assert.Equal("{\"type\": \"json\"}", elements[17].GetJson());
-            Assert.Equal("{\"type\": \"jsondoc\"}", elements[18].GetJsonDocument());
-            Assert.True(elements[19].GetBool());
-            Assert.False(elements[20].GetBool());
-
-            Assert.Equal(-1, (sbyte)elements[0]);
-            Assert.Equal(200u, (byte)elements[1]);
-            Assert.Equal(-200, (short)elements[2]);
-            Assert.Equal(40_000, (ushort) elements[3]);
-            Assert.Equal(-40_000, (int) elements[4]);
-            Assert.Equal(4_000_000_000, (uint)elements[5]);
-            Assert.Equal(-4_000_000_000, (long)elements[6]);
-            Assert.Equal(10_000_000_000ul, (ulong)elements[7]);
-            Assert.Equal(-1.7f, (float)elements[8]);
-            Assert.Equal(123.45, (double)elements[9]);
-            Assert.Equal(new DateTime(2021, 08, 21), (DateTime)elements[10]);
-            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47), (DateTime)elements[11]);
-            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47, 581), (DateTime)elements[12]);
-            Assert.Equal(-new TimeSpan(3, 7, 40, 27, 729), (TimeSpan)elements[13]);
-            Assert.Equal("test str", Encoding.ASCII.GetString((byte[])elements[14]!));
-            Assert.Equal("unicode str", (string)elements[15]!);
-            Assert.Equal("{type=\"yson\"}", Encoding.ASCII.GetString((byte[])elements[16]!));
-            Assert.Equal("{\"type\": \"json\"}", (string)elements[17]!);
-            Assert.Equal("{\"type\": \"jsondoc\"}", (string)elements[18]!);
-            Assert.True((bool)elements[19]);
-            Assert.False((bool)elements[20]);
         }
 
         [Fact]
-        public void OptimalPrimitiveTypes()
+        public void PrimitiveTypesExplicitCast() {
+
+            var valueBool = true;
+            var valueInt8 = (sbyte)-1;
+            var valueUint8 = (byte)200;
+            var valueInt16 = (short)-200;
+            var valueUint16 = (ushort)40_000;
+            var valueInt32 = -40000;
+            var valueUint32 = 4_000_000_000;
+            var valueInt64 = -4_000_000_000;
+            var valueUint64 = 10_000_000_000ul;
+            var valueFloat = -1.7f;
+            var valueDouble = 123.45;
+
+            Assert.Equal(valueBool, (bool)(YdbValue)valueBool);
+            Assert.Equal(valueInt8, (sbyte)(YdbValue)valueInt8);
+            Assert.Equal(valueUint8, (byte)(YdbValue)valueUint8);
+            Assert.Equal(valueInt16, (short)(YdbValue)valueInt16);
+            Assert.Equal(valueUint16, (ushort)(YdbValue)valueUint16);
+            Assert.Equal(valueInt32, (int)(YdbValue)valueInt32);
+            Assert.Equal(valueUint32, (uint)(YdbValue)valueUint32);
+            Assert.Equal(valueInt64, (long)(YdbValue)valueInt64);
+            Assert.Equal(valueUint64, (ulong)(YdbValue)valueUint64);
+            Assert.Equal(valueFloat, (float)(YdbValue)valueFloat);
+            Assert.Equal(valueDouble, (double)(YdbValue)valueDouble);
+        }
+
+        [Fact]
+        public void OptimalPrimitiveTypesMakeGet()
         {
-            var value = YdbValue.MakeTuple(new YdbValue[] {
-                (YdbValue)(sbyte?)-1,
-                (YdbValue)(byte?)200,
-                (YdbValue)(short?)-200,
-                (YdbValue)(ushort?)40_000,
-                (YdbValue)(int?)-40000,
-                (YdbValue)(uint?)4_000_000_000,
-                (YdbValue)(long?)-4_000_000_000,
-                (YdbValue)(ulong?)10_000_000_000,
-                (YdbValue)(float?)-1.7f,
-                (YdbValue)(double?)123.45,
-                YdbValue.MakeOptionalDate(new DateTime(2021, 08, 21)),
-                YdbValue.MakeOptionalDatetime(new DateTime(2021, 08, 21, 23, 30, 47)),
-                YdbValue.MakeOptionalTimestamp(new DateTime(2021, 08, 21, 23, 30, 47, 581)),
-                YdbValue.MakeOptionalInterval(-new TimeSpan(3, 7, 40, 27, 729)),
-                (YdbValue)(bool?)true,
-                (YdbValue)(bool?)false,
-            });
+            var valueBool = true;
+            var valueInt8 = (sbyte)-1;
+            var valueUint8 = (byte)200;
+            var valueInt16 = (short)-200;
+            var valueUint16 = (ushort)40_000;
+            var valueInt32 = -40000;
+            var valueUint32 = 4_000_000_000;
+            var valueInt64 = -4_000_000_000;
+            var valueUint64 = 10_000_000_000ul;
+            var valueFloat = -1.7f;
+            var valueDouble = 123.45;
+            var valueDate = new DateTime(2021, 08, 21);
+            var valueDatetime = new DateTime(2021, 08, 21, 23, 30, 47);
+            var valueTimestamp = new DateTime(2021, 08, 21, 23, 30, 47, 581);
+            var valueInterval = -new TimeSpan(3, 7, 40, 27, 729);
 
-            _output.WriteLine(value.ToString());
+            Assert.Equal(valueBool, YdbValue.MakeOptionalBool(valueBool).GetOptionalBool());
+            Assert.Equal(valueInt8, YdbValue.MakeOptionalInt8(valueInt8).GetOptionalInt8());
+            Assert.Equal(valueUint8, YdbValue.MakeOptionalUint8(valueUint8).GetOptionalUint8());
+            Assert.Equal(valueInt16, YdbValue.MakeOptionalInt16(valueInt16).GetOptionalInt16());
+            Assert.Equal(valueUint16, YdbValue.MakeOptionalUint16(valueUint16).GetOptionalUint16());
+            Assert.Equal(valueInt32, YdbValue.MakeOptionalInt32(valueInt32).GetOptionalInt32());
+            Assert.Equal(valueUint32, YdbValue.MakeOptionalUint32(valueUint32).GetOptionalUint32());
+            Assert.Equal(valueInt64, YdbValue.MakeOptionalInt64(valueInt64).GetOptionalInt64());
+            Assert.Equal(valueUint64, YdbValue.MakeOptionalUint64(valueUint64).GetOptionalUint64());
+            Assert.Equal(valueFloat, YdbValue.MakeOptionalFloat(valueFloat).GetOptionalFloat());
+            Assert.Equal(valueDouble, YdbValue.MakeOptionalDouble(valueDouble).GetOptionalDouble());
+            Assert.Equal(valueDate, YdbValue.MakeOptionalDate(valueDate).GetOptionalDate());
+            Assert.Equal(valueDatetime, YdbValue.MakeOptionalDatetime(valueDatetime).GetOptionalDatetime());
+            Assert.Equal(valueTimestamp, YdbValue.MakeOptionalTimestamp(valueTimestamp).GetOptionalTimestamp());
+            Assert.Equal(valueInterval, YdbValue.MakeOptionalInterval(valueInterval).GetOptionalInterval());
 
-            var elements = value.GetTuple();
-            Assert.Equal(16, elements.Count);
+            // TODO make optional string types
+        }
 
-            Assert.Equal((sbyte?)-1, elements[0].GetOptionalInt8());
-            Assert.Equal((byte?)200, elements[1].GetOptionalUint8());
-            Assert.Equal((short?)-200, elements[2].GetOptionalInt16());
-            Assert.Equal((ushort?)40_000, elements[3].GetOptionalUint16());
-            Assert.Equal(-40_000, elements[4].GetOptionalInt32());
-            Assert.Equal(4_000_000_000, elements[5].GetOptionalUint32());
-            Assert.Equal(-4_000_000_000, elements[6].GetOptionalInt64());
-            Assert.Equal(10_000_000_000ul, elements[7].GetOptionalUint64());
-            Assert.Equal(-1.7f, elements[8].GetOptionalFloat());
-            Assert.Equal(123.45, elements[9].GetOptionalDouble());
-            Assert.Equal(new DateTime(2021, 08, 21), elements[10].GetOptionalDate());
-            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47), elements[11].GetOptionalDatetime());
-            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47, 581), elements[12].GetOptionalTimestamp());
-            Assert.Equal(-new TimeSpan(3, 7, 40, 27, 729), elements[13].GetOptionalInterval());
-            Assert.Equal(true, elements[14].GetOptionalBool());
-            Assert.Equal(false, elements[15].GetOptionalBool());
+        [Fact]
+        public void OptimalPrimitiveCast()
+        {
+            var valueBool = (bool?)true;
+            var valueInt8 = (sbyte?)-1;
+            var valueUint8 = (byte?)200;
+            var valueInt16 = (short?)-200;
+            var valueUint16 = (ushort?)40_000;
+            var valueInt32 = (int?)-40000;
+            var valueUint32 = (uint?)4_000_000_000;
+            var valueInt64 = (long?)-4_000_000_000;
+            var valueUint64 = (ulong?)10_000_000_000ul;
+            var valueFloat = (float?)-1.7f;
+            var valueDouble = (double?)123.45;
 
-            Assert.Equal((sbyte?)-1, (sbyte?)elements[0]);
-            Assert.Equal((byte?)200u, (byte?)elements[1]);
-            Assert.Equal((short?)-200, (short?)elements[2]);
-            Assert.Equal((ushort?)40_000, (ushort?) elements[3]);
-            Assert.Equal(-40_000, (int?) elements[4]);
-            Assert.Equal(4_000_000_000, (uint?)elements[5]);
-            Assert.Equal(-4_000_000_000, (long?)elements[6]);
-            Assert.Equal(10_000_000_000ul, (ulong?)elements[7]);
-            Assert.Equal(-1.7f, (float?)elements[8]);
-            Assert.Equal(123.45, (double?)elements[9]);
-            Assert.Equal(new DateTime(2021, 08, 21), (DateTime?)elements[10]);
-            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47), (DateTime?)elements[11]);
-            Assert.Equal(new DateTime(2021, 08, 21, 23, 30, 47, 581), (DateTime?)elements[12]);
-            Assert.Equal(-new TimeSpan(3, 7, 40, 27, 729), (TimeSpan?)elements[13]);
-            Assert.True((bool?)elements[14]);
-            Assert.False((bool?)elements[15]);
+            Assert.Equal(valueBool, (bool?)(YdbValue)valueBool);
+            Assert.Equal(valueInt8, (sbyte?)(YdbValue)valueInt8);
+            Assert.Equal(valueUint8, (byte?)(YdbValue)valueUint8);
+            Assert.Equal(valueInt16, (short?)(YdbValue)valueInt16);
+            Assert.Equal(valueUint16, (ushort?)(YdbValue)valueUint16);
+            Assert.Equal(valueInt32, (int?)(YdbValue)valueInt32);
+            Assert.Equal(valueUint32, (uint?)(YdbValue)valueUint32);
+            Assert.Equal(valueInt64, (long?)(YdbValue)valueInt64);
+            Assert.Equal(valueUint64, (ulong?)(YdbValue)valueUint64);
+            Assert.Equal(valueFloat, (float?)(YdbValue)valueFloat);
+            Assert.Equal(valueDouble, (double?)(YdbValue)valueDouble);
+
+            // TODO make optional string types
         }
 
         [Fact]
@@ -168,10 +172,14 @@ namespace Ydb.Sdk.Value.Tests
                 YdbValue.MakeOptional(
                     YdbValue.MakeOptional(YdbValue.MakeInt32(17))
                 ),
+                YdbValue.MakeOptionalInt32(123),
+                (YdbValue)(int?)321,
+                YdbValue.MakeOptionalInt32(null),
+                (YdbValue)(int?)null,
             });
 
             var elements = value.GetTuple();
-            Assert.Equal(4, elements.Count);
+            Assert.Equal(8, elements.Count);
 
             Assert.Null(elements[0].GetOptional());
             Assert.Null(elements[1].GetOptional());
@@ -185,6 +193,11 @@ namespace Ydb.Sdk.Value.Tests
             Assert.Equal("test", (string)elements[2]!);
 
             Assert.Equal(17, (int?)elements[3].GetOptional()!);
+
+            Assert.Equal(123, (int?)elements[4]);
+            Assert.Equal(321, (int?)elements[5]);
+            Assert.Null((int?)elements[6]);
+            Assert.Null((int?)elements[7]);
         }
 
         [Fact]

--- a/src/Ydb.Sdk/tests/Value/TestBasicUnit.cs
+++ b/src/Ydb.Sdk/tests/Value/TestBasicUnit.cs
@@ -23,181 +23,235 @@ namespace Ydb.Sdk.Value.Tests
         public void PrimitiveTypesMakeGet()
         {
             var valueBool = true;
-            var valueInt8 = (sbyte)-1;
-            var valueUint8 = (byte)200;
-            var valueInt16 = (short)-200;
-            var valueUint16 = (ushort)40_000;
-            var valueInt32 = -40000;
-            var valueUint32 = 4_000_000_000;
-            var valueInt64 = -4_000_000_000;
-            var valueUint64 = 10_000_000_000ul;
-            var valueFloat = -1.7f;
-            var valueDouble = 123.45;
-            var valueDate = new DateTime(2021, 08, 21);
-            var valueDatetime = new DateTime(2021, 08, 21, 23, 30, 47);
-            var valueTimestamp = new DateTime(2021, 08, 21, 23, 30, 47, 581);
-            var valueInterval = -new TimeSpan(3, 7, 40, 27, 729);
-            var valueString = Encoding.ASCII.GetBytes("test str");
-            var valueUtf8 = "unicode str";
-            var valueYson = Encoding.ASCII.GetBytes("{type=\"yson\"}");
-            var valueJson = "{\"type\": \"json\"}";
-            var valueJsonDocument = "{\"type\": \"jsondoc\"}";
-
             Assert.Equal(valueBool, YdbValue.MakeBool(valueBool).GetBool());
-            Assert.Equal(valueInt8, YdbValue.MakeInt8(valueInt8).GetInt8());
-            Assert.Equal(valueUint8, YdbValue.MakeUint8(valueUint8).GetUint8());
-            Assert.Equal(valueInt16, YdbValue.MakeInt16(valueInt16).GetInt16());
-            Assert.Equal(valueUint16, YdbValue.MakeUint16(valueUint16).GetUint16());
-            Assert.Equal(valueInt32, YdbValue.MakeInt32(valueInt32).GetInt32());
-            Assert.Equal(valueUint32, YdbValue.MakeUint32(valueUint32).GetUint32());
-            Assert.Equal(valueInt64, YdbValue.MakeInt64(valueInt64).GetInt64());
-            Assert.Equal(valueUint64, YdbValue.MakeUint64(valueUint64).GetUint64());
-            Assert.Equal(valueFloat, YdbValue.MakeFloat(valueFloat).GetFloat());
-            Assert.Equal(valueDouble, YdbValue.MakeDouble(valueDouble).GetDouble());
-            Assert.Equal(valueDate, YdbValue.MakeDate(valueDate).GetDate());
-            Assert.Equal(valueDatetime, YdbValue.MakeDatetime(valueDatetime).GetDatetime());
-            Assert.Equal(valueTimestamp, YdbValue.MakeTimestamp(valueTimestamp).GetTimestamp());
-            Assert.Equal(valueInterval, YdbValue.MakeInterval(valueInterval).GetInterval());
-            Assert.Equal(valueString, YdbValue.MakeString(valueString).GetString());
-            Assert.Equal(valueUtf8, YdbValue.MakeUtf8(valueUtf8).GetUtf8());
-            Assert.Equal(valueYson, YdbValue.MakeYson(valueYson).GetYson());
-            Assert.Equal(valueJson, YdbValue.MakeJson(valueJson).GetJson());
-            Assert.Equal(valueJsonDocument, YdbValue.MakeJsonDocument(valueJsonDocument).GetJsonDocument());
 
+            var valueInt8 = (sbyte)-1;
+            Assert.Equal(valueInt8, YdbValue.MakeInt8(valueInt8).GetInt8());
+
+            var valueUint8 = (byte)200;
+            Assert.Equal(valueUint8, YdbValue.MakeUint8(valueUint8).GetUint8());
+
+            var valueInt16 = (short)-200;
+            Assert.Equal(valueInt16, YdbValue.MakeInt16(valueInt16).GetInt16());
+
+            var valueUint16 = (ushort)40_000;
+            Assert.Equal(valueUint16, YdbValue.MakeUint16(valueUint16).GetUint16());
+
+            var valueInt32 = -40000;
+            Assert.Equal(valueInt32, YdbValue.MakeInt32(valueInt32).GetInt32());
+
+            var valueUint32 = 4_000_000_000;
+            Assert.Equal(valueUint32, YdbValue.MakeUint32(valueUint32).GetUint32());
+
+            var valueInt64 = -4_000_000_000;
+            Assert.Equal(valueInt64, YdbValue.MakeInt64(valueInt64).GetInt64());
+
+            var valueUint64 = 10_000_000_000ul;
+            Assert.Equal(valueUint64, YdbValue.MakeUint64(valueUint64).GetUint64());
+
+            var valueFloat = -1.7f;
+            Assert.Equal(valueFloat, YdbValue.MakeFloat(valueFloat).GetFloat());
+
+            var valueDouble = 123.45;
+            Assert.Equal(valueDouble, YdbValue.MakeDouble(valueDouble).GetDouble());
+
+            var valueDate = new DateTime(2021, 08, 21);
+            Assert.Equal(valueDate, YdbValue.MakeDate(valueDate).GetDate());
+
+            var valueDatetime = new DateTime(2021, 08, 21, 23, 30, 47);
+            Assert.Equal(valueDatetime, YdbValue.MakeDatetime(valueDatetime).GetDatetime());
+
+            var valueTimestamp = new DateTime(2021, 08, 21, 23, 30, 47, 581);
+            Assert.Equal(valueTimestamp, YdbValue.MakeTimestamp(valueTimestamp).GetTimestamp());
+
+            var valueInterval = -new TimeSpan(3, 7, 40, 27, 729);
+            Assert.Equal(valueInterval, YdbValue.MakeInterval(valueInterval).GetInterval());
+
+            var valueString = Encoding.ASCII.GetBytes("test str");
+            Assert.Equal(valueString, YdbValue.MakeString(valueString).GetString());
+
+            var valueUtf8 = "unicode str";
+            Assert.Equal(valueUtf8, YdbValue.MakeUtf8(valueUtf8).GetUtf8());
+
+            var valueYson = Encoding.ASCII.GetBytes("{type=\"yson\"}");
+            Assert.Equal(valueYson, YdbValue.MakeYson(valueYson).GetYson());
+
+            var valueJson = "{\"type\": \"json\"}";
+            Assert.Equal(valueJson, YdbValue.MakeJson(valueJson).GetJson());
+
+            var valueJsonDocument = "{\"type\": \"jsondoc\"}";
+            Assert.Equal(valueJsonDocument, YdbValue.MakeJsonDocument(valueJsonDocument).GetJsonDocument());
         }
 
         [Fact]
-        public void PrimitiveTypesExplicitCast() {
-
+        public void PrimitiveTypesExplicitCast()
+        {
             var valueBool = true;
-            var valueInt8 = (sbyte)-1;
-            var valueUint8 = (byte)200;
-            var valueInt16 = (short)-200;
-            var valueUint16 = (ushort)40_000;
-            var valueInt32 = -40000;
-            var valueUint32 = 4_000_000_000;
-            var valueInt64 = -4_000_000_000;
-            var valueUint64 = 10_000_000_000ul;
-            var valueFloat = -1.7f;
-            var valueDouble = 123.45;
-
             Assert.Equal(valueBool, (bool)(YdbValue)valueBool);
+
+            var valueInt8 = (sbyte)-1;
             Assert.Equal(valueInt8, (sbyte)(YdbValue)valueInt8);
+
+            var valueUint8 = (byte)200;
             Assert.Equal(valueUint8, (byte)(YdbValue)valueUint8);
+
+            var valueInt16 = (short)-200;
             Assert.Equal(valueInt16, (short)(YdbValue)valueInt16);
+
+            var valueUint16 = (ushort)40_000;
             Assert.Equal(valueUint16, (ushort)(YdbValue)valueUint16);
+
+            var valueInt32 = -40000;
             Assert.Equal(valueInt32, (int)(YdbValue)valueInt32);
+
+            var valueUint32 = 4_000_000_000;
             Assert.Equal(valueUint32, (uint)(YdbValue)valueUint32);
+
+            var valueInt64 = -4_000_000_000;
             Assert.Equal(valueInt64, (long)(YdbValue)valueInt64);
+
+            var valueUint64 = 10_000_000_000ul;
             Assert.Equal(valueUint64, (ulong)(YdbValue)valueUint64);
+
+            var valueFloat = -1.7f;
             Assert.Equal(valueFloat, (float)(YdbValue)valueFloat);
+
+            var valueDouble = 123.45;
             Assert.Equal(valueDouble, (double)(YdbValue)valueDouble);
         }
 
         [Fact]
-        public void OptimalPrimitiveTypesMakeGet()
+        public void OptionalPrimitiveTypesMakeGet()
         {
             var valueBool = true;
-            var valueInt8 = (sbyte)-1;
-            var valueUint8 = (byte)200;
-            var valueInt16 = (short)-200;
-            var valueUint16 = (ushort)40_000;
-            var valueInt32 = -40000;
-            var valueUint32 = 4_000_000_000;
-            var valueInt64 = -4_000_000_000;
-            var valueUint64 = 10_000_000_000ul;
-            var valueFloat = -1.7f;
-            var valueDouble = 123.45;
-            var valueDate = new DateTime(2021, 08, 21);
-            var valueDatetime = new DateTime(2021, 08, 21, 23, 30, 47);
-            var valueTimestamp = new DateTime(2021, 08, 21, 23, 30, 47, 581);
-            var valueInterval = -new TimeSpan(3, 7, 40, 27, 729);
-
             Assert.Equal(valueBool, YdbValue.MakeOptionalBool(valueBool).GetOptionalBool());
+
+            var valueInt8 = (sbyte)-1;
             Assert.Equal(valueInt8, YdbValue.MakeOptionalInt8(valueInt8).GetOptionalInt8());
+
+            var valueUint8 = (byte)200;
             Assert.Equal(valueUint8, YdbValue.MakeOptionalUint8(valueUint8).GetOptionalUint8());
+
+            var valueInt16 = (short)-200;
             Assert.Equal(valueInt16, YdbValue.MakeOptionalInt16(valueInt16).GetOptionalInt16());
+
+            var valueUint16 = (ushort)40_000;
             Assert.Equal(valueUint16, YdbValue.MakeOptionalUint16(valueUint16).GetOptionalUint16());
+
+            var valueInt32 = -40000;
             Assert.Equal(valueInt32, YdbValue.MakeOptionalInt32(valueInt32).GetOptionalInt32());
+
+            var valueUint32 = 4_000_000_000;
             Assert.Equal(valueUint32, YdbValue.MakeOptionalUint32(valueUint32).GetOptionalUint32());
+
+            var valueInt64 = -4_000_000_000;
             Assert.Equal(valueInt64, YdbValue.MakeOptionalInt64(valueInt64).GetOptionalInt64());
+
+            var valueUint64 = 10_000_000_000ul;
             Assert.Equal(valueUint64, YdbValue.MakeOptionalUint64(valueUint64).GetOptionalUint64());
+
+            var valueFloat = -1.7f;
             Assert.Equal(valueFloat, YdbValue.MakeOptionalFloat(valueFloat).GetOptionalFloat());
+
+            var valueDouble = 123.45;
             Assert.Equal(valueDouble, YdbValue.MakeOptionalDouble(valueDouble).GetOptionalDouble());
+
+            var valueDate = new DateTime(2021, 08, 21);
             Assert.Equal(valueDate, YdbValue.MakeOptionalDate(valueDate).GetOptionalDate());
+
+            var valueDatetime = new DateTime(2021, 08, 21, 23, 30, 47);
             Assert.Equal(valueDatetime, YdbValue.MakeOptionalDatetime(valueDatetime).GetOptionalDatetime());
+
+            var valueTimestamp = new DateTime(2021, 08, 21, 23, 30, 47, 581);
             Assert.Equal(valueTimestamp, YdbValue.MakeOptionalTimestamp(valueTimestamp).GetOptionalTimestamp());
+
+            var valueInterval = -new TimeSpan(3, 7, 40, 27, 729);
             Assert.Equal(valueInterval, YdbValue.MakeOptionalInterval(valueInterval).GetOptionalInterval());
 
-            // TODO make optional string types
+            var valueString = Encoding.ASCII.GetBytes("test str");
+            Assert.Equal(valueString, YdbValue.MakeOptionalString(valueString).GetOptionalString());
+
+            var valueUtf8 = "unicode str";
+            Assert.Equal(valueUtf8, YdbValue.MakeOptionalUtf8(valueUtf8).GetOptionalUtf8());
+
+            var valueYson = Encoding.ASCII.GetBytes("{type=\"yson\"}");
+            Assert.Equal(valueYson, YdbValue.MakeOptionalYson(valueYson).GetOptionalYson());
+
+            var valueJson = "{\"type\": \"json\"}";
+            Assert.Equal(valueJson, YdbValue.MakeOptionalJson(valueJson).GetOptionalJson());
+
+            var valueJsonDocument = "{\"type\": \"jsondoc\"}";
+            Assert.Equal(valueJsonDocument, YdbValue.MakeOptionalJsonDocument(valueJsonDocument).GetOptionalJsonDocument());
+
+            Assert.Null(YdbValue.MakeOptionalBool(null).GetOptionalBool());
+            Assert.Null(YdbValue.MakeOptionalInt8(null).GetOptionalInt8());
+            Assert.Null(YdbValue.MakeOptionalUint8(null).GetOptionalUint8());
+            Assert.Null(YdbValue.MakeOptionalInt16(null).GetOptionalInt16());
+            Assert.Null(YdbValue.MakeOptionalUint16(null).GetOptionalUint16());
+            Assert.Null(YdbValue.MakeOptionalInt32(null).GetOptionalInt32());
+            Assert.Null(YdbValue.MakeOptionalUint32(null).GetOptionalUint32());
+            Assert.Null(YdbValue.MakeOptionalInt64(null).GetOptionalInt64());
+            Assert.Null(YdbValue.MakeOptionalUint64(null).GetOptionalUint64());
+            Assert.Null(YdbValue.MakeOptionalFloat(null).GetOptionalFloat());
+            Assert.Null(YdbValue.MakeOptionalDouble(null).GetOptionalDouble());
+            Assert.Null(YdbValue.MakeOptionalDate(null).GetOptionalDate());
+            Assert.Null(YdbValue.MakeOptionalDatetime(null).GetOptionalDatetime());
+            Assert.Null(YdbValue.MakeOptionalTimestamp(null).GetOptionalTimestamp());
+            Assert.Null(YdbValue.MakeOptionalInterval(null).GetOptionalInterval());
+            Assert.Null(YdbValue.MakeOptionalString(null).GetOptionalString());
+            Assert.Null(YdbValue.MakeOptionalUtf8(null).GetOptionalUtf8());
+            Assert.Null(YdbValue.MakeOptionalYson(null).GetOptionalYson());
+            Assert.Null(YdbValue.MakeOptionalJson(null).GetOptionalJson());
+            Assert.Null(YdbValue.MakeOptionalJsonDocument(null).GetOptionalJsonDocument());
         }
 
         [Fact]
-        public void OptimalPrimitiveCast()
+        public void OptionalPrimitiveCast()
         {
-            var valueBool = (bool?)true;
-            var valueInt8 = (sbyte?)-1;
-            var valueUint8 = (byte?)200;
-            var valueInt16 = (short?)-200;
-            var valueUint16 = (ushort?)40_000;
-            var valueInt32 = (int?)-40000;
-            var valueUint32 = (uint?)4_000_000_000;
-            var valueInt64 = (long?)-4_000_000_000;
-            var valueUint64 = (ulong?)10_000_000_000ul;
-            var valueFloat = (float?)-1.7f;
-            var valueDouble = (double?)123.45;
-
+            bool? valueBool = true;
             Assert.Equal(valueBool, (bool?)(YdbValue)valueBool);
+            
+            sbyte? valueInt8 = -1;
             Assert.Equal(valueInt8, (sbyte?)(YdbValue)valueInt8);
+            
+            byte? valueUint8 = 200;
             Assert.Equal(valueUint8, (byte?)(YdbValue)valueUint8);
+            
+            short? valueInt16 = -200;
             Assert.Equal(valueInt16, (short?)(YdbValue)valueInt16);
+            
+            ushort? valueUint16 = 40_000;
             Assert.Equal(valueUint16, (ushort?)(YdbValue)valueUint16);
+            
+            int? valueInt32 = -40000;
             Assert.Equal(valueInt32, (int?)(YdbValue)valueInt32);
+            
+            uint? valueUint32 = 4_000_000_000;
             Assert.Equal(valueUint32, (uint?)(YdbValue)valueUint32);
+            
+            long? valueInt64 = -4_000_000_000;
             Assert.Equal(valueInt64, (long?)(YdbValue)valueInt64);
+            
+            ulong? valueUint64 = 10_000_000_000ul;
             Assert.Equal(valueUint64, (ulong?)(YdbValue)valueUint64);
+            
+            float? valueFloat = -1.7f;
             Assert.Equal(valueFloat, (float?)(YdbValue)valueFloat);
+            
+            double? valueDouble = 123.45;
             Assert.Equal(valueDouble, (double?)(YdbValue)valueDouble);
 
-            // TODO make optional string types
-        }
-
-        [Fact]
-        public void OptionalType()
-        {
-            var value = YdbValue.MakeTuple(new YdbValue[] {
-                YdbValue.MakeEmptyOptional(YdbTypeId.Int32),
-                YdbValue.MakeEmptyOptional(YdbTypeId.String),
-                YdbValue.MakeOptional(YdbValue.MakeUtf8("test")),
-                YdbValue.MakeOptional(
-                    YdbValue.MakeOptional(YdbValue.MakeInt32(17))
-                ),
-                YdbValue.MakeOptionalInt32(123),
-                (YdbValue)(int?)321,
-                YdbValue.MakeOptionalInt32(null),
-                (YdbValue)(int?)null,
-            });
-
-            var elements = value.GetTuple();
-            Assert.Equal(8, elements.Count);
-
-            Assert.Null(elements[0].GetOptional());
-            Assert.Null(elements[1].GetOptional());
-
-            Assert.Null(elements[0].GetOptionalInt32());
-            Assert.Null(elements[1].GetOptionalString());
-
-            Assert.Null((int?)elements[0]);
-            Assert.Null((string?)elements[1]);
-
-            Assert.Equal("test", (string)elements[2]!);
-
-            Assert.Equal(17, (int?)elements[3].GetOptional()!);
-
-            Assert.Equal(123, (int?)elements[4]);
-            Assert.Equal(321, (int?)elements[5]);
-            Assert.Null((int?)elements[6]);
-            Assert.Null((int?)elements[7]);
+            Assert.Null((bool?)(YdbValue)(bool?)null);
+            Assert.Null((sbyte?)(YdbValue)(sbyte?)null);
+            Assert.Null((byte?)(YdbValue)(byte?)null);
+            Assert.Null((short?)(YdbValue)(short?)null);
+            Assert.Null((ushort?)(YdbValue)(ushort?)null);
+            Assert.Null((int?)(YdbValue)(int?)null);
+            Assert.Null((uint?)(YdbValue)(uint?)null);
+            Assert.Null((long?)(YdbValue)(long?)null);
+            Assert.Null((ulong?)(YdbValue)(ulong?)null);
+            Assert.Null((float?)(YdbValue)(float?)null);
+            Assert.Null((double?)(YdbValue)(double?)null);
         }
 
         [Fact]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Now there is no convenient way to convert the nullable type to YdbValue(YQL Optional)
One of the available options looks like this:
``` c#
value.HasValue
    ? YdbValue.MakeOptional(MakeUtf8(value))
    : YdbValue.MakeEmptyOptional(YdbTypeId.Utf8));
```
but it takes up a lot of space and allows for errors

## What is the new behavior?
To do the same thing you can use one of the options:
``` c#
YdbValue.MakeOptionalUtf8(value);
// or
(YdbValue)value;
```

## Other information

![image](https://github.com/ydb-platform/ydb-dotnet-sdk/assets/86735308/24e7b111-8af0-4748-bc90-53781ae9278b)
