### PR TITLE
change lock to interlocked atomics

### DIFF
--- a/src/Ydb.Sdk/src/Services/Table/Transaction.cs
+++ b/src/Ydb.Sdk/src/Services/Table/Transaction.cs
@@ -32,7 +32,6 @@ public class Transaction
 
         return tx;
     }
-    
     private static int IncTxCounter()
     {
         return Interlocked.Increment(ref _txCounter);

--- a/src/Ydb.Sdk/src/Services/Table/Transaction.cs
+++ b/src/Ydb.Sdk/src/Services/Table/Transaction.cs
@@ -13,6 +13,8 @@ public class Transaction
     public string TxId { get; }
 
     internal int? TxNum { get; private set; }
+    
+    private static int _txCounter;
 
     internal static Transaction? FromProto(TransactionMeta proto, ILogger? logger = null)
     {
@@ -23,26 +25,17 @@ public class Transaction
 
         var tx = new Transaction(
             txId: proto.Id);
+        
         if (!string.IsNullOrEmpty(proto.Id))
         {
-            tx.TxNum = GetTxCounter();
+            tx.TxNum = IncTxCounter();
             logger.LogTrace($"Received tx #{tx.TxNum}");
         }
 
         return tx;
     }
-
-    private static readonly object TxCounterLock = new();
-    private static int _txCounter;
-
-    private static int GetTxCounter()
-    {
-        lock (TxCounterLock)
-        {
-            _txCounter++;
-            return _txCounter;
-        }
-    }
+    
+    private static int IncTxCounter() => Interlocked.Increment(ref _txCounter);
 }
 
 public enum TransactionState

--- a/src/Ydb.Sdk/src/Services/Table/Transaction.cs
+++ b/src/Ydb.Sdk/src/Services/Table/Transaction.cs
@@ -33,7 +33,10 @@ public class Transaction
         return tx;
     }
     
-    private static int IncTxCounter() => Interlocked.Increment(ref _txCounter);
+    private static int IncTxCounter()
+    {
+        return Interlocked.Increment(ref _txCounter);
+    }
 }
 
 public enum TransactionState

--- a/src/Ydb.Sdk/src/Services/Table/Transaction.cs
+++ b/src/Ydb.Sdk/src/Services/Table/Transaction.cs
@@ -24,7 +24,6 @@ public class Transaction
 
         var tx = new Transaction(
             txId: proto.Id);
-        
         if (!string.IsNullOrEmpty(proto.Id))
         {
             tx.TxNum = IncTxCounter();

--- a/src/Ydb.Sdk/src/Services/Table/Transaction.cs
+++ b/src/Ydb.Sdk/src/Services/Table/Transaction.cs
@@ -13,7 +13,6 @@ public class Transaction
     public string TxId { get; }
 
     internal int? TxNum { get; private set; }
-    
     private static int _txCounter;
 
     internal static Transaction? FromProto(TransactionMeta proto, ILogger? logger = null)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Using `lock` to increment `_txCounter`

Issue Number: N/A

## What is the new behavior?

Now implementation uses lock-free CAS based value computation, which would work faster, without allocating new object and creating a monitor.

## Other information

None
