### PR TITLE
Graceful session shutdown support ("session-close" in "x-ydb-server-hints" metadata means to "forget" a session and not use it again)

### DIFF
--- a/src/Ydb.Sdk/src/Driver.cs
+++ b/src/Ydb.Sdk/src/Driver.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Grpc.Core;
+using Grpc.Net.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Ydb.Discovery;
@@ -117,15 +118,19 @@ public class Driver : IDisposable, IAsyncDisposable
 
         try
         {
-            var data = await callInvoker.AsyncUnaryCall(
+            using var call = callInvoker.AsyncUnaryCall(
                 method: method,
                 host: null,
                 options: GetCallOptions(settings, false),
                 request: request);
 
+            var data = await call.ResponseAsync;
+            var trailers = call.GetTrailers();
+
             return new UnaryResponse<TResponse>(
                 data: data,
-                usedEndpoint: endpoint);
+                usedEndpoint: endpoint,
+                trailers: trailers);
         }
         catch (RpcException e)
         {
@@ -312,17 +317,20 @@ public class Driver : IDisposable, IAsyncDisposable
 
     internal sealed class UnaryResponse<TResponse>
     {
-        internal UnaryResponse(
-            TResponse data,
-            string usedEndpoint)
+        internal UnaryResponse(TResponse data,
+            string usedEndpoint,
+            Grpc.Core.Metadata? trailers)
         {
             Data = data;
             UsedEndpoint = usedEndpoint;
+            Trailers = trailers;
         }
 
         public TResponse Data { get; }
 
         public string UsedEndpoint { get; }
+
+        public Grpc.Core.Metadata? Trailers { get; }
     }
 
     internal sealed class StreamIterator<TResponse>

--- a/src/Ydb.Sdk/src/Metadata.cs
+++ b/src/Ydb.Sdk/src/Metadata.cs
@@ -7,4 +7,7 @@ internal static class Metadata
     public const string RpcRequestTypeHeader = "x-ydb-request-type";
     public const string RpcTraceIdHeader = "x-ydb-trace-id";
     public const string RpcSdkInfoHeader = "x-ydb-sdk-build-info";
+    public const string RpcServerHintsHeader = "x-ydb-server-hints";
+
+    public const string GracefulShutdownHint = "session-close";
 }

--- a/src/Ydb.Sdk/src/Services/Table/ExecuteDataQuery.cs
+++ b/src/Ydb.Sdk/src/Services/Table/ExecuteDataQuery.cs
@@ -84,9 +84,9 @@ public partial class Session
                 request: request,
                 settings: settings);
 
-            ExecuteQueryResult? resultProto;
-            var status = UnpackOperation(response.Data.Operation, out resultProto);
+            var status = UnpackOperation(response.Data.Operation, out ExecuteQueryResult? resultProto);
             OnResponseStatus(status);
+            OnResponseTrailers(response.Trailers);
 
             var txState = TransactionState.Unknown;
             Transaction? tx = null;

--- a/src/Ydb.Sdk/src/Services/Table/ExecuteSchemeQuery.cs
+++ b/src/Ydb.Sdk/src/Services/Table/ExecuteSchemeQuery.cs
@@ -41,6 +41,7 @@ public partial class Session
 
             var status = UnpackOperation(response.Data.Operation);
             OnResponseStatus(status);
+            OnResponseTrailers(response.Trailers);
 
             return new ExecuteSchemeQueryResponse(status);
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Graceful session shutdown support ("session-close" in "x-ydb-server-hints" metadata means to "forget" a session and not use it again)