### PR TITLE
fix: Pass logger to TxControl.ToProto

### DIFF
--- a/src/Ydb.Sdk/src/Services/Table/ExecuteDataQuery.cs
+++ b/src/Ydb.Sdk/src/Services/Table/ExecuteDataQuery.cs
@@ -65,7 +65,7 @@ public partial class Session
         {
             OperationParams = MakeOperationParams(settings),
             SessionId = Id,
-            TxControl = txControl.ToProto(),
+            TxControl = txControl.ToProto(Logger),
             Query = new Ydb.Table.Query
             {
                 YqlText = query

--- a/src/Ydb.Sdk/src/Services/Table/Transaction.cs
+++ b/src/Ydb.Sdk/src/Services/Table/Transaction.cs
@@ -114,7 +114,7 @@ public class TxControl
         return this;
     }
 
-    internal TransactionControl ToProto(ILogger? logger = null)
+    internal TransactionControl ToProto(ILogger logger)
     {
         if (_txNum != null)
         {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`ArgumentNullException` on `logger.LogTrace(...)` when doing more than two queries in one transaction using `TxControl`.

## What is the new behavior?

Logger is passed to `TxControl.ToProto()` method and this issue is fixed.