### PR TITLE
Fix: Replaced `OpenTelemetry` SDK dependency (>= 1.15.0) with `OpenTelemetry.Api` (>= 1.15.3)

### DIFF
--- a/src/Ydb.Sdk.OpenTelemetry/CHANGELOG.md
+++ b/src/Ydb.Sdk.OpenTelemetry/CHANGELOG.md
@@ -1,3 +1,10 @@
+- ## v1.0.1
+
+- Fix: Replaced `OpenTelemetry` SDK dependency (>= 1.15.0) with `OpenTelemetry.Api` (>= 1.15.3). The package now only
+  relies on the public OpenTelemetry API surface (`TracerProviderBuilder` / `MeterProviderBuilder`), so it can be added
+  to projects that still use older OpenTelemetry SDK / Hosting / Exporter packages (e.g. 1.10.x) without triggering
+  `NU1605` downgrade errors.
+
 ## v1.0.0
 
 - Feat: Initial release. Extension methods for registering `Ydb.Sdk` as an OpenTelemetry source.

--- a/src/Ydb.Sdk.OpenTelemetry/src/Ydb.Sdk.OpenTelemetry.csproj
+++ b/src/Ydb.Sdk.OpenTelemetry/src/Ydb.Sdk.OpenTelemetry.csproj
@@ -20,7 +20,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry" Version="1.15.0"/>
+        <PackageReference Include="OpenTelemetry.Api" Version="1.15.3"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The package now only  relies on the public OpenTelemetry API surface (`TracerProviderBuilder` / `MeterProviderBuilder`), so it can be added to projects that still use older OpenTelemetry SDK / Hosting / Exporter packages (e.g. 1.10.x) without triggering `NU1605` downgrade errors.
