### PR TITLE
Migrate SLO workflow and workload to ydb-slo-action v2

### DIFF
--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -159,131 +159,42 @@ jobs:
             --ref "${{ steps.baseline.outputs.ref }}" \
             --workload "${{ matrix.workload.name }}"
 
-      - name: Initialize YDB SLO
-        id: ydb-slo
-        uses: ydb-platform/ydb-slo-action/init@main
+      - name: Run YDB SLO
+        uses: ydb-platform/ydb-slo-action/init@v2
+        timeout-minutes: 30
         with:
           github_issue: ${{ github.event.inputs.github_issue }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workload_name: ${{ matrix.workload.name }}
+          workload_duration: ${{ inputs.slo_workload_duration_seconds || '600' }}
           workload_current_ref: ${{ github.head_ref || github.ref_name }}
+          workload_current_image: ydb-app-current
+          workload_current_command: >-
+            run "Host=ydb;Port=2136;Database=/Root/testdb"
+            --read-rps ${{ inputs.slo_workload_read_max_rps || '1000' }}
+            --write-rps ${{ inputs.slo_workload_write_max_rps || '100' }}
+            --read-timeout 1000
+            --write-timeout 1000
           workload_baseline_ref: ${{ steps.baseline.outputs.ref }}
+          workload_baseline_image: ydb-app-baseline
+          workload_baseline_command: >-
+            run "Host=ydb;Port=2136;Database=/Root/testdb"
+            --read-rps ${{ inputs.slo_workload_read_max_rps || '1000' }}
+            --write-rps ${{ inputs.slo_workload_write_max_rps || '100' }}
+            --read-timeout 1000
+            --write-timeout 1000
 
-      - name: Prepare SLO Database
-        run: |
-          echo "Preparing SLO database..."
-
-          IFS=',' read -ra DATABASE_IPS <<< "${{ steps.ydb-slo.outputs.ydb-database-ips }}"
-          ADD_HOST_ARGS=""
-          for ip in "${DATABASE_IPS[@]}"; do
-            ADD_HOST_ARGS="$ADD_HOST_ARGS --add-host ydb:$ip"
-          done
-
-          docker run --rm --network ydb_ydb-net \
-            $ADD_HOST_ARGS \
-            ydb-app-current create "Host=ydb;Port=2136;Database=/Root/testdb"
-
-      - name: Run SLO Tests (parallel)
-        timeout-minutes: 15
-        run: |
-          DURATION=${{ inputs.slo_workload_duration_seconds || 600 }}
-          READ_RPS=${{ inputs.slo_workload_read_max_rps || 1000 }}
-          WRITE_RPS=${{ inputs.slo_workload_write_max_rps || 100 }}
-          CURRENT_REF="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-
-          IFS=',' read -ra DATABASE_IPS <<< "${{ steps.ydb-slo.outputs.ydb-database-ips }}"
-          ADD_HOST_ARGS=""
-          for ip in "${DATABASE_IPS[@]}"; do
-            ADD_HOST_ARGS="$ADD_HOST_ARGS --add-host ydb:$ip"
-          done
-
-          CONNECTION_STRING="Host=ydb;Port=2136;Database=/Root/testdb"
-          OTLP_ENDPOINT="${{ steps.ydb-slo.outputs.ydb-prometheus-otlp }}"
-
-          echo "Connection string: $CONNECTION_STRING"
-          echo "OTLP endpoint: $OTLP_ENDPOINT"
-
-          echo "Starting ydb-app-current..."
-          docker run -d \
-            --name ydb-app-current \
-            --network ydb_ydb-net \
-            $ADD_HOST_ARGS \
-            -e "REF=${CURRENT_REF}" \
-            -e "WORKLOAD=${{ matrix.workload.name }}" \
-            ydb-app-current run "$CONNECTION_STRING" \
-              --otlp-endpoint "$OTLP_ENDPOINT" \
-              --report-period 250 \
-              --time $DURATION \
-              --read-rps $READ_RPS \
-              --write-rps $WRITE_RPS \
-              --read-timeout 1000 \
-              --write-timeout 1000
-
-          echo "Starting ydb-app-baseline..."
-          docker run -d \
-            --name ydb-app-baseline \
-            --network ydb_ydb-net \
-            $ADD_HOST_ARGS \
-            -e "REF=${{ steps.baseline.outputs.ref }}" \
-            -e "WORKLOAD=${{ matrix.workload.name }}" \
-            ydb-app-baseline run "$CONNECTION_STRING" \
-              --otlp-endpoint "$OTLP_ENDPOINT" \
-              --report-period 250 \
-              --time $DURATION \
-              --read-rps $READ_RPS \
-              --write-rps $WRITE_RPS \
-              --read-timeout 1000 \
-              --write-timeout 1000
-
-          # Show initial logs
-          echo ""
-          echo "==================== INITIAL CURRENT LOGS ===================="
-          docker logs -n 15 ydb-app-current 2>&1 || echo "No current container"
-          echo ""
-          echo "==================== INITIAL BASELINE LOGS ===================="
-          docker logs -n 15 ydb-app-baseline 2>&1 || echo "No baseline container"
-          echo ""
-
-          # Wait for workloads to complete
-          echo "Waiting for workloads to complete (${DURATION}s)..."
-          sleep ${DURATION}
-
-          # Stop containers after workload duration and wait for graceful shutdown
-          echo "Stopping containers after ${DURATION}s..."
-          docker stop --timeout=30 ydb-app-current ydb-app-baseline 2>&1 || true
-
-          # Force kill if still running
-          docker kill ydb-app-current ydb-app-baseline 2>&1 || true
-
-          # Check exit codes
-          CURRENT_EXIT=$(docker inspect ydb-app-current --format='{{.State.ExitCode}}' 2>/dev/null || echo "1")
-          BASELINE_EXIT=$(docker inspect ydb-app-baseline --format='{{.State.ExitCode}}' 2>/dev/null || echo "0")
-
-          echo "Current container exit code: $CURRENT_EXIT"
-          echo "Baseline container exit code: $BASELINE_EXIT"
-
-          # Show final logs
-          echo ""
-          echo "==================== FINAL CURRENT LOGS ===================="
-          docker logs -n 15 ydb-app-current 2>&1 || echo "No current container"
-          echo ""
-          echo "==================== FINAL BASELINE LOGS ===================="
-          docker logs -n 15 ydb-app-baseline 2>&1 || echo "No baseline container"
-          echo ""
-
-          echo "SUCCESS: Workloads completed successfully"
-
-      - if: always()
-        name: Store logs
-        run: |
-          docker logs ydb-app-current > current.log 2>&1 || echo "No current container"
-          docker logs ydb-app-baseline > baseline.log 2>&1 || echo "No baseline container"
-
-      - if: always()
-        uses: actions/upload-artifact@v4
+  ydb-slo-report:
+    if: always() && (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'SLO'))
+    needs: ydb-slo-action
+    name: Publish YDB SLO report
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: ydb-platform/ydb-slo-action/report@v2
         with:
-          name: ${{ matrix.workload.name }}-logs
-          path: |
-            ./current.log
-            ./baseline.log
-          retention-days: 1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_run_id: ${{ github.run_id }}

--- a/slo/src/AdoNet/SloTableContext.cs
+++ b/slo/src/AdoNet/SloTableContext.cs
@@ -19,7 +19,7 @@ public class SloTableContext : SloTableContext<YdbDataSource>
         await new YdbCommand(ydbConnection)
         {
             CommandText = $"""
-                           CREATE TABLE `{SloTable.Name}` (
+                           CREATE TABLE IF NOT EXISTS `{SloTable.Name}` (
                                Guid             Uuid,
                                Id               Int32,
                                PayloadStr       Text,

--- a/slo/src/Dapper/SloTableContext.cs
+++ b/slo/src/Dapper/SloTableContext.cs
@@ -17,14 +17,14 @@ public class SloTableContext : SloTableContext<YdbDataSource>
     {
         await using var connection = await client.OpenConnectionAsync();
         await connection.ExecuteAsync($"""
-                                       CREATE TABLE `{SloTable.Name}` (
+                                       CREATE TABLE IF NOT EXISTS `{SloTable.Name}` (
                                            Guid             Uuid,
                                            Id               Int32,
                                            PayloadStr       Text,
                                            PayloadDouble    Double,
                                            PayloadTimestamp Timestamp,
                                            PRIMARY KEY (Guid, Id)
-                                       ); 
+                                       );
                                        {SloTable.Options}
                                        """);
     }

--- a/slo/src/Internal/Cli.cs
+++ b/slo/src/Internal/Cli.cs
@@ -8,9 +8,9 @@ public static class Cli
         "connectionString",
         "YDB connection string ADO NET format");
 
-    private static readonly Option<string> OtlpEndpointOption = new(
+    private static readonly Option<string?> OtlpEndpointOption = new(
         "--otlp-endpoint",
-        "OpenTelemetry OTLP endpoint URL (e.g., http://localhost:4318)");
+        "OpenTelemetry OTLP metrics endpoint URL. Falls back to OTEL_EXPORTER_OTLP_METRICS_ENDPOINT / OTEL_EXPORTER_OTLP_ENDPOINT env vars.");
 
     private static readonly Option<int> WriteTimeoutOption = new(
         "--write-timeout",
@@ -19,7 +19,7 @@ public static class Cli
 
     private static readonly Option<int> ReportPeriodOption = new(
         "--report-period",
-        () => 250,
+        () => 1000,
         "metrics export period in milliseconds");
 
     private static readonly Option<int> ReadRpsOption = new(
@@ -39,8 +39,8 @@ public static class Cli
 
     private static readonly Option<int> TimeOption = new(
         "--time",
-        () => 600,
-        "run time in seconds");
+        () => int.TryParse(Environment.GetEnvironmentVariable("WORKLOAD_DURATION"), out var t) ? t : 600,
+        "run time in seconds. Falls back to WORKLOAD_DURATION env var.");
 
     private static readonly Option<int> InitialDataCountOption = new(
         new[] { "-c", "--initial-data-count" },
@@ -58,7 +58,7 @@ public static class Cli
 
     private static readonly Command RunCommand = new(
         "run",
-        "runs workload (read and write to table with sets RPS)")
+        "runs workload (read and write to table with sets RPS). Creates table and seeds initial data if missing.")
     {
         ConnectionStringArgument,
         InitialDataCountOption,
@@ -97,7 +97,8 @@ public static class Cli
                 ReadTimeoutOption,
                 WriteRpsOption,
                 WriteTimeoutOption,
-                TimeOption
+                TimeOption,
+                InitialDataCountOption
             )
         );
 

--- a/slo/src/Internal/ConfigBinders.cs
+++ b/slo/src/Internal/ConfigBinders.cs
@@ -19,24 +19,26 @@ public class CreateConfigBinder(
 
 internal class RunConfigBinder(
     Argument<string> connectionString,
-    Option<string> otlpEndpointOption,
+    Option<string?> otlpEndpointOption,
     Option<int> reportPeriodOption,
     Option<int> readRpsOption,
     Option<int> readTimeoutOption,
     Option<int> writeRpsOption,
     Option<int> writeTimeoutOption,
-    Option<int> timeOption
+    Option<int> timeOption,
+    Option<int> initialDataCountOption
 ) : BinderBase<RunConfig>
 {
     protected override RunConfig GetBoundValue(BindingContext bindingContext) =>
         new(
             bindingContext.ParseResult.GetValueForArgument(connectionString),
-            bindingContext.ParseResult.GetValueForOption(otlpEndpointOption)!,
+            bindingContext.ParseResult.GetValueForOption(otlpEndpointOption),
             bindingContext.ParseResult.GetValueForOption(reportPeriodOption),
             bindingContext.ParseResult.GetValueForOption(readRpsOption),
             bindingContext.ParseResult.GetValueForOption(readTimeoutOption),
             bindingContext.ParseResult.GetValueForOption(writeRpsOption),
             bindingContext.ParseResult.GetValueForOption(writeTimeoutOption),
-            bindingContext.ParseResult.GetValueForOption(timeOption)
+            bindingContext.ParseResult.GetValueForOption(timeOption),
+            bindingContext.ParseResult.GetValueForOption(initialDataCountOption)
         );
 }

--- a/slo/src/Internal/Configs.cs
+++ b/slo/src/Internal/Configs.cs
@@ -7,12 +7,13 @@ public record CreateConfig(
 
 public record RunConfig(
     string ConnectionString,
-    string OtlpEndpoint,
+    string? OtlpEndpoint,
     int ReportPeriod,
     int ReadRps,
     int ReadTimeout,
     int WriteRps,
     int WriteTimeout,
-    int Time) : Config(ConnectionString, WriteTimeout);
+    int Time,
+    int InitialDataCount) : Config(ConnectionString, WriteTimeout);
 
 public record Config(string ConnectionString, int WriteTimeout);

--- a/slo/src/Internal/Internal.csproj
+++ b/slo/src/Internal/Internal.csproj
@@ -16,6 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="HdrHistogram" Version="2.5.0"/>
         <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0"/>
         <PackageReference Include="OpenTelemetry" Version="1.15.0"/>
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0"/>

--- a/slo/src/Internal/SloTableContext.cs
+++ b/slo/src/Internal/SloTableContext.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Security.Cryptography;
 using System.Threading.RateLimiting;
+using HdrHistogram;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
 using OpenTelemetry;
@@ -86,36 +87,85 @@ public abstract class SloTableContext<T> : ISloContext
 
     public async Task Run(RunConfig runConfig)
     {
-        var refLabel = Environment.GetEnvironmentVariable("REF") ?? "unknown";
-        var workloadLabel = Environment.GetEnvironmentVariable("WORKLOAD") ?? Job;
+        var refLabel = Environment.GetEnvironmentVariable("WORKLOAD_REF") ?? "unknown";
+        var workloadLabel = Environment.GetEnvironmentVariable("WORKLOAD_NAME") ?? Job;
+
+        await Create(new CreateConfig(
+            runConfig.ConnectionString,
+            runConfig.InitialDataCount,
+            runConfig.WriteTimeout));
+
+        using var meter = new Meter("YDB.SLO");
+
+        var operationsTotal = meter.CreateCounter<long>(
+            "sdk.operations.total",
+            description: "Total number of operations, by type and status."
+        );
+
+        // Latency is measured only for successful operations (matches go-sdk / js-sdk SLO contract);
+        // failed operations are reflected via sdk.operations.total{operation_status="error"} only.
+        var latencyAggregators = new Dictionary<string, LatencyAggregator>
+        {
+            ["read"] = new(),
+            ["write"] = new()
+        };
+
+        // Snapshots refreshed on each push tick. ObservableGauge callbacks read from here.
+        var snapshots = latencyAggregators.Keys
+            .ToDictionary(k => k, _ => (P50: 0.0, P95: 0.0, P99: 0.0));
+        var snapshotLock = new object();
+
+        meter.CreateObservableGauge(
+            "sdk.operation.latency.p50.seconds",
+            () => SnapshotMeasurements(snapshots, snapshotLock, refLabel, s => s.P50),
+            unit: "s",
+            description: "P50 latency of operations, recomputed each push period.");
+        meter.CreateObservableGauge(
+            "sdk.operation.latency.p95.seconds",
+            () => SnapshotMeasurements(snapshots, snapshotLock, refLabel, s => s.P95),
+            unit: "s",
+            description: "P95 latency of operations, recomputed each push period.");
+        meter.CreateObservableGauge(
+            "sdk.operation.latency.p99.seconds",
+            () => SnapshotMeasurements(snapshots, snapshotLock, refLabel, s => s.P99),
+            unit: "s",
+            description: "P99 latency of operations, recomputed each push period.");
 
         var meterProvider = Sdk.CreateMeterProviderBuilder()
             .ConfigureResource(resource => resource
                 .AddService(serviceName: $"workload-{workloadLabel}")
                 .AddAttributes([
-                    new KeyValuePair<string, object>("ref", refLabel),
                     new KeyValuePair<string, object>("sdk", "dotnet"),
                     new KeyValuePair<string, object>("sdk_version", Environment.Version.ToString())
                 ]))
             .AddMeter("YDB.SLO")
             .AddOtlpExporter((exporterOptions, metricReaderOptions) =>
             {
-                // Prometheus OTLP endpoint: http://prometheus:9090/api/v1/otlp/v1/metrics
-                var uri = new Uri(runConfig.OtlpEndpoint);
-                var endpoint = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
-                var path = uri.AbsolutePath.TrimEnd('/');
-                if (string.IsNullOrEmpty(path))
+                var endpointUri = ResolveOtlpEndpoint(runConfig.OtlpEndpoint);
+                if (endpointUri != null)
                 {
-                    path = "/api/v1/otlp/v1/metrics";
+                    exporterOptions.Endpoint = endpointUri;
                 }
 
-                exporterOptions.Endpoint = new Uri($"{endpoint}{path}");
                 exporterOptions.Protocol = OtlpExportProtocol.HttpProtobuf;
-
                 metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds =
                     runConfig.ReportPeriod;
             })
             .Build();
+
+        // Refresh percentile snapshots and reset histograms one push period before export so
+        // the gauge callbacks observe fresh values when the SDK harvests them.
+        using var snapshotTimer = new Timer(_ =>
+        {
+            foreach (var kv in latencyAggregators)
+            {
+                var snapshot = kv.Value.SnapshotAndReset();
+                lock (snapshotLock)
+                {
+                    snapshots[kv.Key] = snapshot;
+                }
+            }
+        }, null, runConfig.ReportPeriod, runConfig.ReportPeriod);
 
         var client = CreateClient(runConfig);
 
@@ -158,67 +208,18 @@ public abstract class SloTableContext<T> : ISloContext
 
         async Task ShootingTask(RateLimiter rateLimitPolicy, string operationType, Func<T, RunConfig, Task> action)
         {
-            var meter = new Meter("YDB.SLO");
-
-            var tags = new TagList
+            var successTags = new TagList
             {
-                { "ref", refLabel },
                 { "operation_type", operationType },
-                { "sdk", "dotnet" },
-                { "sdk_version", Environment.Version.ToString() },
-                { "workload", workloadLabel }
+                { "operation_status", "success" },
+                { "ref", refLabel }
             };
-
-            var successTags = new KeyValuePair<string, object?>[]
+            var errorTags = new TagList
             {
-                new("ref", refLabel),
-                new("operation_type", operationType),
-                new("sdk", "dotnet"),
-                new("sdk_version", Environment.Version.ToString()),
-                new("workload", workloadLabel),
-                new("operation_status", "success")
+                { "operation_type", operationType },
+                { "operation_status", "error" },
+                { "ref", refLabel }
             };
-
-            var failureTags = new KeyValuePair<string, object?>[]
-            {
-                new("ref", refLabel),
-                new("operation_type", operationType),
-                new("sdk", "dotnet"),
-                new("sdk_version", Environment.Version.ToString()),
-                new("workload", workloadLabel),
-                new("operation_status", "failure")
-            };
-
-            var operationsTotal = meter.CreateCounter<long>(
-                "sdk.operations.total",
-                description: "Total number of operations performed by the SDK, categorized by type."
-            );
-
-            var operationsSuccessTotal = meter.CreateCounter<long>(
-                "sdk.operations.success.total",
-                description: "Total number of successful operations, categorized by type."
-            );
-
-            var retryAttemptsTotal = meter.CreateCounter<long>(
-                "sdk.retry.attempts.total",
-                description: "Total number of retry attempts performed by the SDK."
-            );
-
-            var operationLatencySeconds = meter.CreateHistogram(
-                "sdk.operation.latency.seconds",
-                unit: "s",
-                description: "Latency of operations performed by the SDK in seconds, categorized by type and status.",
-                advice: new InstrumentAdvice<double>
-                {
-                    HistogramBucketBoundaries =
-                        [0.001, 0.002, 0.003, 0.004, 0.005, 0.0075, 0.010, 0.020, 0.050, 0.100, 0.200, 0.500, 1.000]
-                }
-            );
-
-            var pendingOperations = meter.CreateUpDownCounter<long>(
-                "sdk.pending.operations",
-                description: "Current number of pending operations, categorized by type."
-            );
 
             var workJobs = new List<Task>();
 
@@ -236,31 +237,19 @@ public abstract class SloTableContext<T> : ISloContext
                             await Task.Delay(Random.Shared.Next(IntervalMs / 2), cancellationTokenSource.Token);
                         }
 
-                        pendingOperations.Add(1, tags);
                         var sw = Stopwatch.StartNew();
 
                         try
                         {
                             await action(client, runConfig);
                             sw.Stop();
-                            operationsTotal.Add(1, tags);
-                            operationsSuccessTotal.Add(1, tags);
-
-                            operationLatencySeconds.Record(sw.Elapsed.TotalSeconds, successTags);
+                            operationsTotal.Add(1, successTags);
+                            latencyAggregators[operationType].Record(sw.Elapsed.TotalSeconds);
                         }
                         catch (Exception ex)
                         {
-                            sw.Stop();
-                            operationsTotal.Add(1, tags);
-                            retryAttemptsTotal.Add(1, tags);
-
-                            operationLatencySeconds.Record(sw.Elapsed.TotalSeconds, failureTags);
-
+                            operationsTotal.Add(1, errorTags);
                             Logger.LogWarning(ex, "Operation {OperationType} failed", operationType);
-                        }
-                        finally
-                        {
-                            pendingOperations.Add(-1, tags);
                         }
                     }
                 }, cancellationTokenSource.Token));
@@ -269,6 +258,86 @@ public abstract class SloTableContext<T> : ISloContext
             await Task.WhenAll(workJobs);
 
             Logger.LogInformation("{ShootingName} shooting is stopped", operationType);
+        }
+    }
+
+    private static IEnumerable<Measurement<double>> SnapshotMeasurements(
+        Dictionary<string, (double P50, double P95, double P99)> snapshots,
+        object snapshotLock,
+        string refLabel,
+        Func<(double P50, double P95, double P99), double> selector)
+    {
+        lock (snapshotLock)
+        {
+            return snapshots
+                .Select(kv => new Measurement<double>(
+                    selector(kv.Value),
+                    new KeyValuePair<string, object?>("operation_type", kv.Key),
+                    new KeyValuePair<string, object?>("operation_status", "success"),
+                    new KeyValuePair<string, object?>("ref", refLabel)))
+                .ToArray();
+        }
+    }
+
+    private static Uri? ResolveOtlpEndpoint(string? cliEndpoint)
+    {
+        // Priority: CLI flag > OTEL_EXPORTER_OTLP_METRICS_ENDPOINT > OTEL_EXPORTER_OTLP_ENDPOINT.
+        // When falling back to the generic OTEL_EXPORTER_OTLP_ENDPOINT, append the Prometheus
+        // OTLP metrics path so the exporter targets the metrics receiver directly.
+        var raw = !string.IsNullOrWhiteSpace(cliEndpoint)
+            ? cliEndpoint
+            : Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
+
+        if (!string.IsNullOrWhiteSpace(raw))
+        {
+            return new Uri(raw);
+        }
+
+        var generic = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
+        if (string.IsNullOrWhiteSpace(generic))
+        {
+            return null;
+        }
+
+        var trimmed = generic.TrimEnd('/');
+        return new Uri($"{trimmed}/v1/metrics");
+    }
+
+    private sealed class LatencyAggregator
+    {
+        private const long HighestTrackableMicros = 60L * 60L * 1_000_000L; // 1 hour
+        private const int SignificantDigits = 3;
+
+        private readonly LongHistogram _histogram = new(HighestTrackableMicros, SignificantDigits);
+        private readonly object _lock = new();
+
+        public void Record(double seconds)
+        {
+            var micros = (long)(seconds * 1_000_000d);
+            if (micros < 1) micros = 1;
+            if (micros > HighestTrackableMicros) micros = HighestTrackableMicros;
+
+            lock (_lock)
+            {
+                _histogram.RecordValue(micros);
+            }
+        }
+
+        public (double P50, double P95, double P99) SnapshotAndReset()
+        {
+            lock (_lock)
+            {
+                if (_histogram.TotalCount == 0)
+                {
+                    return (0d, 0d, 0d);
+                }
+
+                var p50 = _histogram.GetValueAtPercentile(50) / 1_000_000d;
+                var p95 = _histogram.GetValueAtPercentile(95) / 1_000_000d;
+                var p99 = _histogram.GetValueAtPercentile(99) / 1_000_000d;
+                _histogram.Reset();
+                return (p50, p95, p99);
+            }
         }
     }
 

--- a/slo/src/Linq2db/SloTableContext.cs
+++ b/slo/src/Linq2db/SloTableContext.cs
@@ -24,7 +24,7 @@ public sealed class SloTableContext : SloTableContext<SloTableContext.Linq2dbCli
         db.CommandTimeout = operationTimeout;
 
         await db.ExecuteAsync($"""
-                                   CREATE TABLE `{SloTable.Name}` (
+                                   CREATE TABLE IF NOT EXISTS `{SloTable.Name}` (
                                        Guid             Uuid,
                                        Id               Int32,
                                        PayloadStr       Text,


### PR DESCRIPTION
## Summary
- Migrate `.github/workflows/slo.yml` from `ydb-slo-action/init@main` (v1) to `init@v2`. The v2 action orchestrates the workload containers itself (chaos, prometheus, OTLP wiring), injecting `WORKLOAD_REF` / `WORKLOAD_NAME` / `WORKLOAD_DURATION` / `OTEL_EXPORTER_OTLP_*` env vars — so the manual `Prepare SLO Database`, parallel `docker run`, log-store and artifact-upload steps are removed in favor of a single init step plus a `report@v2` job.
- Rewrite the workload metrics in `slo/src/Internal/SloTableContext.cs` to match the v2 contract: `sdk.operations.total{operation_type, operation_status, ref}` counter and three pre-computed `sdk.operation.latency.{p50,p95,p99}.seconds` gauges backed by `HdrHistogram` (reset on each push), latency recorded only for successful operations — same approach as the `ydb-go-sdk` / `ydb-js-sdk` v2 migrations.
- Make `--otlp-endpoint` / `--time` CLI options optional with env fallbacks (`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` / `OTEL_EXPORTER_OTLP_ENDPOINT` / `WORKLOAD_DURATION`) so the workload binary still runs standalone outside the v2 harness.
- Bootstrap the schema idempotently from `Run` (`CREATE TABLE IF NOT EXISTS` in AdoNet/Dapper/Linq2db; EF already uses `EnsureCreatedAsync`), removing the need for an external `create` step.

## What's intentionally **not** in this PR
- `sdk_retry_attempts_total` — the v1 version of this metric was incremented on each catch (which counts failures, not retries). It's dropped here and to be wired correctly in a follow-up: AdoNet/Dapper via an `IRetryPolicy` decorator, EF/Linq2db via their respective `ExecutionStrategy` / provider hooks.

## Test plan
- [ ] CI runs `Run YDB SLO Tests` matrix (AdoNet / Dapper / EF / Linq2db) under the `SLO` label; baseline+current images build, `init@v2` orchestrates workloads, `report@v2` posts the comparison to the configured GitHub issue.
- [ ] Confirm exported metrics in the SLO grafana dashboards: `sdk_operations_total{operation_status="success|error", ref}` and `sdk_operation_latency_p{50,95,99}_seconds{operation_status="success", ref}`.
- [ ] Spot-check that local invocation `dotnet slo.dll run "..." --time 30` still works without `OTEL_EXPORTER_OTLP_*` env vars (falls back to the CLI flag / generic OTLP env if set).

## Note
The `slo/src/EF/Dockerfile` build is currently broken on `main` and remains broken here — `EntityFrameworkCore.Ydb.csproj` multi-targets `net8.0;net10.0` (#600), but the EF Dockerfile uses `mcr.microsoft.com/dotnet/sdk:8.0` which can't compile the net10.0 target. Fix is independent of this migration.