### PR TITLE
dev: Update tracing `YdbRetryPolicyExecutor`

### DIFF
--- a/src/Ydb.Sdk/src/Ado/RetryPolicy/YdbRetryPolicyExecutor.cs
+++ b/src/Ydb.Sdk/src/Ado/RetryPolicy/YdbRetryPolicyExecutor.cs
@@ -58,7 +58,11 @@ internal sealed class YdbRetryPolicyExecutor(IRetryPolicy retryPolicy)
                 {
                     var delay = retryPolicy.GetNextDelay(e, attempt++);
                     if (delay == null)
+                    {
+                        dbRetryActivity?.SetException(e);
+                        dbActivity?.SetException(e);
                         throw;
+                    }
 
                     // Close the previous retry span before starting a new one
                     dbRetryActivity?.SetException(e);

--- a/src/Ydb.Sdk/src/Ado/RetryPolicy/YdbRetryPolicyExecutor.cs
+++ b/src/Ydb.Sdk/src/Ado/RetryPolicy/YdbRetryPolicyExecutor.cs
@@ -40,27 +40,39 @@ internal sealed class YdbRetryPolicyExecutor(IRetryPolicy retryPolicy)
         CancellationToken cancellationToken
     )
     {
+        using var dbActivity = YdbActivitySource.StartActivity("ydb.Execute", ActivityKind.Internal);
+
         var attempt = 0;
-        while (true)
+        Activity? dbRetryActivity = null;
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            using var dbActive = YdbActivitySource.StartActivity("ydb.ExecuteWithRetry", ActivityKind.Internal);
-
-            try
+            while (true)
             {
-                return await operation(cancellationToken).ConfigureAwait(false);
-            }
-            catch (YdbException e)
-            {
-                dbActive?.SetException(e);
+                cancellationToken.ThrowIfCancellationRequested();
 
-                var delay = retryPolicy.GetNextDelay(e, attempt++);
-                if (delay == null)
-                    throw;
+                try
+                {
+                    return await operation(cancellationToken).ConfigureAwait(false);
+                }
+                catch (YdbException e)
+                {
+                    var delay = retryPolicy.GetNextDelay(e, attempt++);
+                    if (delay == null)
+                        throw;
 
-                dbActive?.SetRetryAttributes(attempt, delay.Value);
-                await Task.Delay(delay.Value, cancellationToken).ConfigureAwait(false);
+                    // Close the previous retry span before starting a new one
+                    dbRetryActivity?.SetException(e);
+                    dbRetryActivity?.Dispose();
+                    dbRetryActivity = YdbActivitySource.StartActivity("ydb.Retry", ActivityKind.Internal);
+                    dbRetryActivity?.SetRetryAttributes(attempt, delay.Value);
+                    await Task.Delay(delay.Value, cancellationToken).ConfigureAwait(false);
+                    // dbRetryActivity stays open so the next operation() call is a child of it
+                }
             }
+        }
+        finally
+        {
+            dbRetryActivity?.Dispose();
         }
     }
 }

--- a/src/Ydb.Sdk/src/DriverConfig.cs
+++ b/src/Ydb.Sdk/src/DriverConfig.cs
@@ -74,7 +74,7 @@ public class DriverConfig
     /// </summary>
     public int MaxReceiveMessageSize { get; init; } = GrpcDefaultSettings.MaxReceiveMessageSize;
 
-    internal X509Certificate2Collection CustomServerCertificates { get; } = new();
+    internal X509Certificate2Collection CustomServerCertificates { get; } = [];
     internal TimeSpan EndpointDiscoveryInterval = TimeSpan.FromMinutes(1);
     internal TimeSpan EndpointDiscoveryTimeout = TimeSpan.FromSeconds(10);
     internal string SdkVersion { get; }

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Tracing/YdbTracingTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Tracing/YdbTracingTests.cs
@@ -167,7 +167,7 @@ public class YdbTracingTests : TestBase
         await ydbDataSource.ExecuteInTransactionAsync(connection =>
             new YdbCommand("SELECT 1;", connection).ExecuteNonQueryAsync());
 
-        var executeWithRetryActivity = GetSingleActivity(activities, "ydb.ExecuteWithRetry");
+        var executeWithRetryActivity = GetSingleActivity(activities, "ydb.Execute");
         Assert.Empty(executeWithRetryActivity.Events);
         Assert.Equal(ActivityKind.Internal, executeWithRetryActivity.Kind);
         Assert.Empty(executeWithRetryActivity.TagObjects);
@@ -181,6 +181,8 @@ public class YdbTracingTests : TestBase
         Assert.Empty(commitActivity.Events);
         Assert.Equal(ActivityKind.Client, commitActivity.Kind);
         AssertCommonDbTags(commitActivity);
+
+        Assert.DoesNotContain(activities, a => a.DisplayName == "ydb.Retry");
     }
 
     [Fact]
@@ -197,7 +199,7 @@ public class YdbTracingTests : TestBase
         await using var ydbRetryableConnection = await ydbDataSource.OpenRetryableConnectionAsync();
         await new YdbCommand("SELECT 1;", ydbRetryableConnection).ExecuteNonQueryAsync();
 
-        var executeWithRetryActivity = GetSingleActivity(activities, "ydb.ExecuteWithRetry");
+        var executeWithRetryActivity = GetSingleActivity(activities, "ydb.Execute");
         Assert.Empty(executeWithRetryActivity.Events);
         Assert.Equal(ActivityKind.Internal, executeWithRetryActivity.Kind);
         Assert.Empty(executeWithRetryActivity.TagObjects);
@@ -207,33 +209,66 @@ public class YdbTracingTests : TestBase
         Assert.Equal(ActivityKind.Client, executeQueryActivity.Kind);
         Assert.Equal(true, executeQueryActivity.GetTagItem("ydb.execute.in_memory"));
         AssertCommonDbTags(executeQueryActivity);
+
+        Assert.DoesNotContain(activities, a => a.DisplayName == "ydb.Retry");
     }
 
     [Fact]
-    public async Task Retry_WhenIsFailed_ExpectedRetryAttributes()
+    public async Task Execute_NoRetry_EmitsSingleExecuteActivity()
     {
         using var activityListener = StartListener(out var activities);
 
-        var retryPolicyExecutor = new YdbRetryPolicyExecutor(YdbRetryPolicy.Default);
+        var executor = new YdbRetryPolicyExecutor(YdbRetryPolicy.Default);
+        await executor.ExecuteAsync(_ => Task.CompletedTask);
 
-        var wasFirstRetry = false;
-        await retryPolicyExecutor.ExecuteAsync(_ =>
+        var executeActivity = GetSingleActivity(activities, "ydb.Execute");
+        Assert.Equal(ActivityKind.Internal, executeActivity.Kind);
+        Assert.Empty(executeActivity.TagObjects);
+        Assert.DoesNotContain(activities, a => a.DisplayName == "ydb.Retry");
+    }
+
+    [Fact]
+    public async Task Execute_WithRetry_EmitsExecuteAndRetryActivities()
+    {
+        using var activityListener = StartListener(out var activities);
+
+        var executor = new YdbRetryPolicyExecutor(YdbRetryPolicy.Default);
+
+        var firstAttempt = true;
+        await executor.ExecuteAsync(_ =>
         {
-            if (wasFirstRetry)
+            if (!firstAttempt)
                 return Task.CompletedTask;
 
-            wasFirstRetry = true;
+            firstAttempt = false;
             throw new YdbException(StatusCode.Aborted, "TLI!");
         });
 
-        Assert.Equal(2, activities.Count);
-        Assert.All(activities, activity => Assert.Equal("ydb.ExecuteWithRetry", activity.DisplayName));
-        var activity = activities.First(activity => activity.Status == ActivityStatusCode.Error);
-        Assert.Equal(ActivityKind.Internal, activity.Kind);
-        Assert.Equal(StatusCode.Aborted, activity.GetTagItem("db.response.status_code"));
-        Assert.Equal(1, activity.GetTagItem("ydb.retry.attempt"));
-        Assert.Equal("TLI!", activity.StatusDescription);
-        Assert.NotNull(activity.GetTagItem("ydb.retry.backoff_ms"));
+        // ydb.Execute wraps everything, ydb.Retry only on actual retry
+        var executeActivity = GetSingleActivity(activities, "ydb.Execute");
+        Assert.Equal(ActivityKind.Internal, executeActivity.Kind);
+        Assert.Empty(executeActivity.TagObjects);
+
+        // ydb.Retry span has no error: the attempt under it succeeded.
+        // The error that triggered the retry is recorded on the span of the previous attempt.
+        var retryActivity = GetSingleActivity(activities, "ydb.Retry");
+        Assert.Equal(ActivityKind.Internal, retryActivity.Kind);
+        Assert.Equal(1, retryActivity.GetTagItem("ydb.retry.attempt"));
+        Assert.NotNull(retryActivity.GetTagItem("ydb.retry.backoff_ms"));
+    }
+
+    [Fact]
+    public async Task Execute_NonRetryableError_EmitsExecuteWithoutRetryActivity()
+    {
+        using var activityListener = StartListener(out var activities);
+
+        var executor = new YdbRetryPolicyExecutor(YdbRetryPolicy.Default);
+
+        await Assert.ThrowsAsync<YdbException>(() =>
+            executor.ExecuteAsync(_ => throw new YdbException(StatusCode.Unauthorized, "no access")));
+
+        GetSingleActivity(activities, "ydb.Execute");
+        Assert.DoesNotContain(activities, a => a.DisplayName == "ydb.Retry");
     }
 
     private static ActivityListener StartListener(out List<Activity> activities)

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Tracing/YdbTracingTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Tracing/YdbTracingTests.cs
@@ -267,8 +267,29 @@ public class YdbTracingTests : TestBase
         await Assert.ThrowsAsync<YdbException>(() =>
             executor.ExecuteAsync(_ => throw new YdbException(StatusCode.Unauthorized, "no access")));
 
-        GetSingleActivity(activities, "ydb.Execute");
+        var executeActivity = GetSingleActivity(activities, "ydb.Execute", expectedStatusCode: ActivityStatusCode.Error);
+        Assert.Equal(StatusCode.Unauthorized, executeActivity.GetTagItem("db.response.status_code"));
         Assert.DoesNotContain(activities, a => a.DisplayName == "ydb.Retry");
+    }
+
+    [Fact]
+    public async Task Execute_RetriesExhausted_EmitsExecuteAndRetryActivitiesWithError()
+    {
+        using var activityListener = StartListener(out var activities);
+
+        var policy = new YdbRetryPolicy(new YdbRetryPolicyConfig { MaxAttempts = 2 });
+        var executor = new YdbRetryPolicyExecutor(policy);
+
+        // Aborted is retryable; with MaxAttempts=2 we get 1 retry then failure
+        await Assert.ThrowsAsync<YdbException>(() =>
+            executor.ExecuteAsync(_ => throw new YdbException(StatusCode.Aborted, "always fails")));
+
+        var executeActivity = GetSingleActivity(activities, "ydb.Execute", expectedStatusCode: ActivityStatusCode.Error);
+        Assert.Equal(StatusCode.Aborted, executeActivity.GetTagItem("db.response.status_code"));
+
+        var retryActivity = GetSingleActivity(activities, "ydb.Retry", expectedStatusCode: ActivityStatusCode.Error);
+        Assert.Equal(1, retryActivity.GetTagItem("ydb.retry.attempt"));
+        Assert.Equal(StatusCode.Aborted, retryActivity.GetTagItem("db.response.status_code"));
     }
 
     private static ActivityListener StartListener(out List<Activity> activities)

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Tracing/YdbTracingTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Tracing/YdbTracingTests.cs
@@ -267,7 +267,8 @@ public class YdbTracingTests : TestBase
         await Assert.ThrowsAsync<YdbException>(() =>
             executor.ExecuteAsync(_ => throw new YdbException(StatusCode.Unauthorized, "no access")));
 
-        var executeActivity = GetSingleActivity(activities, "ydb.Execute", expectedStatusCode: ActivityStatusCode.Error);
+        var executeActivity =
+            GetSingleActivity(activities, "ydb.Execute", expectedStatusCode: ActivityStatusCode.Error);
         Assert.Equal(StatusCode.Unauthorized, executeActivity.GetTagItem("db.response.status_code"));
         Assert.DoesNotContain(activities, a => a.DisplayName == "ydb.Retry");
     }
@@ -284,7 +285,8 @@ public class YdbTracingTests : TestBase
         await Assert.ThrowsAsync<YdbException>(() =>
             executor.ExecuteAsync(_ => throw new YdbException(StatusCode.Aborted, "always fails")));
 
-        var executeActivity = GetSingleActivity(activities, "ydb.Execute", expectedStatusCode: ActivityStatusCode.Error);
+        var executeActivity =
+            GetSingleActivity(activities, "ydb.Execute", expectedStatusCode: ActivityStatusCode.Error);
         Assert.Equal(StatusCode.Aborted, executeActivity.GetTagItem("db.response.status_code"));
 
         var retryActivity = GetSingleActivity(activities, "ydb.Retry", expectedStatusCode: ActivityStatusCode.Error);


### PR DESCRIPTION
- Added `ydb.Execute` span wrapping the entire retry loop — child RPC spans from the first attempt attach directly to it
- `ydb.Retry` span is created only on actual retries (not the first attempt), covers `Task.Delay` + the next operation call so retry attempt's child spans attach to it
- Consecutive retry spans are chained: previous span is closed with the error that caused the next retry before a new `ydb.Retry` is started