### PR TITLE
fix: memory leak CancellationTokenRegistration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+- Do not pessimize the node on Grpc.Core.StatusCode.Cancelled.
+- Dispose of WriterSession using dispose CancellationToken.
+- BidirectionalStream is internal class.
+- Move Metadata class to Ydb.Sdk.Services.Topic.
+- Fixed memory leak CancellationTokenRegistration.
+- Cancel writing tasks after disposing of Writer.
+
 ## v0.9.3
 - Fixed bug in Topic Writer: worker is stopped by disposeCts
 - Fixed bug in sql parser ADO.NET: deduplication declare param in YQL query 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Do not pessimize the node on Grpc.Core.StatusCode.Cancelled.
+- Do not pessimize the node on Grpc.Core.StatusCode.Cancelled and Grpc.Core.StatusCode.DeadlineExceeded.
 - Dispose of WriterSession using dispose CancellationToken.
 - BidirectionalStream is internal class.
 - Move Metadata class to Ydb.Sdk.Services.Topic.

--- a/src/Ydb.Sdk/src/Driver.cs
+++ b/src/Ydb.Sdk/src/Driver.cs
@@ -98,7 +98,7 @@ public sealed class Driver : BaseDriver
     {
         Logger.LogWarning("gRPC error [{Status}] on channel {Endpoint}", e.Status, endpoint);
 
-        if (e.StatusCode == Grpc.Core.StatusCode.Cancelled)
+        if (e.StatusCode is Grpc.Core.StatusCode.Cancelled or Grpc.Core.StatusCode.DeadlineExceeded)
         {
             return;
         }

--- a/src/Ydb.Sdk/src/Driver.cs
+++ b/src/Ydb.Sdk/src/Driver.cs
@@ -102,7 +102,7 @@ public sealed class Driver : BaseDriver
         {
             return;
         }
-        
+
         if (!_endpointPool.PessimizeEndpoint(endpoint))
         {
             return;

--- a/src/Ydb.Sdk/src/Driver.cs
+++ b/src/Ydb.Sdk/src/Driver.cs
@@ -97,6 +97,12 @@ public sealed class Driver : BaseDriver
     protected override void OnRpcError(string endpoint, RpcException e)
     {
         Logger.LogWarning("gRPC error [{Status}] on channel {Endpoint}", e.Status, endpoint);
+
+        if (e.StatusCode == Grpc.Core.StatusCode.Cancelled)
+        {
+            return;
+        }
+        
         if (!_endpointPool.PessimizeEndpoint(endpoint))
         {
             return;

--- a/src/Ydb.Sdk/src/GrpcRequestSettings.cs
+++ b/src/Ydb.Sdk/src/GrpcRequestSettings.cs
@@ -11,6 +11,7 @@ public class GrpcRequestSettings
     public string TraceId { get; set; } = string.Empty;
     public TimeSpan TransportTimeout { get; set; } = TimeSpan.Zero;
     public ImmutableArray<string> CustomClientHeaders { get; } = new();
+    public CancellationToken CancellationToken = default;
 
     internal long NodeId { get; set; }
     internal Action<Grpc.Core.Metadata> TrailersHandler { get; set; } = _ => { };

--- a/src/Ydb.Sdk/src/IDriver.cs
+++ b/src/Ydb.Sdk/src/IDriver.cs
@@ -144,7 +144,8 @@ public abstract class BaseDriver : IDriver
         }
 
         var options = new CallOptions(
-            headers: meta
+            headers: meta,
+            cancellationToken: settings.CancellationToken
         );
 
         if (settings.TransportTimeout != TimeSpan.Zero)
@@ -213,7 +214,7 @@ public sealed class ServerStream<TResponse> : IAsyncEnumerator<TResponse>, IAsyn
     }
 }
 
-public class BidirectionalStream<TRequest, TResponse> : IBidirectionalStream<TRequest, TResponse>
+internal class BidirectionalStream<TRequest, TResponse> : IBidirectionalStream<TRequest, TResponse>
 {
     private readonly AsyncDuplexStreamingCall<TRequest, TResponse> _stream;
     private readonly Action<RpcException> _rpcErrorAction;

--- a/src/Ydb.Sdk/src/Services/Topic/Metadata.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Metadata.cs
@@ -1,0 +1,3 @@
+namespace Ydb.Sdk.Services.Topic;
+
+public record Metadata(string Key, byte[] Value);

--- a/src/Ydb.Sdk/src/Services/Topic/Writer/Message.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Writer/Message.cs
@@ -13,5 +13,3 @@ public class Message<TValue>
 
     public List<Metadata> Metadata { get; } = new();
 }
-
-public record Metadata(string Key, byte[] Value);

--- a/src/Ydb.Sdk/src/Services/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Services/Topic/Writer/Writer.cs
@@ -488,14 +488,12 @@ Client SeqNo: {SeqNo}, WriteAck: {WriteAck}",
                     _inFlightMessages.TryDequeue(out _); // Dequeue 
                 }
             }
+
+            Logger.LogWarning("WriterSession[{SessionId}]: stream is closed", SessionId);
         }
         catch (Driver.TransportException e)
         {
             Logger.LogError(e, "WriterSession[{SessionId}] have error on processing writeAck", SessionId);
-        }
-        catch (ObjectDisposedException)
-        {
-            Logger.LogWarning("WriterSession[{SessionId}]: stream is closed", SessionId);
         }
         finally
         {


### PR DESCRIPTION
1) Do not pessimize the node on Grpc.Core.StatusCode.Cancelled.
2) Dispose of WriterSession using dispose CancellationToken.
3) BidirectionalStream is internal class.
4) Move Metadata class to Ydb.Sdk.Services.Topic.
5) Fixed memory leak CancellationTokenRegistration.
6) Cancel writing tasks after disposing of Writer.
