### PR TITLE
fix(slo): split workflow report jobs and simplify image build

### DIFF
--- a/.github/scripts/build-slo-image.sh
+++ b/.github/scripts/build-slo-image.sh
@@ -8,14 +8,12 @@ Usage:
   build-slo-image.sh \
     --context <path> \
     --tag <docker-tag> \
-    --workload <workload-name> \
-    --ref <git-ref>
+    --workload <workload-name>
 
 Options:
   --context     Docker build context directory (e.g. $GITHUB_WORKSPACE/current).
   --tag         Docker image tag to build (e.g. ydb-app-current).
   --workload    Workload name (e.g. AdoNet, Dapper, EF, Linq2db.Slo, TopicService).
-  --ref         Git ref (e.g. branch name / sha).
 ENDUSAGE
 }
 
@@ -26,7 +24,6 @@ die() {
 
 context_dir=""
 tag=""
-ref=""
 workload=""
 
 while [[ $# -gt 0 ]]; do
@@ -37,10 +34,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --tag)
       tag="${2:-}"
-      shift 2
-      ;;
-    --ref)
-      ref="${2:-}"
       shift 2
       ;;
     --workload)
@@ -57,7 +50,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$context_dir" || -z "$tag" || -z "$workload" || -z "$ref" ]]; then
+if [[ -z "$context_dir" || -z "$tag" || -z "$workload" ]]; then
   usage
   exit 2
 fi
@@ -70,7 +63,6 @@ dockerfile="slo/src/${workload}/Dockerfile"
 
 echo "Building SLO image..."
 echo "  TAG:        $tag"
-echo "  REF:        $ref"
 echo "  WORKLOAD:   $workload"
 echo "  DOCKERFILE: $dockerfile"
 

--- a/.github/workflows/slo-report.yml
+++ b/.github/workflows/slo-report.yml
@@ -7,18 +7,34 @@ on:
       - completed
 
 jobs:
-  ydb-slo-action-report:
+  publish-slo-report:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     name: Publish YDB SLO Report
     permissions:
       checks: write
       contents: read
       pull-requests: write
-    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Publish YDB SLO Report
-        uses: ydb-platform/ydb-slo-action/report@main
+        uses: ydb-platform/ydb-slo-action/report@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_run_id: ${{ github.event.workflow_run.id }}
 
+  remove-slo-label:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    name: Remove SLO Label
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove SLO label from PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
+          REPO: ${{ github.event.workflow_run.repository.full_name }}
+        run: |
+          set -euo pipefail
+          PR=$(jq -r '.[0].number' <<<"$PRS")
+          gh pr edit "$PR" --repo "$REPO" --remove-label SLO

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -108,7 +108,8 @@ jobs:
           baseline/.github/scripts/build-slo-image.sh \
             --tag "ydb-app-baseline" \
             --context "$GITHUB_WORKSPACE/baseline" \
-            --workload "${{ matrix.workload.name }}"
+            --workload "${{ matrix.workload.name }}" \
+            --ref "${{ steps.baseline.outputs.ref }}"
 
       - name: Run YDB SLO
         uses: ydb-platform/ydb-slo-action/init@v2

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -1,69 +1,20 @@
 name: SLO
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [opened, reopened, synchronize, labeled]
-    branches:
-      - main
-  workflow_dispatch:
-    inputs:
-      github_issue:
-        description: "GitHub issue number where the SLO results will be reported"
-        required: true
-      baseline_ref:
-        description: "Baseline commit/branch/tag to compare against (leave empty to auto-detect merge-base with main)"
-        required: false
-      slo_workload_duration_seconds:
-        description: "Duration of the SLO workload in seconds"
-        required: false
-        default: "600"
-      slo_workload_read_max_rps:
-        description: "Maximum read RPS for the SLO workload"
-        required: false
-        default: "1000"
-      slo_workload_write_max_rps:
-        description: "Maximum write RPS for the SLO workload"
-        required: false
-        default: "100"
 
 jobs:
-  remove-slo-label:
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'SLO')
-    runs-on: ubuntu-latest
-    name: Remove SLO Label
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Remove SLO label
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                name: 'SLO'
-              });
-              console.log(`Removed SLO label from PR #${context.payload.pull_request.number}`);
-            } catch (error) {
-              if (error.status === 404) {
-                console.log('SLO label not found, skipping');
-              } else {
-                throw error;
-              }
-            }
-
   ydb-slo-action:
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'SLO')
-
+    if: contains(github.event.pull_request.labels.*.name, 'SLO')
     name: Run YDB SLO Tests
     runs-on: "large-runner-dotnet-sdk"
 
+    permissions:
+      contents: read
+
     strategy:
+      fail-fast: false
       matrix:
         workload:
           - name: AdoNet
@@ -105,21 +56,18 @@ jobs:
           docker compose version
 
       - name: Checkout current version
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: current
           fetch-depth: 0
 
       - name: Determine baseline commit
         id: baseline
+        working-directory: current
         run: |
-          cd current
-          if [[ -n "${{ inputs.baseline_ref }}" ]]; then
-            BASELINE="${{ inputs.baseline_ref }}"
-          else
-            BASELINE=$(git merge-base HEAD origin/main)
-          fi
-          echo "sha=$BASELINE" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          BASELINE=$(git merge-base HEAD origin/main)
+          echo "sha=${BASELINE}" >> "$GITHUB_OUTPUT"
 
           # Try to determine a human-readable ref name for baseline
           if git merge-base --is-ancestor $BASELINE origin/main && \
@@ -136,27 +84,30 @@ jobs:
           echo "ref=$BASELINE_REF" >> $GITHUB_OUTPUT
 
       - name: Checkout baseline version
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.baseline.outputs.sha }}
           path: baseline
           fetch-depth: 1
 
-      - name: Build workload images
+      - name: Build current workload image
         run: |
-          SCRIPT="$GITHUB_WORKSPACE/current/.github/scripts/build-slo-image.sh"
-          CURRENT_REF="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          set -euxo pipefail
+          chmod +x current/.github/scripts/build-slo-image.sh
 
-          bash "$SCRIPT" \
-            --context "$GITHUB_WORKSPACE/current" \
+          current/.github/scripts/build-slo-image.sh \
             --tag "ydb-app-current" \
-            --ref "${CURRENT_REF}" \
+            --context "$GITHUB_WORKSPACE/current" \
             --workload "${{ matrix.workload.name }}"
 
-          bash "$SCRIPT" \
-            --context "$GITHUB_WORKSPACE/baseline" \
+      - name: Build baseline workload image
+        run: |
+          set -euxo pipefail
+          chmod +x baseline/.github/scripts/build-slo-image.sh
+
+          baseline/.github/scripts/build-slo-image.sh \
             --tag "ydb-app-baseline" \
-            --ref "${{ steps.baseline.outputs.ref }}" \
+            --context "$GITHUB_WORKSPACE/baseline" \
             --workload "${{ matrix.workload.name }}"
 
       - name: Run YDB SLO
@@ -183,18 +134,3 @@ jobs:
             --write-rps ${{ inputs.slo_workload_write_max_rps || '100' }}
             --read-timeout 1000
             --write-timeout 1000
-
-  ydb-slo-report:
-    if: always() && (github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'SLO'))
-    needs: ydb-slo-action
-    name: Publish YDB SLO report
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: ydb-platform/ydb-slo-action/report@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_run_id: ${{ github.run_id }}


### PR DESCRIPTION
Move SLO label removal into slo-report workflow keyed off workflow_run, drop the unused --ref argument from build-slo-image.sh, and trim slo.yml to PR-label-triggered runs.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
