### PR TITLE
Fixed bug: 'System.DateOnly' is not supported by YdbParameter

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed bug: 'System.DateOnly' is not supported by YdbParameter ([#449](https://github.com/ydb-platform/ydb-dotnet-sdk/issues/449)).
 - Fixed bug: Unhandled exception.
   System.Net.Http.HttpIOException ([#452](https://github.com/ydb-platform/ydb-dotnet-sdk/issues/451)).
 - dev: LogLevel `Warning` -> `Debug` on AttachStream has been cancelled.

--- a/src/Ydb.Sdk/src/Ado/YdbParameter.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbParameter.cs
@@ -109,6 +109,8 @@ public sealed class YdbParameter : DbParameter
         },
         DateTimeOffset dateTimeOffset when DbType is DbType.DateTimeOffset or DbType.Object =>
             YdbValue.MakeTimestamp(dateTimeOffset.UtcDateTime),
+        DateOnly dateOnlyValue when DbType is DbType.Date or DbType.Object =>
+            YdbValue.MakeDate(dateOnlyValue.ToDateTime(TimeOnly.MinValue)),
         float floatValue => DbType switch
         {
             DbType.Single or DbType.Object => YdbValue.MakeFloat(floatValue),

--- a/src/Ydb.Sdk/tests/Ado/YdbCommandTests.cs
+++ b/src/Ydb.Sdk/tests/Ado/YdbCommandTests.cs
@@ -463,4 +463,18 @@ SELECT Key, Cast(Value AS Text) FROM AS_TABLE($new_data); SELECT 1, 'text';"
 
         Assert.Equal(guid.ToLower(), actualGuidText); // Guid.ToString() method represents lowercase
     }
+
+    [Fact]
+    public async Task Date_WhenSetDateOnly_ReturnDateTime()
+    {
+        await using var ydbConnection = await CreateOpenConnectionAsync();
+        var ydbCommand = new YdbCommand(ydbConnection) { CommandText = "SELECT @dateOnly;" };
+        ydbCommand.Parameters.AddWithValue("dateOnly", new DateOnly(2002, 2, 24));
+
+        Assert.Equal(new DateTime(2002, 2, 24), await ydbCommand.ExecuteScalarAsync());
+
+        ydbCommand.Parameters.Clear();
+        ydbCommand.Parameters.AddWithValue("dateOnly", DbType.Date, new DateOnly(2102, 2, 24));
+        Assert.Equal(new DateTime(2102, 2, 24), await ydbCommand.ExecuteScalarAsync());
+    }
 }


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
