### PR TITLE
feat: add nearest DC detection with TCP race

### DIFF
--- a/src/Ydb.Sdk/src/Ado/YdbConnectionStringBuilder.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbConnectionStringBuilder.cs
@@ -64,6 +64,7 @@ public sealed class YdbConnectionStringBuilder : DbConnectionStringBuilder, IDri
         _disableDiscovery = GrpcDefaultSettings.DisableDiscovery;
         _disableServerBalancer = false;
         _enableImplicitSession = false;
+        _enablePreferNearestDcBalancing = false;
     }
 
     /// <summary>
@@ -533,6 +534,25 @@ public sealed class YdbConnectionStringBuilder : DbConnectionStringBuilder, IDri
     private bool _enableImplicitSession;
 
     /// <summary>
+    /// Gets or sets a value indicating whether nearest-datacenter balancing should be enabled.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, the driver performs a TCP race across discovered endpoints and prefers
+    /// endpoints from the fastest datacenter. Default value: false.
+    /// </remarks>
+    public bool EnablePreferNearestDcBalancing
+    {
+        get => _enablePreferNearestDcBalancing;
+        set
+        {
+            _enablePreferNearestDcBalancing = value;
+            SaveValue(nameof(EnablePreferNearestDcBalancing), value);
+        }
+    }
+
+    private bool _enablePreferNearestDcBalancing;
+
+    /// <summary>
     /// Path to a Yandex.Cloud service account key file (JSON).
     /// </summary>
     /// <remarks>
@@ -731,7 +751,8 @@ public sealed class YdbConnectionStringBuilder : DbConnectionStringBuilder, IDri
         $"ConnectTimeout={ConnectTimeout};KeepAlivePingDelay={KeepAlivePingDelay};KeepAlivePingTimeout={KeepAlivePingTimeout};" +
         $"EnableMultipleHttp2Connections={EnableMultipleHttp2Connections};MaxSendMessageSize={MaxSendMessageSize};" +
         $"MaxReceiveMessageSize={MaxReceiveMessageSize};DisableDiscovery={DisableDiscovery};" +
-        $"ServiceAccountKeyFilePath={ServiceAccountKeyFilePath};EnableMetadataCredentials={EnableMetadataCredentials}";
+        $"ServiceAccountKeyFilePath={ServiceAccountKeyFilePath};EnableMetadataCredentials={EnableMetadataCredentials};" +
+        $"EnablePreferNearestDcBalancing={EnablePreferNearestDcBalancing}";
 
     async Task<IDriver> IDriverFactory.CreateAsync()
     {
@@ -763,7 +784,8 @@ public sealed class YdbConnectionStringBuilder : DbConnectionStringBuilder, IDri
             Password = Password,
             EnableMultipleHttp2Connections = EnableMultipleHttp2Connections,
             MaxSendMessageSize = MaxSendMessageSize,
-            MaxReceiveMessageSize = MaxReceiveMessageSize
+            MaxReceiveMessageSize = MaxReceiveMessageSize,
+            EnablePreferNearestDcBalancing = EnablePreferNearestDcBalancing
         };
 
         return DisableDiscovery
@@ -879,6 +901,10 @@ public sealed class YdbConnectionStringBuilder : DbConnectionStringBuilder, IDri
             AddOption(new YdbConnectionOption<bool>(BoolExtractor, (builder, enableMetadataCredentials) =>
                     builder.EnableMetadataCredentials = enableMetadataCredentials),
                 "EnableMetadataCredentials", "Enable Metadata Credentials");
+            AddOption(new YdbConnectionOption<bool>(BoolExtractor,
+                    (builder, enablePreferNearestDcBalancing) =>
+                        builder.EnablePreferNearestDcBalancing = enablePreferNearestDcBalancing),
+                "EnablePreferNearestDcBalancing", "Enable Prefer Nearest Dc Balancing");
             AddOption(new YdbConnectionOption<string>(StringExtractor,
                     (builder, poolName) => builder.PoolName = poolName),
                 "PoolName", "Pool Name");

--- a/src/Ydb.Sdk/src/Driver.cs
+++ b/src/Ydb.Sdk/src/Driver.cs
@@ -28,6 +28,7 @@ public sealed class Driver : BaseDriver
     );
 
     private readonly EndpointPool _endpointPool;
+    private readonly EndpointLocalDcDetector _endpointLocalDcDetector;
 
     private volatile Timer? _discoveryTimer;
 
@@ -41,6 +42,7 @@ public sealed class Driver : BaseDriver
             (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<Driver>())
     {
         _endpointPool = new EndpointPool(LoggerFactory);
+        _endpointLocalDcDetector = new EndpointLocalDcDetector(LoggerFactory);
     }
 
     /// <summary>
@@ -182,15 +184,60 @@ public sealed class Driver : BaseDriver
             }
 
             var resultProto = operation.Result.Unpack<ListEndpointsResult>();
+            var discoveredEndpoints = resultProto.Endpoints.Select(infoProto =>
+                new EndpointInfo(infoProto.NodeId, infoProto.Ssl, infoProto.Address, infoProto.Port, infoProto.Location)
+            ).ToImmutableList();
+
+            string? preferredLocation = null;
+            if (Config.EnablePreferNearestDcBalancing)
+            {
+                preferredLocation = resultProto.SelfLocation;
+                try
+                {
+                    var detectedLocation = await _endpointLocalDcDetector.DetectNearestLocationDc(
+                        discoveredEndpoints,
+                        Config.ConnectTimeout
+                    );
+
+                    if (!string.IsNullOrEmpty(detectedLocation))
+                    {
+                        preferredLocation = detectedLocation;
+                        Logger.LogInformation(
+                            "Detected nearest DC via TCP latency: {DetectedLocation} (server reported: {SelfLocation})",
+                            detectedLocation,
+                            resultProto.SelfLocation
+                        );
+                    }
+                    else
+                    {
+                        Logger.LogWarning(
+                            "Failed to detect nearest DC via TCP latency, using server location: {SelfLocation}",
+                            resultProto.SelfLocation
+                        );
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.LogWarning(
+                        e,
+                        "Failed to detect nearest DC via TCP latency, using server location: {SelfLocation}",
+                        resultProto.SelfLocation
+                    );
+                }
+            }
 
             Logger.LogDebug(
-                "Successfully discovered endpoints: {EndpointsCount}, self location: {SelfLocation}, sdk info: {SdkInfo}",
-                resultProto.Endpoints.Count, resultProto.SelfLocation, Config.SdkVersion
+                "Successfully discovered endpoints: {EndpointsCount}, self location: {SelfLocation}, preferred location: {PreferredLocation}, sdk info: {SdkInfo}",
+                resultProto.Endpoints.Count,
+                resultProto.SelfLocation,
+                preferredLocation ?? "<disabled>",
+                Config.SdkVersion
             );
 
-            await ChannelPool.RemoveChannels(_endpointPool.Reset(resultProto.Endpoints.Select(infoProto =>
-                new EndpointInfo(infoProto.NodeId, infoProto.Ssl, infoProto.Address, infoProto.Port, infoProto.Location)
-            ).ToImmutableList()));
+            await ChannelPool.RemoveChannels(_endpointPool.Reset(
+                discoveredEndpoints,
+                preferredLocation
+            ));
         }
         catch (RpcException e)
         {

--- a/src/Ydb.Sdk/src/Driver.cs
+++ b/src/Ydb.Sdk/src/Driver.cs
@@ -191,7 +191,6 @@ public sealed class Driver : BaseDriver
             string? preferredLocation = null;
             if (Config.EnablePreferNearestDcBalancing)
             {
-                preferredLocation = resultProto.SelfLocation;
                 try
                 {
                     var detectedLocation = await _endpointLocalDcDetector.DetectNearestLocationDc(
@@ -211,8 +210,7 @@ public sealed class Driver : BaseDriver
                     else
                     {
                         Logger.LogWarning(
-                            "Failed to detect nearest DC via TCP latency, using server location: {SelfLocation}",
-                            resultProto.SelfLocation
+                            "Failed to detect nearest DC via TCP latency, no preferred location will be used"
                         );
                     }
                 }
@@ -220,8 +218,7 @@ public sealed class Driver : BaseDriver
                 {
                     Logger.LogWarning(
                         e,
-                        "Failed to detect nearest DC via TCP latency, using server location: {SelfLocation}",
-                        resultProto.SelfLocation
+                        "Failed to detect nearest DC via TCP latency, no preferred location will be used"
                     );
                 }
             }

--- a/src/Ydb.Sdk/src/DriverConfig.cs
+++ b/src/Ydb.Sdk/src/DriverConfig.cs
@@ -74,6 +74,15 @@ public class DriverConfig
     /// </summary>
     public int MaxReceiveMessageSize { get; init; } = GrpcDefaultSettings.MaxReceiveMessageSize;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether nearest-datacenter balancing should be enabled.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, the driver performs a TCP race across discovered endpoints and prefers
+    /// endpoints from the fastest datacenter. Default value: false.
+    /// </remarks>
+    public bool EnablePreferNearestDcBalancing { get; init; }
+
     internal X509Certificate2Collection CustomServerCertificates { get; } = [];
     internal TimeSpan EndpointDiscoveryInterval = TimeSpan.FromMinutes(1);
     internal TimeSpan EndpointDiscoveryTimeout = TimeSpan.FromSeconds(10);

--- a/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
+++ b/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
@@ -167,13 +167,28 @@ internal sealed class SocketTcpConnector : ITcpConnector
     public async Task ConnectAsync(string host, int port, CancellationToken cancellationToken)
     {
         var addresses = await Dns.GetHostAddressesAsync(host, cancellationToken);
+        if (addresses.Length == 0)
+        {
+            throw new SocketException((int)SocketError.HostNotFound);
+        }
+
+        SocketException? lastException = null;
         foreach (var address in addresses)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            using var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            await socket.ConnectAsync(new IPEndPoint(address, port), cancellationToken);
-            return;
+            try
+            {
+                using var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                await socket.ConnectAsync(new IPEndPoint(address, port), cancellationToken);
+                return;
+            }
+            catch (SocketException e)
+            {
+                lastException = e;
+            }
         }
+
+        throw lastException!;
     }
 }

--- a/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
+++ b/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace Ydb.Sdk.Pool;
+
+internal sealed class EndpointLocalDcDetector
+{
+    private const int MaxEndpointsCheckPerLocation = 5;
+
+    private readonly ILogger<EndpointLocalDcDetector> _logger;
+
+    public EndpointLocalDcDetector(ILoggerFactory loggerFactory)
+    {
+        _logger = loggerFactory.CreateLogger<EndpointLocalDcDetector>();
+    }
+
+    public async Task<string?> DetectNearestLocationDc(
+        IReadOnlyList<EndpointInfo> endpoints,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
+
+        if (endpoints.Count == 0)
+        {
+            throw new ArgumentException("Empty endpoints list for local DC detection", nameof(endpoints));
+        }
+
+        var endpointsByLocation = SplitEndpointsByLocation(endpoints);
+
+        _logger.LogDebug(
+            "Detecting nearest DC from {EndpointsCount} endpoints across {LocationsCount} locations",
+            endpoints.Count,
+            endpointsByLocation.Count
+        );
+
+        if (endpointsByLocation.Count == 1)
+        {
+            var location = endpointsByLocation.Keys.Single();
+            _logger.LogDebug("Only one location found: {Location}", location);
+            return location;
+        }
+
+        var endpointsToTest = new List<EndpointInfo>(MaxEndpointsCheckPerLocation * endpointsByLocation.Count);
+        foreach (var (location, locationEndpoints) in endpointsByLocation)
+        {
+            var sample = GetRandomEndpoints(locationEndpoints, MaxEndpointsCheckPerLocation);
+            endpointsToTest.AddRange(sample);
+
+            _logger.LogDebug(
+                "Selected {SelectedCount}/{LocationEndpointsCount} endpoints from location '{Location}' for testing",
+                sample.Count,
+                locationEndpoints.Count,
+                location
+            );
+        }
+
+        var fastestEndpoint = await DetectFastestEndpoint(endpointsToTest, timeout, cancellationToken);
+        if (fastestEndpoint is null)
+        {
+            _logger.LogDebug("Failed to detect nearest DC via TCP race: no endpoint connected in time");
+            return null;
+        }
+
+        _logger.LogDebug("Detected nearest DC: {Location}", fastestEndpoint.LocationDc);
+        return fastestEndpoint.LocationDc;
+    }
+
+    private async Task<EndpointInfo?> DetectFastestEndpoint(
+        IReadOnlyList<EndpointInfo> endpoints,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+
+        var winner = new TaskCompletionSource<EndpointInfo?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tasks = endpoints.Select(endpoint => TryConnect(endpoint, winner, cts.Token)).ToArray();
+
+        try
+        {
+            await Task.WhenAll(tasks);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+        }
+
+        if (winner.Task.IsCompletedSuccessfully)
+        {
+            return await winner.Task;
+        }
+
+        return null;
+    }
+
+    private async Task TryConnect(
+        EndpointInfo endpoint,
+        TaskCompletionSource<EndpointInfo?> winner,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var addresses = await Dns.GetHostAddressesAsync(endpoint.Host, cancellationToken);
+            foreach (var address in addresses)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                using var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                await socket.ConnectAsync(new IPEndPoint(address, checked((int)endpoint.Port)), cancellationToken);
+
+                if (winner.TrySetResult(endpoint))
+                {
+                    _logger.LogDebug("TCP race winner endpoint: {Endpoint}", endpoint.Endpoint);
+                }
+
+                return;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (SocketException e)
+        {
+            _logger.LogTrace(e, "TCP race failed for endpoint {Endpoint}", endpoint.Endpoint);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "Unexpected error during TCP race for endpoint {Endpoint}", endpoint.Endpoint);
+        }
+    }
+
+    private static Dictionary<string, List<EndpointInfo>> SplitEndpointsByLocation(
+        IReadOnlyList<EndpointInfo> endpoints)
+    {
+        var result = new Dictionary<string, List<EndpointInfo>>(StringComparer.Ordinal);
+        foreach (var endpoint in endpoints)
+        {
+            if (!result.TryGetValue(endpoint.LocationDc, out var locationEndpoints))
+            {
+                locationEndpoints = [];
+                result[endpoint.LocationDc] = locationEndpoints;
+            }
+
+            locationEndpoints.Add(endpoint);
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyList<EndpointInfo> GetRandomEndpoints(IReadOnlyList<EndpointInfo> endpoints, int count)
+    {
+        if (endpoints.Count <= count)
+        {
+            return endpoints;
+        }
+
+        return endpoints
+            .OrderBy(_ => Random.Shared.Next())
+            .Take(count)
+            .ToArray();
+    }
+}

--- a/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
+++ b/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
@@ -4,15 +4,22 @@ using Microsoft.Extensions.Logging;
 
 namespace Ydb.Sdk.Pool;
 
+internal interface ITcpConnector
+{
+    Task ConnectAsync(string host, int port, CancellationToken cancellationToken);
+}
+
 internal sealed class EndpointLocalDcDetector
 {
     private const int MaxEndpointsCheckPerLocation = 5;
 
     private readonly ILogger<EndpointLocalDcDetector> _logger;
+    private readonly ITcpConnector _tcpConnector;
 
-    public EndpointLocalDcDetector(ILoggerFactory loggerFactory)
+    public EndpointLocalDcDetector(ILoggerFactory loggerFactory, ITcpConnector? tcpConnector = null)
     {
         _logger = loggerFactory.CreateLogger<EndpointLocalDcDetector>();
+        _tcpConnector = tcpConnector ?? new SocketTcpConnector();
     }
 
     public async Task<string?> DetectNearestLocationDc(
@@ -76,7 +83,7 @@ internal sealed class EndpointLocalDcDetector
         cts.CancelAfter(timeout);
 
         var winner = new TaskCompletionSource<EndpointInfo?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var tasks = endpoints.Select(endpoint => TryConnect(endpoint, winner, cts.Token)).ToArray();
+        var tasks = endpoints.Select(endpoint => TryConnect(endpoint, winner, cts)).ToArray();
 
         try
         {
@@ -97,28 +104,21 @@ internal sealed class EndpointLocalDcDetector
     private async Task TryConnect(
         EndpointInfo endpoint,
         TaskCompletionSource<EndpointInfo?> winner,
-        CancellationToken cancellationToken)
+        CancellationTokenSource cts)
     {
         try
         {
-            var addresses = await Dns.GetHostAddressesAsync(endpoint.Host, cancellationToken);
-            foreach (var address in addresses)
+            await _tcpConnector.ConnectAsync(endpoint.Host, checked((int)endpoint.Port), cts.Token);
+
+            if (winner.TrySetResult(endpoint))
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                using var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-                await socket.ConnectAsync(new IPEndPoint(address, checked((int)endpoint.Port)), cancellationToken);
-
-                if (winner.TrySetResult(endpoint))
-                {
-                    _logger.LogDebug("TCP race winner endpoint: {Endpoint}", endpoint.Endpoint);
-                }
-
-                return;
+                _logger.LogDebug("TCP race winner endpoint: {Endpoint}", endpoint.Endpoint);
+                cts.Cancel();
             }
         }
         catch (OperationCanceledException)
         {
+            // Expected: either timeout expired or another endpoint won the race
         }
         catch (SocketException e)
         {
@@ -159,5 +159,21 @@ internal sealed class EndpointLocalDcDetector
             .OrderBy(_ => Random.Shared.Next())
             .Take(count)
             .ToArray();
+    }
+}
+
+internal sealed class SocketTcpConnector : ITcpConnector
+{
+    public async Task ConnectAsync(string host, int port, CancellationToken cancellationToken)
+    {
+        var addresses = await Dns.GetHostAddressesAsync(host, cancellationToken);
+        foreach (var address in addresses)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            await socket.ConnectAsync(new IPEndPoint(address, port), cancellationToken);
+            return;
+        }
     }
 }

--- a/src/Ydb.Sdk/src/Pool/EndpointPool.cs
+++ b/src/Ydb.Sdk/src/Pool/EndpointPool.cs
@@ -38,29 +38,47 @@ internal class EndpointPool
         }
     }
 
-    public ImmutableArray<EndpointInfo> Reset(IReadOnlyList<EndpointInfo> endpointSettingsList)
+    public ImmutableArray<EndpointInfo> Reset(IReadOnlyList<EndpointInfo> endpointSettingsList,
+        string? preferredLocationDc = null)
     {
         Dictionary<long, EndpointInfo> nodeIdToEndpoint = new();
         HashSet<string> newEndpoints = new();
 
-        _logger.LogDebug("Init endpoint pool with {EndpointLength} endpoints", endpointSettingsList.Count);
+        _logger.LogDebug(
+            "Init endpoint pool with {EndpointLength} endpoints. Preferred location: {PreferredLocation}",
+            endpointSettingsList.Count,
+            preferredLocationDc ?? "<none>"
+        );
 
-        foreach (var endpointSettings in endpointSettingsList)
-        {
-            _logger.LogDebug("Registered endpoint: {Endpoint}", endpointSettings.Endpoint);
-
-            if (!newEndpoints.Add(endpointSettings.Endpoint))
+        var prioritizedEndpoints = endpointSettingsList
+            .Select(endpointSettings =>
             {
-                _logger.LogWarning("Duplicate endpoint: {Endpoint}", endpointSettings.Endpoint);
+                _logger.LogDebug("Registered endpoint: {Endpoint}", endpointSettings.Endpoint);
 
-                continue;
-            }
+                if (!newEndpoints.Add(endpointSettings.Endpoint))
+                {
+                    _logger.LogWarning("Duplicate endpoint: {Endpoint}", endpointSettings.Endpoint);
+                    return null;
+                }
 
-            if (endpointSettings.NodeId != 0) // NodeId == 0 - serverless proxy
-            {
-                nodeIdToEndpoint.Add(endpointSettings.NodeId, endpointSettings);
-            }
-        }
+                var prioritizedEndpoint = endpointSettings;
+                if (!string.IsNullOrEmpty(preferredLocationDc) &&
+                    !string.Equals(endpointSettings.LocationDc, preferredLocationDc, StringComparison.Ordinal))
+                {
+                    prioritizedEndpoint = endpointSettings with { };
+                    prioritizedEndpoint.Pessimize();
+                }
+
+                if (prioritizedEndpoint.NodeId != 0) // NodeId == 0 - serverless proxy
+                {
+                    nodeIdToEndpoint.Add(prioritizedEndpoint.NodeId, prioritizedEndpoint);
+                }
+
+                return prioritizedEndpoint;
+            })
+            .Where(endpointSettings => endpointSettings is not null)
+            .Select(endpointSettings => endpointSettings!)
+            .ToImmutableArray();
 
         _rwLock.EnterWriteLock();
         try
@@ -69,8 +87,16 @@ internal class EndpointPool
                 .Where(priorityEndpoint => !newEndpoints.Contains(priorityEndpoint.Endpoint))
                 .ToImmutableArray();
 
-            _sortedByPriorityEndpoints = endpointSettingsList;
-            _preferredEndpointCount = endpointSettingsList.Count;
+            _sortedByPriorityEndpoints =
+            [
+                ..prioritizedEndpoints
+                    .OrderBy(priorityEndpoint => priorityEndpoint.Priority)
+            ];
+
+            _preferredEndpointCount =
+                _sortedByPriorityEndpoints.Count(endpoint =>
+                    endpoint.Priority == _sortedByPriorityEndpoints[0].Priority);
+
             _nodeIdToEndpoint = nodeIdToEndpoint;
 
             return removed;

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Pool/EndpointLocalDcDetectorTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Pool/EndpointLocalDcDetectorTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using Xunit;
@@ -8,13 +9,13 @@ namespace Ydb.Sdk.Ado.Tests.Pool;
 
 public class EndpointLocalDcDetectorTests
 {
-    private readonly EndpointLocalDcDetector _detector = new(TestUtils.LoggerFactory);
-
     [Fact]
     public async Task DetectNearestLocationDc_WhenEndpointsEmpty_ThrowsArgumentException()
     {
+        var detector = new EndpointLocalDcDetector(TestUtils.LoggerFactory);
+
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
-            _detector.DetectNearestLocationDc([], TimeSpan.FromMilliseconds(100)));
+            detector.DetectNearestLocationDc([], TimeSpan.FromMilliseconds(100)));
 
         Assert.Contains("Empty endpoints list", exception.Message);
     }
@@ -22,13 +23,14 @@ public class EndpointLocalDcDetectorTests
     [Fact]
     public async Task DetectNearestLocationDc_WhenSingleLocation_ReturnsImmediately()
     {
+        var detector = new EndpointLocalDcDetector(TestUtils.LoggerFactory);
         var endpoints = new[]
         {
             new EndpointInfo(1, false, "dc1-a.example.com", 2136, "dc1"),
             new EndpointInfo(2, false, "dc1-b.example.com", 2136, "dc1")
         };
 
-        var location = await _detector.DetectNearestLocationDc(endpoints, TimeSpan.FromMilliseconds(100));
+        var location = await detector.DetectNearestLocationDc(endpoints, TimeSpan.FromMilliseconds(100));
 
         Assert.Equal("dc1", location);
     }
@@ -36,13 +38,18 @@ public class EndpointLocalDcDetectorTests
     [Fact]
     public async Task DetectNearestLocationDc_WhenAllConnectionsFail_ReturnsNull()
     {
+        var connector = new FakeTcpConnector();
+        connector.SetupThrow("host1", new SocketException());
+        connector.SetupThrow("host2", new SocketException());
+
+        var detector = new EndpointLocalDcDetector(TestUtils.LoggerFactory, connector);
         var endpoints = new[]
         {
-            new EndpointInfo(1, false, "127.0.0.1", 65001, "dc1"),
-            new EndpointInfo(2, false, "127.0.0.1", 65002, "dc2")
+            new EndpointInfo(1, false, "host1", 2136, "dc1"),
+            new EndpointInfo(2, false, "host2", 2136, "dc2")
         };
 
-        var location = await _detector.DetectNearestLocationDc(endpoints, TimeSpan.FromMilliseconds(100));
+        var location = await detector.DetectNearestLocationDc(endpoints, TimeSpan.FromMilliseconds(100));
 
         Assert.Null(location);
     }
@@ -50,20 +57,52 @@ public class EndpointLocalDcDetectorTests
     [Fact]
     public async Task DetectNearestLocationDc_WhenOneEndpointConnectsFirst_ReturnsItsLocation()
     {
-        await using var fastListener = await StartListener();
+        await using var fastListener = StartListener();
 
+        var detector = new EndpointLocalDcDetector(TestUtils.LoggerFactory);
         var endpoints = new[]
         {
+            // port 65003 is not listening → ECONNREFUSED immediately
             new EndpointInfo(1, false, "127.0.0.1", 65003, "slow-dc"),
             new EndpointInfo(2, false, "127.0.0.1", fastListener.Port, "fast-dc")
         };
 
-        var location = await _detector.DetectNearestLocationDc(endpoints, TimeSpan.FromSeconds(1));
+        var location = await detector.DetectNearestLocationDc(endpoints, TimeSpan.FromSeconds(1));
 
         Assert.Equal("fast-dc", location);
     }
 
-    private static Task<TestTcpListener> StartListener()
+    [Fact]
+    public async Task DetectNearestLocationDc_WhenWinnerFound_CancelsRemainingTasks()
+    {
+        // fast-dc connects immediately; slow-dc blocks until its CancellationToken is
+        // cancelled.  If cts.Cancel() is NOT called when the winner is found,
+        // Task.WhenAll waits for the full 5-second timeout.
+        // With cancellation the test should finish in well under 1 second.
+        var connector = new FakeTcpConnector();
+        connector.SetupImmediate("fast-host");
+        connector.SetupBlockUntilCancelled("slow-host");
+
+        var detector = new EndpointLocalDcDetector(TestUtils.LoggerFactory, connector);
+        var endpoints = new[]
+        {
+            new EndpointInfo(1, false, "slow-host", 2136, "slow-dc"),
+            new EndpointInfo(2, false, "fast-host", 2136, "fast-dc")
+        };
+
+        var timeout = TimeSpan.FromSeconds(5);
+        var sw = Stopwatch.StartNew();
+
+        var location = await detector.DetectNearestLocationDc(endpoints, timeout);
+
+        sw.Stop();
+
+        Assert.Equal("fast-dc", location);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+            $"Detection took {sw.Elapsed.TotalMilliseconds:F0} ms — cts.Cancel() after winner found may not be working");
+    }
+
+    private static TestTcpListener StartListener()
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
@@ -74,7 +113,7 @@ public class EndpointLocalDcDetectorTests
             await Task.Delay(50);
         });
 
-        return Task.FromResult(new TestTcpListener(listener, acceptTask));
+        return new TestTcpListener(listener, acceptTask);
     }
 
     private sealed class TestTcpListener(TcpListener listener, Task acceptTask) : IAsyncDisposable
@@ -94,6 +133,38 @@ public class EndpointLocalDcDetectorTests
             catch (ObjectDisposedException)
             {
             }
+        }
+    }
+
+    /// <summary>
+    /// Fake implementation of <see cref="ITcpConnector"/> for unit tests.
+    /// Per-host behaviour is configured via <c>Setup*</c> methods.
+    /// </summary>
+    private sealed class FakeTcpConnector : ITcpConnector
+    {
+        private readonly Dictionary<string, Func<CancellationToken, Task>> _handlers = new();
+
+        /// <summary>Host connects successfully without any delay.</summary>
+        public void SetupImmediate(string host) =>
+            _handlers[host] = _ => Task.CompletedTask;
+
+        /// <summary>Host blocks until the <see cref="CancellationToken"/> is cancelled.</summary>
+        public void SetupBlockUntilCancelled(string host) =>
+            _handlers[host] = ct => Task.Delay(Timeout.InfiniteTimeSpan, ct);
+
+        /// <summary>Host throws the given exception immediately.</summary>
+        public void SetupThrow(string host, Exception ex) =>
+            _handlers[host] = _ => Task.FromException(ex);
+
+        public Task ConnectAsync(string host, int port, CancellationToken cancellationToken)
+        {
+            if (_handlers.TryGetValue(host, out var handler))
+            {
+                return handler(cancellationToken);
+            }
+
+            // Default: throw SocketException (connection refused)
+            return Task.FromException(new SocketException());
         }
     }
 }

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Pool/EndpointLocalDcDetectorTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Pool/EndpointLocalDcDetectorTests.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using System.Net.Sockets;
+using Xunit;
+using Ydb.Sdk.Ado.Tests.Utils;
+using Ydb.Sdk.Pool;
+
+namespace Ydb.Sdk.Ado.Tests.Pool;
+
+public class EndpointLocalDcDetectorTests
+{
+    private readonly EndpointLocalDcDetector _detector = new(TestUtils.LoggerFactory);
+
+    [Fact]
+    public async Task DetectNearestLocationDc_WhenEndpointsEmpty_ThrowsArgumentException()
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _detector.DetectNearestLocationDc([], TimeSpan.FromMilliseconds(100)));
+
+        Assert.Contains("Empty endpoints list", exception.Message);
+    }
+
+    [Fact]
+    public async Task DetectNearestLocationDc_WhenSingleLocation_ReturnsImmediately()
+    {
+        var endpoints = new[]
+        {
+            new EndpointInfo(1, false, "dc1-a.example.com", 2136, "dc1"),
+            new EndpointInfo(2, false, "dc1-b.example.com", 2136, "dc1")
+        };
+
+        var location = await _detector.DetectNearestLocationDc(endpoints, TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal("dc1", location);
+    }
+
+    [Fact]
+    public async Task DetectNearestLocationDc_WhenAllConnectionsFail_ReturnsNull()
+    {
+        var endpoints = new[]
+        {
+            new EndpointInfo(1, false, "127.0.0.1", 65001, "dc1"),
+            new EndpointInfo(2, false, "127.0.0.1", 65002, "dc2")
+        };
+
+        var location = await _detector.DetectNearestLocationDc(endpoints, TimeSpan.FromMilliseconds(100));
+
+        Assert.Null(location);
+    }
+
+    [Fact]
+    public async Task DetectNearestLocationDc_WhenOneEndpointConnectsFirst_ReturnsItsLocation()
+    {
+        await using var fastListener = await StartListener();
+
+        var endpoints = new[]
+        {
+            new EndpointInfo(1, false, "127.0.0.1", 65003, "slow-dc"),
+            new EndpointInfo(2, false, "127.0.0.1", fastListener.Port, "fast-dc")
+        };
+
+        var location = await _detector.DetectNearestLocationDc(endpoints, TimeSpan.FromSeconds(1));
+
+        Assert.Equal("fast-dc", location);
+    }
+
+    private static Task<TestTcpListener> StartListener()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+
+        var acceptTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            await Task.Delay(50);
+        });
+
+        return Task.FromResult(new TestTcpListener(listener, acceptTask));
+    }
+
+    private sealed class TestTcpListener(TcpListener listener, Task acceptTask) : IAsyncDisposable
+    {
+        public uint Port => (uint)((IPEndPoint)listener.LocalEndpoint).Port;
+
+        public async ValueTask DisposeAsync()
+        {
+            listener.Stop();
+            try
+            {
+                await acceptTask;
+            }
+            catch (SocketException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+    }
+}

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Pool/EndpointPoolTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Pool/EndpointPoolTests.cs
@@ -188,6 +188,65 @@ public class EndpointPoolTests
         }
 
         [Fact]
+        public void Reset_WhenEmptyList_DoesNotThrow()
+        {
+            var exception = Record.Exception(() => _endpointPool.Reset([]));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Reset_WhenPreferredLocationSpecified_ReturnEndpointByNodeId()
+        {
+            _endpointPool.Reset(_endpointSettingsList, "SAS");
+
+            Assert.Equal(_endpointSettingsList.Single(endpoint => endpoint.NodeId == 1).Endpoint,
+                _endpointPool.GetEndpoint(1).Endpoint);
+            Assert.Equal(_endpointSettingsList.Single(endpoint => endpoint.NodeId == 3).Endpoint,
+                _endpointPool.GetEndpoint(3).Endpoint);
+            Assert.Equal(_endpointSettingsList.Single(endpoint => endpoint.NodeId == 4).Endpoint,
+                _endpointPool.GetEndpoint(4).Endpoint);
+        }
+
+        [Fact]
+        public void
+            Reset_WhenPreferredLocationSpecifiedAndFirstEndpointIsNonPreferred_GetEndpointUsesOnlyPreferredEndpoints()
+        {
+            var endpoints = new List<EndpointInfo>
+            {
+                new(1, false, "n1.ydb.tech", 2136, "MAN"),
+                new(2, true, "n2.ydb.tech", 2135, "SAS"),
+                new(3, false, "n3.ydb.tech", 2136, "SAS")
+            };
+
+            _endpointPool.Reset(endpoints, "SAS");
+
+            _mockRandom.Setup(random => random.Next(2)).Returns(0);
+            Assert.Contains(_endpointPool.GetEndpoint().Endpoint, new[]
+            {
+                "https://n2.ydb.tech:2135",
+                "http://n3.ydb.tech:2136"
+            });
+
+            _mockRandom.Setup(random => random.Next(2)).Returns(1);
+            Assert.Contains(_endpointPool.GetEndpoint().Endpoint, new[]
+            {
+                "https://n2.ydb.tech:2135",
+                "http://n3.ydb.tech:2136"
+            });
+        }
+
+        [Fact]
+        public void Reset_WhenPreferredLocationNotSpecified_KeepsAllEndpointsPreferred()
+        {
+            for (var i = 0; i < _endpointSettingsList.Count; i++)
+            {
+                _mockRandom.Setup(random => random.Next(_endpointSettingsList.Count)).Returns(i);
+                Assert.Equal(_endpointSettingsList[i].Endpoint, _endpointPool.GetEndpoint().Endpoint);
+            }
+        }
+
+        [Fact]
         public void PessimizeEndpoint_WhenPessimizedAllNodes_ReturnRandomEndpoint()
         {
             foreach (var endpointSettings in _endpointSettingsList)

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbConnectionStringBuilderTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbConnectionStringBuilderTests.cs
@@ -35,11 +35,13 @@ public class YdbConnectionStringBuilderTests
         Assert.Null(ydbConnectionStringBuilder.ServiceAccountKeyFilePath);
         Assert.False(ydbConnectionStringBuilder.EnableMetadataCredentials);
         Assert.Null(ydbConnectionStringBuilder.PoolName);
+        Assert.False(ydbConnectionStringBuilder.EnablePreferNearestDcBalancing);
 
         Assert.Equal("UseTls=False;Host=localhost;Port=2136;Database=/local;User=;Password=;ConnectTimeout=5;" +
                      "KeepAlivePingDelay=10;KeepAlivePingTimeout=10;EnableMultipleHttp2Connections=False;" +
                      $"MaxSendMessageSize={MessageSize};MaxReceiveMessageSize={MessageSize};DisableDiscovery=False;" +
-                     "ServiceAccountKeyFilePath=;EnableMetadataCredentials=False",
+                     "ServiceAccountKeyFilePath=;EnableMetadataCredentials=False;" +
+                     "EnablePreferNearestDcBalancing=False",
             ((IDriverFactory)ydbConnectionStringBuilder).GrpcConnectionString);
     }
 
@@ -61,7 +63,7 @@ public class YdbConnectionStringBuilderTests
             "CreateSessionTimeout=30;SessionIdleTimeout=600;ConnectTimeout=30;KeepAlivePingDelay=30;" +
             "KeepAlivePingTimeout=60;EnableMultipleHttp2Connections=true;MaxSendMessageSize=1000000;" +
             "MaxReceiveMessageSize=1000000;DisableDiscovery=true;DisableServerBalancer=true;EnableImplicitSession=true;" +
-            "PoolName=my-pool"
+            "PoolName=my-pool;EnablePreferNearestDcBalancing=true"
         );
 
         Assert.Equal(2135, ydbConnectionStringBuilder.Port);
@@ -87,15 +89,17 @@ public class YdbConnectionStringBuilderTests
                      "EnableMultipleHttp2Connections=True;" +
                      "MaxSendMessageSize=1000000;MaxReceiveMessageSize=1000000;" +
                      "DisableDiscovery=True;DisableServerBalancer=True;EnableImplicitSession=True;" +
-                     "PoolName=my-pool",
+                     "PoolName=my-pool;EnablePreferNearestDcBalancing=True",
             ydbConnectionStringBuilder.ConnectionString);
         Assert.True(ydbConnectionStringBuilder.DisableDiscovery);
         Assert.True(ydbConnectionStringBuilder.DisableServerBalancer);
         Assert.True(ydbConnectionStringBuilder.EnableImplicitSession);
+        Assert.True(ydbConnectionStringBuilder.EnablePreferNearestDcBalancing);
         Assert.Equal("UseTls=True;Host=server;Port=2135;Database=/my/path;User=Kirill;Password=;ConnectTimeout=30;" +
                      "KeepAlivePingDelay=30;KeepAlivePingTimeout=60;EnableMultipleHttp2Connections=True;" +
                      "MaxSendMessageSize=1000000;MaxReceiveMessageSize=1000000;DisableDiscovery=True;" +
-                     "ServiceAccountKeyFilePath=;EnableMetadataCredentials=False",
+                     "ServiceAccountKeyFilePath=;EnableMetadataCredentials=False;" +
+                     "EnablePreferNearestDcBalancing=True",
             ((IDriverFactory)ydbConnectionStringBuilder).GrpcConnectionString);
     }
 
@@ -107,7 +111,8 @@ public class YdbConnectionStringBuilderTests
         Assert.Equal("UseTls=False;Host=server;Port=2135;Database=/my/path;User=;Password=;ConnectTimeout=5;" +
                      "KeepAlivePingDelay=10;KeepAlivePingTimeout=10;EnableMultipleHttp2Connections=False;" +
                      $"MaxSendMessageSize={MessageSize};MaxReceiveMessageSize={MessageSize};DisableDiscovery=False;" +
-                     "ServiceAccountKeyFilePath=./k.json;EnableMetadataCredentials=False",
+                     "ServiceAccountKeyFilePath=./k.json;EnableMetadataCredentials=False;" +
+                     "EnablePreferNearestDcBalancing=False",
             ((IDriverFactory)ydbConnectionStringBuilder).GrpcConnectionString);
         Assert.Equal("server", ydbConnectionStringBuilder.Host);
         ydbConnectionStringBuilder.Host = "new_server";
@@ -115,7 +120,8 @@ public class YdbConnectionStringBuilderTests
         Assert.Equal("UseTls=False;Host=new_server;Port=2135;Database=/my/path;User=;Password=;ConnectTimeout=5;" +
                      "KeepAlivePingDelay=10;KeepAlivePingTimeout=10;EnableMultipleHttp2Connections=False;" +
                      $"MaxSendMessageSize={MessageSize};MaxReceiveMessageSize={MessageSize};DisableDiscovery=False;" +
-                     "ServiceAccountKeyFilePath=./k.json;EnableMetadataCredentials=False",
+                     "ServiceAccountKeyFilePath=./k.json;EnableMetadataCredentials=False;" +
+                     "EnablePreferNearestDcBalancing=False",
             ((IDriverFactory)ydbConnectionStringBuilder).GrpcConnectionString);
         Assert.Equal("Host=new_server;Port=2135;Database=/my/path;ServiceAccountKeyFilePath=./k.json",
             ydbConnectionStringBuilder.ConnectionString);


### PR DESCRIPTION
Add automatic nearest datacenter detection for connection pooling

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The SDK uses uniform random load balancing across all discovered endpoints without considering network latency, which can lead to suboptimal performance in multi-datacenter deployments.

Fixes: https://github.com/ydb-platform/ydb-dotnet-sdk/issues/99

## What is the new behavior?

Adds opt-in nearest datacenter detection that uses TCP connection racing to identify and prioritize the fastest-responding datacenter, reducing request latency in multi-DC deployments.

## Other information

- Fully backward compatible (disabled by default)