### PR TITLE
feat: implement consistent retry logic for topic writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Topic Writer updated release candidate
+
 ## v0.9.0-rc0
 - Topic Writer release candidate
 - Fixed: grpc requests go via proxy on Grpc.NET.Client >= 2.44 

--- a/src/Ydb.Sdk/src/Services/Topic/Exceptions.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Exceptions.cs
@@ -4,20 +4,15 @@ public class WriterException : Exception
 {
     public WriterException(string message) : base(message)
     {
-        Status = new Status(StatusCode.Unspecified);
     }
 
     public WriterException(string message, Status status) : base(message + ": " + status)
     {
-        Status = status;
     }
 
-    public WriterException(string message, Driver.TransportException e) : base(message, e)
+    public WriterException(string message, Exception inner) : base(message, inner)
     {
-        Status = e.Status;
     }
-
-    public Status Status { get; }
 }
 
 public class ReaderException : Exception

--- a/src/Ydb.Sdk/src/Services/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/TopicSession.cs
@@ -24,7 +24,8 @@ internal abstract class TopicSession<TFromClient, TFromServer> : IDisposable
         _initialize = initialize;
     }
 
-    protected async void ReconnectSession() {
+    protected async void ReconnectSession()
+    {
         if (Interlocked.CompareExchange(ref _isActive, 0, 1) == 0)
         {
             Logger.LogDebug("Skipping reconnect. A reconnect session has already been initiated");

--- a/src/Ydb.Sdk/src/Services/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/TopicSession.cs
@@ -5,7 +5,6 @@ namespace Ydb.Sdk.Services.Topic;
 internal abstract class TopicSession<TFromClient, TFromServer> : IDisposable
 {
     private readonly Func<Task> _initialize;
-    private readonly Action<WriterException> _resetSessionOnTransportError;
 
     protected readonly IBidirectionalStream<TFromClient, TFromServer> Stream;
     protected readonly ILogger Logger;
@@ -17,18 +16,15 @@ internal abstract class TopicSession<TFromClient, TFromServer> : IDisposable
         IBidirectionalStream<TFromClient, TFromServer> stream,
         ILogger logger,
         string sessionId,
-        Func<Task> initialize,
-        Action<WriterException> resetSessionOnTransportError)
+        Func<Task> initialize)
     {
         Stream = stream;
         Logger = logger;
         SessionId = sessionId;
         _initialize = initialize;
-        _resetSessionOnTransportError = resetSessionOnTransportError;
     }
 
-    protected async void ReconnectSession(WriterException exception)
-    {
+    protected async void ReconnectSession() {
         if (Interlocked.CompareExchange(ref _isActive, 0, 1) == 0)
         {
             Logger.LogDebug("Skipping reconnect. A reconnect session has already been initiated");
@@ -36,9 +32,7 @@ internal abstract class TopicSession<TFromClient, TFromServer> : IDisposable
             return;
         }
 
-        _resetSessionOnTransportError(exception);
-
-        Logger.LogInformation("WriterSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
+        Logger.LogInformation("TopicSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
 
         await _initialize();
     }

--- a/src/Ydb.Sdk/src/Services/Topic/Writer/WriteResult.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Writer/WriteResult.cs
@@ -4,6 +4,8 @@ namespace Ydb.Sdk.Services.Topic.Writer;
 
 public class WriteResult
 {
+    internal static readonly WriteResult Skipped = new();
+
     private readonly long _offset;
 
     internal WriteResult(StreamWriteMessage.Types.WriteResponse.Types.WriteAck ack)
@@ -21,6 +23,11 @@ public class WriteResult
             default:
                 throw new WriterException($"Unexpected WriteAck status: {ack.MessageWriteStatusCase}");
         }
+    }
+
+    private WriteResult()
+    {
+        Status = PersistenceStatus.AlreadyWritten;
     }
 
     public PersistenceStatus Status { get; }

--- a/src/Ydb.Sdk/src/Services/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Writer/Writer.cs
@@ -149,7 +149,7 @@ internal class Writer<TValue> : IWriter<TValue>
 
     private async Task Initialize()
     {
-        _session = DummyWriteSession.Instance;
+        _session = DummyWriterSession.Instance;
 
         try
         {
@@ -332,11 +332,11 @@ internal class NotStartedWriterSession : IWriteSession
     }
 }
 
-internal class DummyWriteSession : IWriteSession
+internal class DummyWriterSession : IWriteSession
 {
-    internal static readonly DummyWriteSession Instance = new();
+    internal static readonly DummyWriterSession Instance = new();
 
-    private DummyWriteSession()
+    private DummyWriterSession()
     {
     }
 

--- a/src/Ydb.Sdk/src/Services/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Writer/Writer.cs
@@ -234,13 +234,6 @@ internal class Writer<TValue> : IWriter<TValue>
             var lastSeqNo = initResponse.LastSeqNo;
             while (_inFlightMessages.TryDequeue(out var sendData))
             {
-                if (sendData.Tcs.Task.IsFaulted)
-                {
-                    _logger.LogWarning("Message[SeqNo={SeqNo}] is cancelled", sendData.MessageData.SeqNo);
-
-                    continue;
-                }
-
                 if (lastSeqNo >= sendData.MessageData.SeqNo)
                 {
                     _logger.LogWarning(
@@ -397,6 +390,13 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
 
             while (toSendBuffer.TryDequeue(out var sendData))
             {
+                if (sendData.Tcs.Task.IsFaulted)
+                {
+                    Logger.LogWarning("Message[SeqNo={SeqNo}] is cancelled", sendData.MessageData.SeqNo);
+
+                    continue;
+                }
+
                 var messageData = sendData.MessageData;
 
                 if (messageData.SeqNo == default)

--- a/src/Ydb.Sdk/src/Services/Topic/Writer/WriterBuilder.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Writer/WriterBuilder.cs
@@ -39,7 +39,26 @@ public class WriterBuilder<TValue>
     /// </summary>    
     public long? PartitionId { get; set; }
 
+    /// <summary>
+    /// The serializer to use to serialize values.
+    /// </summary>
+    /// <remarks>
+    ///     If your value serializer throws an exception, this will be
+    ///     wrapped in a WriterException with unspecified status.
+    /// </remarks>
     public ISerializer<TValue>? Serializer { get; set; }
+
+
+    /// <summary>
+    /// Represents the timeout duration, in milliseconds, used when a buffer overflow is detected.
+    /// This timeout specifies how long the system should wait before attempting to retry the operation.
+    /// </summary>
+    /// <remarks>
+    /// This timeout is important for managing system performance and stability. 
+    /// Too short a timeout could lead to rapid retry attempts, potentially causing further resource contention
+    /// and degrading system performance. Conversely, too long a timeout might delay processing significantly.
+    /// </remarks>
+    public int BufferOverflowRetryTimeoutMs { get; set; } = 10;
 
     public IWriter<TValue> Build()
     {
@@ -48,7 +67,8 @@ public class WriterBuilder<TValue>
             producerId: ProducerId,
             codec: Codec,
             bufferMaxSize: BufferMaxSize,
-            partitionId: PartitionId
+            partitionId: PartitionId,
+            bufferOverflowRetryTimeoutMs: BufferOverflowRetryTimeoutMs
         );
 
         return new Writer<TValue>(

--- a/src/Ydb.Sdk/src/Services/Topic/Writer/WriterConfig.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Writer/WriterConfig.cs
@@ -9,14 +9,15 @@ internal class WriterConfig
         string? producerId,
         Codec codec,
         int bufferMaxSize,
-        long? partitionId
-    )
+        long? partitionId, 
+        int bufferOverflowRetryTimeoutMs)
     {
         TopicPath = topicPath;
         ProducerId = producerId;
         Codec = codec;
         BufferMaxSize = bufferMaxSize;
         PartitionId = partitionId;
+        BufferOverflowRetryTimeoutMs = bufferOverflowRetryTimeoutMs;
     }
 
     public string TopicPath { get; }
@@ -28,6 +29,8 @@ internal class WriterConfig
     public int BufferMaxSize { get; }
 
     public long? PartitionId { get; }
+    
+    public int BufferOverflowRetryTimeoutMs { get; }
 
     public override string ToString()
     {

--- a/src/Ydb.Sdk/src/Services/Topic/Writer/WriterConfig.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Writer/WriterConfig.cs
@@ -9,7 +9,7 @@ internal class WriterConfig
         string? producerId,
         Codec codec,
         int bufferMaxSize,
-        long? partitionId, 
+        long? partitionId,
         int bufferOverflowRetryTimeoutMs)
     {
         TopicPath = topicPath;
@@ -29,7 +29,7 @@ internal class WriterConfig
     public int BufferMaxSize { get; }
 
     public long? PartitionId { get; }
-    
+
     public int BufferOverflowRetryTimeoutMs { get; }
 
     public override string ToString()

--- a/src/Ydb.Sdk/tests/Topic/WriterIntegrationTests.cs
+++ b/src/Ydb.Sdk/tests/Topic/WriterIntegrationTests.cs
@@ -45,8 +45,10 @@ public class WriterIntegrationTests : IClassFixture<DriverFixture>
         using var writer = new WriterBuilder<string>(_driver, _topicName + "_not_found")
             { ProducerId = "producerId" }.Build();
 
-        Assert.Equal("StatusCode.SchemeError", (await Assert.ThrowsAsync<WriterException>(
-            () => writer.WriteAsync("hello world"))).Message);
+        Assert.Contains(
+            $"Initialization failed: Status: SchemeError, Issues:\n[500017] Error: no path 'local/{_topicName + "_not_found"}'",
+            (await Assert.ThrowsAsync<WriterException>(() => writer.WriteAsync("hello world"))).Message
+        );
     }
 
     [Fact]

--- a/src/Ydb.Sdk/tests/Topic/WriterIntegrationTests.cs
+++ b/src/Ydb.Sdk/tests/Topic/WriterIntegrationTests.cs
@@ -45,8 +45,8 @@ public class WriterIntegrationTests : IClassFixture<DriverFixture>
         using var writer = new WriterBuilder<string>(_driver, _topicName + "_not_found")
             { ProducerId = "producerId" }.Build();
 
-        Assert.Equal(StatusCode.SchemeError, (await Assert.ThrowsAsync<WriterException>(
-            () => writer.WriteAsync("hello world"))).Status.StatusCode);
+        Assert.Equal("StatusCode.SchemeError", (await Assert.ThrowsAsync<WriterException>(
+            () => writer.WriteAsync("hello world"))).Message);
     }
 
     [Fact]

--- a/src/Ydb.Sdk/tests/Topic/WriterUnitTests.cs
+++ b/src/Ydb.Sdk/tests/Topic/WriterUnitTests.cs
@@ -249,7 +249,6 @@ public class WriterUnitTests
                 },
                 Status = StatusIds.Types.StatusCode.Success
             });
-        ;
 
         using var writer = new WriterBuilder<long>(_mockIDriver.Object, "/topic")
             { ProducerId = "producerId" }.Build();

--- a/src/Ydb.Sdk/tests/Topic/WriterUnitTests.cs
+++ b/src/Ydb.Sdk/tests/Topic/WriterUnitTests.cs
@@ -77,7 +77,6 @@ public class WriterUnitTests
 
         var writerException = await Assert.ThrowsAsync<WriterException>(() => writer.WriteAsync("abacaba"));
         Assert.Equal("Transport error on creating WriterSession", writerException.Message);
-        Assert.Equal(StatusCode.Cancelled, writerException.Status.StatusCode);
 
         await taskNextComplete.Task;
         // check attempt repeated!!!
@@ -105,7 +104,6 @@ public class WriterUnitTests
 
         var writerException = await Assert.ThrowsAsync<WriterException>(() => writer.WriteAsync("abacaba"));
         Assert.Equal("Transport error on creating WriterSession", writerException.Message);
-        Assert.Equal(StatusCode.ClientTransportTimeout, writerException.Status.StatusCode);
 
         await taskNextComplete.Task;
         // check attempt repeated!!!
@@ -361,7 +359,6 @@ public class WriterUnitTests
         var writerExceptionAfterResetSession = await Assert.ThrowsAsync<WriterException>(() => writer.WriteAsync(100));
         Assert.Equal("Transport error in the WriterSession on write messages",
             writerExceptionAfterResetSession.Message);
-        Assert.Equal(StatusCode.Cancelled, writerExceptionAfterResetSession.Status.StatusCode);
 
         moveSecondNextSource.SetResult(true);
         await nextCompleted.Task;
@@ -419,7 +416,6 @@ public class WriterUnitTests
         var writerExceptionAfterResetSession = await Assert.ThrowsAsync<WriterException>(() => writer.WriteAsync(100));
         Assert.Equal("Transport error in the WriterSession on processing writeAck",
             writerExceptionAfterResetSession.Message);
-        Assert.Equal(StatusCode.Cancelled, writerExceptionAfterResetSession.Status.StatusCode);
 
         _mockStream.Verify(stream => stream.Write(It.IsAny<FromClient>()), Times.Exactly(2));
         _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Exactly(3));
@@ -471,7 +467,6 @@ public class WriterUnitTests
         await nextCompleted.Task;
         var writerExceptionAfterResetSession = await Assert.ThrowsAsync<WriterException>(() => writer.WriteAsync(100));
         Assert.Equal("WriterStream is closed", writerExceptionAfterResetSession.Message);
-        Assert.Equal(StatusCode.Unspecified, writerExceptionAfterResetSession.Status.StatusCode);
 
         _mockStream.Verify(stream => stream.Write(It.IsAny<FromClient>()), Times.Exactly(2));
         _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Exactly(3));
@@ -653,7 +648,6 @@ public class WriterUnitTests
         var writerExceptionAfterResetSession = await Assert.ThrowsAsync<WriterException>(() => writer.WriteAsync(100));
         Assert.Equal("Transport error in the WriterSession on write messages",
             writerExceptionAfterResetSession.Message);
-        Assert.Equal(StatusCode.Cancelled, writerExceptionAfterResetSession.Status.StatusCode);
 
         ctx.Cancel(); // reconnect write invoke cancel on cancellation token
         moveSecondNextSource.SetResult(true);


### PR DESCRIPTION
* Do not send messages that have a timeout by cancelToken.
* If your value serializer throws an exception, this will be wrapped in a WriterException with unspecified status.
* Added BufferOverflowRetryTimeoutMs to the next try write.
* Rename _disposeTokenSource -> _disposeCts.
* Optimize write worker: if (_toSendBuffer.IsEmpty) continue.
* On RPC errors create DummyWriterSession.
* Message has been skipped because its sequence number is less than or equal to the last processed server's SeqNo.
* Calculate the next sequence number from the calculated previous messages.