### PR TITLE
Fix dapper example

### DIFF
--- a/examples/src/DapperExample/Program.cs
+++ b/examples/src/DapperExample/Program.cs
@@ -15,10 +15,10 @@ await connection.ExecuteAsync("""
                               );
                               """);
 
-await connection.ExecuteAsync("INSERT INTO Users(Id, Name, Email) VALUES ($Id, $Name, $Email)",
+await connection.ExecuteAsync("INSERT INTO Users(Id, Name, Email) VALUES (@Id, @Name, @Email)",
     new User { Id = 1, Name = "Name", Email = "Email" });
 
-Console.WriteLine(await connection.QuerySingleAsync<User>("SELECT * FROM Users WHERE Id = $Id",
+Console.WriteLine(await connection.QuerySingleAsync<User>("SELECT * FROM Users WHERE Id = @Id",
     new { Id = 1 }));
 
 await connection.ExecuteAsync("DROP TABLE Users");


### PR DESCRIPTION
Parameters with the `$` prefix are currently not supported, so we need to fix the example.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

At the moment the example for dapper uses parameters with the prefix $, which is currently unsupported and causes an error when executing the request.

## What is the new behavior?

The corrected example uses the @ prefix for parameters, which is supported by sdk.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

At the moment (sdk 0.7.0) a simple query made using an example like:

```cs
await connection.ExecuteAsync(
    "insert into items (addtime, name) values (@AddTime, @ItemName)",
    new { AddTime = DateTime.UtcNow, ItemName = item });
```

results in an error:
```
{"errorMessage":"Status: GenericError, Issues:\n[0] (:1:43)Error: Unknown name: $AddTime\n","errorType":"YdbException","stackTrace":"   at Ydb.Sdk.Ado.YdbDataReader.NextExecPart()\n   at Ydb.Sdk.Ado.YdbDataReader.Init()\n   at Ydb.Sdk.Ado.YdbDataReader.CreateYdbDataReader(IAsyncEnumerator\u00601 resultSetStream, Action\u00601 onStatus, YdbTransaction ydbTransaction)\n   at Ydb.Sdk.Ado.YdbCommand.ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)\n   at Ydb.Sdk.Ado.YdbCommand.ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)\n   at Ydb.Sdk.Ado.YdbCommand.ExecuteNonQueryAsync(CancellationToken cancellationToken)\n   at Dapper.SqlMapper.ExecuteImplAsync(IDbConnection cnn, CommandDefinition command, Object param) in /_/Dapper/SqlMapper.Async.cs:line 662\n   at Bot.Commands.AddCommand.ExecuteAsync(ITelegramBotClient bot, Int64 chatId, DbConnection connection) in /home/mvs/source/playground/tg-bot/src/Bot/Commands/AddCommand.cs:line 15\n   at Bot.Handler.FunctionHandler(Request request) in /home/mvs/source/playground/tg-bot/src/Bot/Handler.cs:line 53\n   at CallSite.Target(Closure, CallSite, Object)\n   at Yandex.Cloud.Runtime.DefaultRuntime.Start() in /bootstrap/runtime/DefaultRuntime.cs:line 57\ninner:\n"}
```
