### PR TITLE
fix: add ConfigureAwait(false) to avoid sync-over-async deadlocks (#647)

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix: add ConfigureAwait(false) to avoid sync-over-async deadlocks ([#647](https://github.com/ydb-platform/ydb-dotnet-sdk/issues/647))
 - Feat tracing: added `ydb.Login` span emitted by the static-credentials auth client.
 - **Breaking Change**: Removed legacy `Retry.cs` (`BackoffSettings`, `RetryPolicy` enum, `RetryRule`, `RetrySettings`).
 - **Breaking Change**: Removed legacy `Pool/SessionPool.cs` (`SessionPool<T>`, `SessionBase<T>`, `SessionPoolConfig`, `SessionPoolDefaultSettings`); the ADO.NET `PoolingSessionSource<T>` is now the only session pool implementation.

--- a/src/Ydb.Sdk/src/.editorconfig
+++ b/src/Ydb.Sdk/src/.editorconfig
@@ -1,0 +1,7 @@
+[*.cs]
+
+# CA2007: Do not directly await a Task without calling ConfigureAwait.
+# This is a library: capturing the caller's SynchronizationContext can deadlock
+# consumers that block on our async APIs (e.g. WPF/WinForms calling Open()).
+# See https://github.com/ydb-platform/ydb-dotnet-sdk/issues/647
+dotnet_diagnostic.CA2007.severity = warning

--- a/src/Ydb.Sdk/src/Ado/BulkUpsert/BulkUpsertImporter.cs
+++ b/src/Ydb.Sdk/src/Ado/BulkUpsert/BulkUpsertImporter.cs
@@ -51,7 +51,7 @@ internal class BulkUpsertImporter : IBulkUpsertImporter
 
         if (_currentBytes + rowSize > _maxBatchByteSize && _rows.Count > 0)
         {
-            await FlushAsync();
+            await FlushAsync().ConfigureAwait(false);
         }
 
         _rows.Add(protoStruct);

--- a/src/Ydb.Sdk/src/Ado/PoolManager.cs
+++ b/src/Ydb.Sdk/src/Ado/PoolManager.cs
@@ -66,7 +66,8 @@ internal static class PoolManager
             if (driver.RegisterOwner())
                 return driver;
 
-            driver = Drivers[driverFactory.GrpcConnectionString] = await driverFactory.CreateAsync().ConfigureAwait(false);
+            driver = Drivers[driverFactory.GrpcConnectionString] =
+                await driverFactory.CreateAsync().ConfigureAwait(false);
             driver.RegisterOwner();
 
             return driver;

--- a/src/Ydb.Sdk/src/Ado/PoolManager.cs
+++ b/src/Ydb.Sdk/src/Ado/PoolManager.cs
@@ -33,7 +33,7 @@ internal static class PoolManager
             // already carries the full chain in `x-ydb-sdk-build-info` (DiscoverEndpoints reads
             // SdkClientInfoRegistry.Chain directly). Unregistration happens symmetrically in
             // the session source's DisposeAsync.
-            SdkClientInfoRegistry.Register($"ado-net/{YdbSdkVersion.Value}");
+            SdkClientInfoRegistry.Register(Metadata.AdoNetClientInfo);
             if (settings.ClientInfo is not null)
             {
                 SdkClientInfoRegistry.Register(settings.ClientInfo);

--- a/src/Ydb.Sdk/src/Ado/PoolManager.cs
+++ b/src/Ydb.Sdk/src/Ado/PoolManager.cs
@@ -20,7 +20,7 @@ internal static class PoolManager
             return sessionPool;
         }
 
-        await SemaphoreSlim.WaitAsync(cancellationToken);
+        await SemaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -39,7 +39,7 @@ internal static class PoolManager
                 SdkClientInfoRegistry.Register(settings.ClientInfo);
             }
 
-            var driver = await GetDriver(settings, withLock: false);
+            var driver = await GetDriver(settings, withLock: false).ConfigureAwait(false);
 
             return Pools[settings.ConnectionString] = settings.EnableImplicitSession
                 ? new ImplicitSessionSource(driver, settings)
@@ -56,17 +56,17 @@ internal static class PoolManager
         try
         {
             if (withLock)
-                await SemaphoreSlim.WaitAsync();
+                await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
 
             var driver = Drivers.TryGetValue(driverFactory.GrpcConnectionString, out var cacheDriver) &&
                          !cacheDriver.IsDisposed
                 ? cacheDriver
-                : Drivers[driverFactory.GrpcConnectionString] = await driverFactory.CreateAsync();
+                : Drivers[driverFactory.GrpcConnectionString] = await driverFactory.CreateAsync().ConfigureAwait(false);
 
             if (driver.RegisterOwner())
                 return driver;
 
-            driver = Drivers[driverFactory.GrpcConnectionString] = await driverFactory.CreateAsync();
+            driver = Drivers[driverFactory.GrpcConnectionString] = await driverFactory.CreateAsync().ConfigureAwait(false);
             driver.RegisterOwner();
 
             return driver;
@@ -82,10 +82,10 @@ internal static class PoolManager
     {
         if (Pools.TryRemove(connectionString, out var sessionPool))
         {
-            await SemaphoreSlim.WaitAsync();
+            await SemaphoreSlim.WaitAsync().ConfigureAwait(false);
             try
             {
-                await sessionPool.DisposeAsync();
+                await sessionPool.DisposeAsync().ConfigureAwait(false);
             }
             finally
             {
@@ -100,6 +100,6 @@ internal static class PoolManager
 
         var tasks = keys.Select(ClearPool).ToList();
 
-        await Task.WhenAll(tasks);
+        await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 }

--- a/src/Ydb.Sdk/src/Ado/Session/ImplicitSessionSource.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/ImplicitSessionSource.cs
@@ -64,7 +64,7 @@ internal sealed class ImplicitSessionSource : ISessionSource
         {
             if (Volatile.Read(ref _activeLeaseCount) != 0)
             {
-                await _drainedTcs.Task.WaitAsync(TimeSpan.FromSeconds(DisposeTimeoutSeconds));
+                await _drainedTcs.Task.WaitAsync(TimeSpan.FromSeconds(DisposeTimeoutSeconds)).ConfigureAwait(false);
             }
         }
         catch (TimeoutException)
@@ -78,7 +78,7 @@ internal sealed class ImplicitSessionSource : ISessionSource
         {
             try
             {
-                await Driver.DisposeAsync();
+                await Driver.DisposeAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/src/Ydb.Sdk/src/Ado/Session/ImplicitSessionSource.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/ImplicitSessionSource.cs
@@ -85,7 +85,7 @@ internal sealed class ImplicitSessionSource : ISessionSource
                 _logger.LogError(e, "Failed to dispose the transport driver");
             }
 
-            SdkClientInfoRegistry.Unregister($"ado-net/{YdbSdkVersion.Value}");
+            SdkClientInfoRegistry.Unregister(Metadata.AdoNetClientInfo);
             if (_frameworkClientInfo is not null)
             {
                 SdkClientInfoRegistry.Unregister(_frameworkClientInfo);

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
@@ -74,7 +74,7 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
             QueryService.CommitTransactionMethod,
             new CommitTransactionRequest { SessionId = SessionId, TxId = txId },
             new GrpcRequestSettings { CancellationToken = cancellationToken, NodeId = NodeId, DbActivity = dbActivity }
-        );
+        ).ConfigureAwait(false);
 
         if (response.Status.IsNotSuccess())
         {
@@ -92,7 +92,7 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
             QueryService.RollbackTransactionMethod,
             new RollbackTransactionRequest { SessionId = SessionId, TxId = txId },
             new GrpcRequestSettings { CancellationToken = cancellationToken, NodeId = NodeId, DbActivity = dbActivity }
-        );
+        ).ConfigureAwait(false);
 
         if (response.Status.IsNotSuccess())
         {
@@ -135,7 +135,7 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
             }
 
             var response =
-                await Driver.UnaryCall(QueryService.CreateSessionMethod, CreateSessionRequest, requestSettings);
+                await Driver.UnaryCall(QueryService.CreateSessionMethod, CreateSessionRequest, requestSettings).ConfigureAwait(false);
 
             if (response.Status.IsNotSuccess())
             {
@@ -156,9 +156,9 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                         QueryService.AttachSessionMethod,
                         new AttachSessionRequest { SessionId = SessionId },
                         new GrpcRequestSettings { NodeId = NodeId }
-                    );
+                    ).ConfigureAwait(false);
 
-                    if (!await stream.MoveNextAsync(cancellationToken))
+                    if (!await stream.MoveNextAsync(cancellationToken).ConfigureAwait(false))
                     {
                         // Session wasn't started!
                         completeTask.SetException(new YdbException(StatusCode.Cancelled,
@@ -181,7 +181,7 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                     try
                     {
                         // ReSharper disable once MethodSupportsCancellation
-                        while (await stream.MoveNextAsync(lifecycleAttachToken))
+                        while (await stream.MoveNextAsync(lifecycleAttachToken).ConfigureAwait(false))
                         {
                             var sessionState = stream.Current;
 
@@ -238,7 +238,7 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                 }
             }, cancellationToken);
 
-            await completeTask.Task;
+            await completeTask.Task.ConfigureAwait(false);
         }
         catch (YdbException e)
         {
@@ -269,7 +269,7 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                 QueryService.DeleteSessionMethod,
                 new DeleteSessionRequest { SessionId = SessionId },
                 new GrpcRequestSettings { TransportTimeout = DeleteSessionTimeout, NodeId = NodeId }
-            );
+            ).ConfigureAwait(false);
 
             if (deleteSessionResponse.Status.IsNotSuccess())
             {

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
@@ -134,8 +134,9 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                 requestSettings.ClientCapabilities.Add(SessionBalancer);
             }
 
-            var response =
-                await Driver.UnaryCall(QueryService.CreateSessionMethod, CreateSessionRequest, requestSettings).ConfigureAwait(false);
+            var response = await Driver
+                .UnaryCall(QueryService.CreateSessionMethod, CreateSessionRequest, requestSettings)
+                .ConfigureAwait(false);
 
             if (response.Status.IsNotSuccess())
             {

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
@@ -326,7 +326,7 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
             _logger.LogError(e, "Failed to dispose the transport driver");
         }
 
-        SdkClientInfoRegistry.Unregister($"ado-net/{YdbSdkVersion.Value}");
+        SdkClientInfoRegistry.Unregister(Metadata.AdoNetClientInfo);
         if (_frameworkClientInfo is not null)
         {
             SdkClientInfoRegistry.Unregister(_frameworkClientInfo);

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
@@ -164,11 +164,11 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
                                          $"(currently {_maxPoolSize}) or 'CreateSessionTimeout' " +
                                          $"(currently {_createSessionTimeout} seconds) in your connection string."));
                 }, useSynchronizationContext: false
-            );
+            ).ConfigureAwait(false);
             await using var disposeRegistration = _disposeCts.Token.Register(
                 () => waiterTcs.TrySetException(ObjectDisposedException),
                 useSynchronizationContext: false
-            );
+            ).ConfigureAwait(false);
             session = await waiterTcs.Task.ConfigureAwait(false);
 
             if (CheckIdleSession(session) || TryGetIdleSession(out session))
@@ -193,7 +193,7 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
                     throw ObjectDisposedException;
 
                 var session = _sessionFactory.NewSession(this);
-                await session.Open(cancellationToken);
+                await session.Open(cancellationToken).ConfigureAwait(false);
 
                 for (var i = 0; i < _maxPoolSize; i++)
                 {
@@ -296,8 +296,8 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
             return;
         }
 
-        await _cleanerTimer.DisposeAsync();
-        await _disposeCts.CancelAsync();
+        await _cleanerTimer.DisposeAsync().ConfigureAwait(false);
+        await _disposeCts.CancelAsync().ConfigureAwait(false);
         MetricsReporter.Dispose();
 
         var sw = Stopwatch.StartNew();
@@ -319,7 +319,7 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
 
         try
         {
-            await _sessionFactory.DisposeAsync();
+            await _sessionFactory.DisposeAsync().ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/src/Ydb.Sdk/src/Ado/Session/RetryableSession.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/RetryableSession.cs
@@ -73,9 +73,9 @@ internal sealed class InMemoryServerStream(
 
     public async Task<bool> MoveNextAsync(CancellationToken cancellationToken = default)
     {
-        _responses ??= await retryPolicyExecutor.ExecuteAsync<List<ExecuteQueryResponsePart>>(async ct =>
+        _responses ??= await retryPolicyExecutor.ExecuteAsync(async ct =>
         {
-            using var session = await sessionSource.OpenSession(ct);
+            using var session = await sessionSource.OpenSession(ct).ConfigureAwait(false);
 
             using var dbActivity = YdbActivitySource.StartActivity("ydb.ExecuteQuery");
 
@@ -86,9 +86,9 @@ internal sealed class InMemoryServerStream(
             try
             {
                 var responses = new List<ExecuteQueryResponsePart>();
-                var serverStream = await session.ExecuteQuery(query, parameters, settings, null);
+                var serverStream = await session.ExecuteQuery(query, parameters, settings, null).ConfigureAwait(false);
 
-                while (await serverStream.MoveNextAsync(ct))
+                while (await serverStream.MoveNextAsync(ct).ConfigureAwait(false))
                 {
                     var current = serverStream.Current;
 
@@ -108,7 +108,7 @@ internal sealed class InMemoryServerStream(
                 dbActivity?.SetException(e);
                 throw;
             }
-        }, cancellationToken);
+        }, cancellationToken).ConfigureAwait(false);
 
         return ++_index < _responses.Count;
     }

--- a/src/Ydb.Sdk/src/Ado/YdbCommand.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbCommand.cs
@@ -252,9 +252,9 @@ public sealed class YdbCommand : DbCommand
             throw new InvalidOperationException("Transaction mismatched! (Maybe using another connection)");
         }
 
-        var ydbDataReader = await YdbDataReader.CreateYdbDataReader(
-            await YdbConnection.Session.ExecuteQuery(
-                preparedSql.ToString(), ydbParameters, execSettings, transaction?.TransactionControl).ConfigureAwait(false),
+        var ydbDataReader = await YdbDataReader.CreateYdbDataReader(await YdbConnection.Session
+                .ExecuteQuery(preparedSql.ToString(), ydbParameters, execSettings, transaction?.TransactionControl)
+                .ConfigureAwait(false),
             YdbConnection, dbActivity, startTimestamp, cancellationToken).ConfigureAwait(false);
 
         YdbConnection.LastReader = ydbDataReader;
@@ -264,7 +264,8 @@ public sealed class YdbCommand : DbCommand
     }
 
     public new async Task<YdbDataReader> ExecuteReaderAsync() =>
-        (YdbDataReader)await ExecuteDbDataReaderAsync(CommandBehavior.Default, CancellationToken.None).ConfigureAwait(false);
+        (YdbDataReader)await ExecuteDbDataReaderAsync(CommandBehavior.Default, CancellationToken.None)
+            .ConfigureAwait(false);
 
     public new Task<YdbDataReader> ExecuteReaderAsync(CancellationToken cancellationToken) =>
         ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);

--- a/src/Ydb.Sdk/src/Ado/YdbCommand.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbCommand.cs
@@ -59,9 +59,10 @@ public sealed class YdbCommand : DbCommand
 
     public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
     {
-        await using var dataReader = await ExecuteReaderAsync(cancellationToken);
+        var dataReader = await ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        await using var _ = ((IAsyncDisposable)dataReader).ConfigureAwait(false);
 
-        while (await dataReader.NextResultAsync(cancellationToken))
+        while (await dataReader.NextResultAsync(cancellationToken).ConfigureAwait(false))
         {
         }
 
@@ -72,11 +73,12 @@ public sealed class YdbCommand : DbCommand
 
     public override async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
     {
-        await using var dataReader = await ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
+        var dataReader = await ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
+        await using var _ = ((IAsyncDisposable)dataReader).ConfigureAwait(false);
 
-        var data = await dataReader.ReadAsync(cancellationToken) ? dataReader.GetValue(0) : null;
+        var data = await dataReader.ReadAsync(cancellationToken).ConfigureAwait(false) ? dataReader.GetValue(0) : null;
 
-        while (await dataReader.NextResultAsync(cancellationToken))
+        while (await dataReader.NextResultAsync(cancellationToken).ConfigureAwait(false))
         {
         }
 
@@ -252,8 +254,8 @@ public sealed class YdbCommand : DbCommand
 
         var ydbDataReader = await YdbDataReader.CreateYdbDataReader(
             await YdbConnection.Session.ExecuteQuery(
-                preparedSql.ToString(), ydbParameters, execSettings, transaction?.TransactionControl),
-            YdbConnection, dbActivity, startTimestamp, cancellationToken);
+                preparedSql.ToString(), ydbParameters, execSettings, transaction?.TransactionControl).ConfigureAwait(false),
+            YdbConnection, dbActivity, startTimestamp, cancellationToken).ConfigureAwait(false);
 
         YdbConnection.LastReader = ydbDataReader;
         YdbConnection.LastCommand = CommandText;
@@ -262,7 +264,7 @@ public sealed class YdbCommand : DbCommand
     }
 
     public new async Task<YdbDataReader> ExecuteReaderAsync() =>
-        (YdbDataReader)await ExecuteDbDataReaderAsync(CommandBehavior.Default, CancellationToken.None);
+        (YdbDataReader)await ExecuteDbDataReaderAsync(CommandBehavior.Default, CancellationToken.None).ConfigureAwait(false);
 
     public new Task<YdbDataReader> ExecuteReaderAsync(CancellationToken cancellationToken) =>
         ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
@@ -274,5 +276,5 @@ public sealed class YdbCommand : DbCommand
     // ReSharper disable once MemberCanBePrivate.Global
     public new async Task<YdbDataReader> ExecuteReaderAsync(CommandBehavior behavior,
         CancellationToken cancellationToken) =>
-        (YdbDataReader)await ExecuteDbDataReaderAsync(behavior, cancellationToken);
+        (YdbDataReader)await ExecuteDbDataReaderAsync(behavior, cancellationToken).ConfigureAwait(false);
 }

--- a/src/Ydb.Sdk/src/Ado/YdbConnection.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbConnection.cs
@@ -151,8 +151,11 @@ public sealed class YdbConnection : DbConnection
     {
         ThrowIfConnectionOpen();
 
-        Session = await (_sessionSource ??= await PoolManager.Get(ConnectionStringBuilder, cancellationToken).ConfigureAwait(false))
-            .OpenSession(cancellationToken).ConfigureAwait(false);
+        Session = await (
+            _sessionSource ??= await PoolManager
+                .Get(ConnectionStringBuilder, cancellationToken)
+                .ConfigureAwait(false)
+        ).OpenSession(cancellationToken).ConfigureAwait(false);
 
         OnStateChange(ClosedToOpenEventArgs);
 
@@ -167,7 +170,8 @@ public sealed class YdbConnection : DbConnection
         ThrowIfConnectionOpen();
 
         Session = new RetryableSession(
-            _sessionSource ??= await PoolManager.Get(ConnectionStringBuilder, cancellationToken).ConfigureAwait(false), retryPolicyExecutor);
+            _sessionSource ??= await PoolManager.Get(ConnectionStringBuilder, cancellationToken).ConfigureAwait(false),
+            retryPolicyExecutor);
 
         ConnectionState = ConnectionState.Open;
     }

--- a/src/Ydb.Sdk/src/Ado/YdbConnection.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbConnection.cs
@@ -151,8 +151,8 @@ public sealed class YdbConnection : DbConnection
     {
         ThrowIfConnectionOpen();
 
-        Session = await (_sessionSource ??= await PoolManager.Get(ConnectionStringBuilder, cancellationToken))
-            .OpenSession(cancellationToken);
+        Session = await (_sessionSource ??= await PoolManager.Get(ConnectionStringBuilder, cancellationToken).ConfigureAwait(false))
+            .OpenSession(cancellationToken).ConfigureAwait(false);
 
         OnStateChange(ClosedToOpenEventArgs);
 
@@ -167,7 +167,7 @@ public sealed class YdbConnection : DbConnection
         ThrowIfConnectionOpen();
 
         Session = new RetryableSession(
-            _sessionSource ??= await PoolManager.Get(ConnectionStringBuilder, cancellationToken), retryPolicyExecutor);
+            _sessionSource ??= await PoolManager.Get(ConnectionStringBuilder, cancellationToken).ConfigureAwait(false), retryPolicyExecutor);
 
         ConnectionState = ConnectionState.Open;
     }
@@ -188,12 +188,12 @@ public sealed class YdbConnection : DbConnection
                 {
                     if (LastReader is { IsClosed: false })
                     {
-                        await LastReader.CloseAsync();
+                        await LastReader.CloseAsync().ConfigureAwait(false);
                     }
 
                     if (CurrentTransaction is { Completed: false })
                     {
-                        await CurrentTransaction.RollbackAsync();
+                        await CurrentTransaction.RollbackAsync().ConfigureAwait(false);
                     }
 
                     OnStateChange(OpenToClosedEventArgs);
@@ -314,7 +314,7 @@ public sealed class YdbConnection : DbConnection
         if (_disposed)
             return;
 
-        await CloseAsync();
+        await CloseAsync().ConfigureAwait(false);
         _disposed = true;
     }
 

--- a/src/Ydb.Sdk/src/Ado/YdbConnectionStringBuilder.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbConnectionStringBuilder.cs
@@ -803,7 +803,7 @@ public sealed class YdbConnectionStringBuilder : DbConnectionStringBuilder, IDri
 
         return DisableDiscovery
             ? new DirectGrpcChannelDriver(driverConfig, LoggerFactory)
-            : await Driver.CreateInitialized(driverConfig, LoggerFactory);
+            : await Driver.CreateInitialized(driverConfig, LoggerFactory).ConfigureAwait(false);
     }
 
     public override void Clear()

--- a/src/Ydb.Sdk/src/Ado/YdbDataReader.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbDataReader.cs
@@ -805,7 +805,8 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
             return true;
         }
 
-        while ((ReaderState = await NextExecPart(cancellationToken).ConfigureAwait(false)) == State.ReadResultSet) // reset _currentRowIndex
+        while ((ReaderState = await NextExecPart(cancellationToken).ConfigureAwait(false)) ==
+               State.ReadResultSet) // reset _currentRowIndex
         {
             if (++_currentRowIndex < RowsCount)
             {
@@ -870,7 +871,8 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
             return;
         }
 
-        var isConsumed = ReaderState == State.IsConsumed || (!await ReadAsync().ConfigureAwait(false) && ReaderState == State.IsConsumed);
+        var isConsumed = ReaderState == State.IsConsumed ||
+                         (!await ReadAsync().ConfigureAwait(false) && ReaderState == State.IsConsumed);
         ReaderMetadata = CloseMetadata.Instance;
         ReaderState = State.Close;
         _dbActivity?.Dispose();

--- a/src/Ydb.Sdk/src/Ado/YdbDataReader.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbDataReader.cs
@@ -102,14 +102,14 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
     )
     {
         var ydbDataReader = new YdbDataReader(resultSetStream, connection, dbActivity, startTimestamp);
-        await ydbDataReader.Init(cancellationToken);
+        await ydbDataReader.Init(cancellationToken).ConfigureAwait(false);
 
         return ydbDataReader;
     }
 
     private async Task Init(CancellationToken cancellationToken)
     {
-        if (State.IsConsumed == await NextExecPart(cancellationToken))
+        if (State.IsConsumed == await NextExecPart(cancellationToken).ConfigureAwait(false))
         {
             throw new YdbException("YDB server closed the stream");
         }
@@ -773,12 +773,12 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
             State.ReadResultSet => await new Func<Task<State>>(async () =>
             {
                 State state;
-                while ((state = await NextExecPart(cancellationToken)) == State.ReadResultSet)
+                while ((state = await NextExecPart(cancellationToken).ConfigureAwait(false)) == State.ReadResultSet)
                 {
                 }
 
                 return state == State.NewResultSet ? State.ReadResultSet : state;
-            })(),
+            })().ConfigureAwait(false),
             State.Close => State.Close, // not invoke
             _ => throw new ArgumentOutOfRangeException(ReaderState.ToString())
         };
@@ -805,7 +805,7 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
             return true;
         }
 
-        while ((ReaderState = await NextExecPart(cancellationToken)) == State.ReadResultSet) // reset _currentRowIndex
+        while ((ReaderState = await NextExecPart(cancellationToken).ConfigureAwait(false)) == State.ReadResultSet) // reset _currentRowIndex
         {
             if (++_currentRowIndex < RowsCount)
             {
@@ -870,7 +870,7 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
             return;
         }
 
-        var isConsumed = ReaderState == State.IsConsumed || (!await ReadAsync() && ReaderState == State.IsConsumed);
+        var isConsumed = ReaderState == State.IsConsumed || (!await ReadAsync().ConfigureAwait(false) && ReaderState == State.IsConsumed);
         ReaderMetadata = CloseMetadata.Instance;
         ReaderState = State.Close;
         _dbActivity?.Dispose();
@@ -938,7 +938,7 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
         {
             _currentRowIndex = -1;
 
-            if (!await _stream.MoveNextAsync(cancellationToken))
+            if (!await _stream.MoveNextAsync(cancellationToken).ConfigureAwait(false))
             {
                 return State.IsConsumed;
             }
@@ -949,7 +949,7 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
 
             if (part.Status.IsNotSuccess())
             {
-                while (await _stream.MoveNextAsync(cancellationToken))
+                while (await _stream.MoveNextAsync(cancellationToken).ConfigureAwait(false))
                 {
                     _issueMessagesInStream.AddRange(_stream.Current.Issues);
                 }
@@ -1008,7 +1008,7 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
     /// and immediately reused for a new request while the previous one is still not completed.
     /// </para>
     /// </remarks>
-    public override async ValueTask DisposeAsync() => await CloseAsync();
+    public override async ValueTask DisposeAsync() => await CloseAsync().ConfigureAwait(false);
 
     /// <summary>
     /// Returns an async enumerator that iterates through the YdbDataReader asynchronously.
@@ -1021,7 +1021,7 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
     /// </remarks>
     public async IAsyncEnumerator<YdbDataRecord> GetAsyncEnumerator(CancellationToken cancellationToken = new())
     {
-        while (await ReadAsync(cancellationToken))
+        while (await ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return new YdbDataRecord(this);
         }

--- a/src/Ydb.Sdk/src/Ado/YdbDataSource.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbDataSource.cs
@@ -828,7 +828,8 @@ public class YdbDataSource : DbDataSource
         var ydbConnection = CreateDbConnection();
         try
         {
-            await ydbConnection.OpenAsync(new YdbRetryPolicyExecutor(retryPolicy), cancellationToken).ConfigureAwait(false);
+            await ydbConnection.OpenAsync(new YdbRetryPolicyExecutor(retryPolicy), cancellationToken)
+                .ConfigureAwait(false);
 
             return ydbConnection;
         }
@@ -851,7 +852,9 @@ public class YdbDataSource : DbDataSource
         string tableName,
         DescribeTableSettings settings = default,
         CancellationToken cancellationToken = default
-    ) => await YdbSchema.DescribeTable(await Driver(cancellationToken).ConfigureAwait(false), tableName, settings, cancellationToken).ConfigureAwait(false);
+    ) => await YdbSchema
+        .DescribeTable(await Driver(cancellationToken).ConfigureAwait(false), tableName, settings, cancellationToken)
+        .ConfigureAwait(false);
 
     /// <summary>
     /// Creates a copy of the specified table.
@@ -963,6 +966,7 @@ public class YdbDataSource : DbDataSource
     /// </summary>
     /// <param name="tableDescription">The table description containing columns, primary key, indexes, and other table properties.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <exception cref="YdbException">Thrown when the table already exists or the operation fails.</exception>
     /// <exception cref="NotSupportedException">Thrown when attempting to create an External table type (not supported via Control Plane RPC).</exception>
@@ -1004,5 +1008,6 @@ public class YdbDataSource : DbDataSource
     private string FullPath(string tableName) => tableName.FullPath(_ydbConnectionStringBuilder.Database);
 
     private async ValueTask<IDriver> Driver(CancellationToken cancellationToken) =>
-        (_sessionSource ??= await PoolManager.Get(_ydbConnectionStringBuilder, cancellationToken).ConfigureAwait(false)).Driver;
+        (_sessionSource ??= await PoolManager.Get(_ydbConnectionStringBuilder, cancellationToken).ConfigureAwait(false))
+        .Driver;
 }

--- a/src/Ydb.Sdk/src/Ado/YdbDataSource.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbDataSource.cs
@@ -129,12 +129,12 @@ public class YdbDataSource : DbDataSource
 
         try
         {
-            await ydbConnection.OpenAsync(cancellationToken);
+            await ydbConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
             return ydbConnection;
         }
         catch
         {
-            await ydbConnection.CloseAsync();
+            await ydbConnection.CloseAsync().ConfigureAwait(false);
             throw;
         }
     }
@@ -142,7 +142,7 @@ public class YdbDataSource : DbDataSource
     public override string ConnectionString => _ydbConnectionStringBuilder.ConnectionString;
 
     protected override async ValueTask DisposeAsyncCore() =>
-        await PoolManager.ClearPool(_ydbConnectionStringBuilder.ConnectionString);
+        await PoolManager.ClearPool(_ydbConnectionStringBuilder.ConnectionString).ConfigureAwait(false);
 
     protected override void Dispose(bool disposing)
     {
@@ -164,8 +164,9 @@ public class YdbDataSource : DbDataSource
     public Task ExecuteAsync(Func<YdbConnection, Task> func) => _retryPolicyExecutor
         .ExecuteAsync(async cancellationToken =>
         {
-            await using var ydbConnection = await OpenConnectionAsync(cancellationToken);
-            await func(ydbConnection);
+            var ydbConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using var _ = ydbConnection.ConfigureAwait(false);
+            await func(ydbConnection).ConfigureAwait(false);
         });
 
     /// <summary>
@@ -181,8 +182,9 @@ public class YdbDataSource : DbDataSource
     public Task<TResult> ExecuteAsync<TResult>(Func<YdbConnection, Task<TResult>> func) => _retryPolicyExecutor
         .ExecuteAsync<TResult>(async cancellationToken =>
         {
-            await using var ydbConnection = await OpenConnectionAsync(cancellationToken);
-            return await func(ydbConnection);
+            var ydbConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using var _ = ydbConnection.ConfigureAwait(false);
+            return await func(ydbConnection).ConfigureAwait(false);
         });
 
     /// <summary>
@@ -200,8 +202,9 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => _retryPolicyExecutor.ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await func(ydbConnection, ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        await func(ydbConnection, ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -220,8 +223,9 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => _retryPolicyExecutor.ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        return await func(ydbConnection, ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        return await func(ydbConnection, ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -239,8 +243,9 @@ public class YdbDataSource : DbDataSource
         YdbRetryPolicyConfig retryPolicyConfig
     ) => GetExecutor(retryPolicyConfig).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await func(ydbConnection);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        await func(ydbConnection).ConfigureAwait(false);
     });
 
     /// <summary>
@@ -258,8 +263,9 @@ public class YdbDataSource : DbDataSource
         IRetryPolicy retryPolicy
     ) => new YdbRetryPolicyExecutor(retryPolicy).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await func(ydbConnection);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        await func(ydbConnection).ConfigureAwait(false);
     });
 
     /// <summary>
@@ -278,8 +284,9 @@ public class YdbDataSource : DbDataSource
         YdbRetryPolicyConfig retryPolicyConfig
     ) => GetExecutor(retryPolicyConfig).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        return await func(ydbConnection);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        return await func(ydbConnection).ConfigureAwait(false);
     });
 
     /// <summary>
@@ -298,8 +305,9 @@ public class YdbDataSource : DbDataSource
         IRetryPolicy retryPolicy
     ) => new YdbRetryPolicyExecutor(retryPolicy).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        return await func(ydbConnection);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        return await func(ydbConnection).ConfigureAwait(false);
     });
 
     /// <summary>
@@ -319,8 +327,9 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => GetExecutor(retryPolicyConfig).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await func(ydbConnection, ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        await func(ydbConnection, ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -340,8 +349,9 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => new YdbRetryPolicyExecutor(retryPolicy).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await func(ydbConnection, ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        await func(ydbConnection, ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -362,8 +372,9 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => GetExecutor(retryPolicyConfig).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        return await func(ydbConnection, ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        return await func(ydbConnection, ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -384,8 +395,9 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => new YdbRetryPolicyExecutor(retryPolicy).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        return await func(ydbConnection, ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        return await func(ydbConnection, ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -404,10 +416,12 @@ public class YdbDataSource : DbDataSource
         TransactionMode transactionMode = TransactionMode.SerializableRw
     ) => _retryPolicyExecutor.ExecuteAsync(async cancellationToken =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(cancellationToken);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        await func(ydbConnection);
-        await transaction.CommitAsync(cancellationToken);
+        var ydbConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        await func(ydbConnection).ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     });
 
     /// <summary>
@@ -427,10 +441,12 @@ public class YdbDataSource : DbDataSource
         TransactionMode transactionMode = TransactionMode.SerializableRw
     ) => _retryPolicyExecutor.ExecuteAsync<TResult>(async cancellationToken =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(cancellationToken);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
+        var ydbConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
         var result = await func(ydbConnection).ConfigureAwait(false);
-        await transaction.CommitAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
         return result;
     });
 
@@ -452,10 +468,12 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => _retryPolicyExecutor.ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        await func(ydbConnection, ct);
-        await transaction.CommitAsync(ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        await func(ydbConnection, ct).ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -477,10 +495,12 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => _retryPolicyExecutor.ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        var result = await func(ydbConnection, ct);
-        await transaction.CommitAsync(ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        var result = await func(ydbConnection, ct).ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
         return result;
     }, cancellationToken);
 
@@ -502,10 +522,12 @@ public class YdbDataSource : DbDataSource
         TransactionMode transactionMode = TransactionMode.SerializableRw
     ) => GetExecutor(retryPolicyConfig).ExecuteAsync(async cancellationToken =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(cancellationToken);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        await func(ydbConnection);
-        await transaction.CommitAsync(cancellationToken);
+        var ydbConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        await func(ydbConnection).ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
     });
 
     /// <summary>
@@ -527,10 +549,12 @@ public class YdbDataSource : DbDataSource
         TransactionMode transactionMode = TransactionMode.SerializableRw
     ) => GetExecutor(retryPolicyConfig).ExecuteAsync(async cancellationToken =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(cancellationToken);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        var result = await func(ydbConnection);
-        await transaction.CommitAsync(cancellationToken);
+        var ydbConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        var result = await func(ydbConnection).ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
         return result;
     });
 
@@ -554,10 +578,12 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => GetExecutor(retryPolicyConfig).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        await func(ydbConnection, ct);
-        await transaction.CommitAsync(ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        await func(ydbConnection, ct).ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -581,10 +607,12 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => GetExecutor(retryPolicyConfig).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        var result = await func(ydbConnection, ct);
-        await transaction.CommitAsync(ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        var result = await func(ydbConnection, ct).ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
         return result;
     }, cancellationToken);
 
@@ -606,10 +634,12 @@ public class YdbDataSource : DbDataSource
         TransactionMode transactionMode = TransactionMode.SerializableRw
     ) => new YdbRetryPolicyExecutor(retryPolicy).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        await func(ydbConnection);
-        await transaction.CommitAsync(ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        await func(ydbConnection).ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
     });
 
     /// <summary>
@@ -631,10 +661,12 @@ public class YdbDataSource : DbDataSource
         TransactionMode transactionMode = TransactionMode.SerializableRw
     ) => new YdbRetryPolicyExecutor(retryPolicy).ExecuteAsync(async cancellationToken =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(cancellationToken);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        var result = await func(ydbConnection);
-        await transaction.CommitAsync(cancellationToken);
+        var ydbConnection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        var result = await func(ydbConnection).ConfigureAwait(false);
+        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
         return result;
     });
 
@@ -658,10 +690,12 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => new YdbRetryPolicyExecutor(retryPolicy).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        await func(ydbConnection, ct);
-        await transaction.CommitAsync(ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        await func(ydbConnection, ct).ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
     }, cancellationToken);
 
     /// <summary>
@@ -685,10 +719,12 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     ) => new YdbRetryPolicyExecutor(retryPolicy).ExecuteAsync(async ct =>
     {
-        await using var ydbConnection = await OpenConnectionAsync(ct);
-        await using var transaction = ydbConnection.BeginTransaction(transactionMode);
-        var result = await func(ydbConnection, ct);
-        await transaction.CommitAsync(ct);
+        var ydbConnection = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var _ = ydbConnection.ConfigureAwait(false);
+        var transaction = ydbConnection.BeginTransaction(transactionMode);
+        await using var transactionScope = transaction.ConfigureAwait(false);
+        var result = await func(ydbConnection, ct).ConfigureAwait(false);
+        await transaction.CommitAsync(ct).ConfigureAwait(false);
         return result;
     }, cancellationToken);
 
@@ -715,13 +751,13 @@ public class YdbDataSource : DbDataSource
         var ydbConnection = CreateDbConnection();
         try
         {
-            await ydbConnection.OpenAsync(_retryPolicyExecutor, cancellationToken);
+            await ydbConnection.OpenAsync(_retryPolicyExecutor, cancellationToken).ConfigureAwait(false);
 
             return ydbConnection;
         }
         catch
         {
-            await ydbConnection.CloseAsync();
+            await ydbConnection.CloseAsync().ConfigureAwait(false);
             throw;
         }
     }
@@ -753,13 +789,13 @@ public class YdbDataSource : DbDataSource
         var ydbConnection = CreateDbConnection();
         try
         {
-            await ydbConnection.OpenAsync(GetExecutor(ydbRetryPolicyConfig), cancellationToken);
+            await ydbConnection.OpenAsync(GetExecutor(ydbRetryPolicyConfig), cancellationToken).ConfigureAwait(false);
 
             return ydbConnection;
         }
         catch
         {
-            await ydbConnection.CloseAsync();
+            await ydbConnection.CloseAsync().ConfigureAwait(false);
             throw;
         }
     }
@@ -792,13 +828,13 @@ public class YdbDataSource : DbDataSource
         var ydbConnection = CreateDbConnection();
         try
         {
-            await ydbConnection.OpenAsync(new YdbRetryPolicyExecutor(retryPolicy), cancellationToken);
+            await ydbConnection.OpenAsync(new YdbRetryPolicyExecutor(retryPolicy), cancellationToken).ConfigureAwait(false);
 
             return ydbConnection;
         }
         catch
         {
-            await ydbConnection.CloseAsync();
+            await ydbConnection.CloseAsync().ConfigureAwait(false);
             throw;
         }
     }
@@ -815,7 +851,7 @@ public class YdbDataSource : DbDataSource
         string tableName,
         DescribeTableSettings settings = default,
         CancellationToken cancellationToken = default
-    ) => await YdbSchema.DescribeTable(await Driver(cancellationToken), tableName, settings, cancellationToken);
+    ) => await YdbSchema.DescribeTable(await Driver(cancellationToken).ConfigureAwait(false), tableName, settings, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Creates a copy of the specified table.
@@ -831,13 +867,13 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     )
     {
-        var driver = await Driver(cancellationToken);
+        var driver = await Driver(cancellationToken).ConfigureAwait(false);
 
         var copyTableResponse = await driver.UnaryCall(TableService.CopyTableMethod, new CopyTableRequest
         {
             SourcePath = FullPath(sourceTable),
             DestinationPath = FullPath(destinationTable)
-        }, new GrpcRequestSettings { CancellationToken = cancellationToken });
+        }, new GrpcRequestSettings { CancellationToken = cancellationToken }).ConfigureAwait(false);
 
         if (copyTableResponse.Operation.Status.IsNotSuccess())
             throw YdbException.FromServer(copyTableResponse.Operation);
@@ -855,7 +891,7 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     )
     {
-        var driver = await Driver(cancellationToken);
+        var driver = await Driver(cancellationToken).ConfigureAwait(false);
         var copyTablesRequest = new CopyTablesRequest();
         foreach (var copyTable in copyTableSettingsList)
             copyTablesRequest.Tables.Add(new CopyTableItem
@@ -866,7 +902,7 @@ public class YdbDataSource : DbDataSource
             });
 
         var copyTablesResponse = await driver.UnaryCall(TableService.CopyTablesMethod, copyTablesRequest,
-            new GrpcRequestSettings { CancellationToken = cancellationToken });
+            new GrpcRequestSettings { CancellationToken = cancellationToken }).ConfigureAwait(false);
 
         if (copyTablesResponse.Operation.Status.IsNotSuccess())
             throw YdbException.FromServer(copyTablesResponse.Operation);
@@ -884,7 +920,7 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     )
     {
-        var driver = await Driver(cancellationToken);
+        var driver = await Driver(cancellationToken).ConfigureAwait(false);
         var renameTablesRequest = new RenameTablesRequest();
         foreach (var renameTable in renameTableSettingsList)
             renameTablesRequest.Tables.Add(new RenameTableItem
@@ -895,7 +931,7 @@ public class YdbDataSource : DbDataSource
             });
 
         var renameTablesResponse = await driver.UnaryCall(TableService.RenameTablesMethod, renameTablesRequest,
-            new GrpcRequestSettings { CancellationToken = cancellationToken });
+            new GrpcRequestSettings { CancellationToken = cancellationToken }).ConfigureAwait(false);
 
         if (renameTablesResponse.Operation.Status.IsNotSuccess())
             throw YdbException.FromServer(renameTablesResponse.Operation);
@@ -910,13 +946,13 @@ public class YdbDataSource : DbDataSource
     /// <exception cref="YdbException">Thrown when the table does not exist or the operation fails.</exception>
     public async Task DropTable(string tableName, CancellationToken cancellationToken = default)
     {
-        var driver = await Driver(cancellationToken);
+        var driver = await Driver(cancellationToken).ConfigureAwait(false);
 
         var dropTableResponse = await driver.UnaryCall(
             TableService.DropTableMethod,
             new DropTableRequest { Path = FullPath(tableName) },
             new GrpcRequestSettings { CancellationToken = cancellationToken }
-        );
+        ).ConfigureAwait(false);
 
         if (dropTableResponse.Operation.Status.IsNotSuccess())
             throw YdbException.FromServer(dropTableResponse.Operation);
@@ -935,7 +971,7 @@ public class YdbDataSource : DbDataSource
         CancellationToken cancellationToken = default
     )
     {
-        var driver = await Driver(cancellationToken);
+        var driver = await Driver(cancellationToken).ConfigureAwait(false);
         var createTableRequest = new CreateTableRequest
         {
             Path = FullPath(tableDescription.Name),
@@ -959,7 +995,7 @@ public class YdbDataSource : DbDataSource
             createTableRequest.PrimaryKey.Add(pkColumn);
 
         var createTableResponse = await driver.UnaryCall(TableService.CreateTableMethod, createTableRequest,
-            new GrpcRequestSettings { CancellationToken = cancellationToken });
+            new GrpcRequestSettings { CancellationToken = cancellationToken }).ConfigureAwait(false);
 
         if (createTableResponse.Operation.Status.IsNotSuccess())
             throw YdbException.FromServer(createTableResponse.Operation);
@@ -968,5 +1004,5 @@ public class YdbDataSource : DbDataSource
     private string FullPath(string tableName) => tableName.FullPath(_ydbConnectionStringBuilder.Database);
 
     private async ValueTask<IDriver> Driver(CancellationToken cancellationToken) =>
-        (_sessionSource ??= await PoolManager.Get(_ydbConnectionStringBuilder, cancellationToken)).Driver;
+        (_sessionSource ??= await PoolManager.Get(_ydbConnectionStringBuilder, cancellationToken).ConfigureAwait(false)).Driver;
 }

--- a/src/Ydb.Sdk/src/Ado/YdbSchema.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbSchema.cs
@@ -94,7 +94,8 @@ internal static class YdbSchema
 
         if (tableName == null) // tableName isn't set
         {
-            foreach (var tupleTable in await ListTables(ydbConnection, tableType, cancellationToken).ConfigureAwait(false))
+            foreach (var tupleTable in await ListTables(ydbConnection, tableType, cancellationToken)
+                         .ConfigureAwait(false))
             {
                 table.Rows.Add(tupleTable.TableName, tupleTable.TableType);
             }
@@ -136,7 +137,8 @@ internal static class YdbSchema
 
         if (tableName == null) // tableName isn't set
         {
-            foreach (var tupleTable in await ListTables(ydbConnection, tableType, cancellationToken).ConfigureAwait(false))
+            foreach (var tupleTable in await ListTables(ydbConnection, tableType, cancellationToken)
+                         .ConfigureAwait(false))
             {
                 await AppendDescribeTable(
                     ydbConnection: ydbConnection,
@@ -204,7 +206,8 @@ internal static class YdbSchema
         var tableNameRestriction = restrictions[0];
         var columnName = restrictions[1];
 
-        var tableNames = await ListTableNames(ydbConnection, tableNameRestriction, cancellationToken).ConfigureAwait(false);
+        var tableNames = await ListTableNames(ydbConnection, tableNameRestriction, cancellationToken)
+            .ConfigureAwait(false);
         foreach (var tableName in tableNames)
         {
             await AppendDescribeTable(
@@ -245,7 +248,8 @@ internal static class YdbSchema
         DescribeTableSettings settings = default,
         CancellationToken cancellationToken = default)
     {
-        var ydbTable = await DescribeTable(ydbConnection.Session.Driver, tableName, settings, cancellationToken).ConfigureAwait(false);
+        var ydbTable = await DescribeTable(ydbConnection.Session.Driver, tableName, settings, cancellationToken)
+            .ConfigureAwait(false);
         var type = ydbTable.IsSystem
             ? "SYSTEM_TABLE"
             : ydbTable.Type switch
@@ -268,14 +272,14 @@ internal static class YdbSchema
     ) => tableName != null
         ? new List<string> { tableName }
         : from table in await ListTables(ydbConnection, cancellationToken: cancellationToken).ConfigureAwait(false)
-          select table.TableName;
+        select table.TableName;
 
     private static async Task<IEnumerable<(string TableName, string TableType)>> ListTables(
         YdbConnection ydbConnection,
         string? tableType = null,
         CancellationToken cancellationToken = default
     ) => from ydbObject in await SchemaObjects(ydbConnection, cancellationToken).ConfigureAwait(false)
-         let type = ydbObject.IsSystem
+        let type = ydbObject.IsSystem
             ? "SYSTEM_TABLE"
             : ydbObject.Type switch
             {
@@ -289,8 +293,9 @@ internal static class YdbSchema
 
     private static async Task<DataTable> GetDataSourceInformation(YdbConnection ydbConnection)
     {
-        var ydbVersion =
-            (await new YdbCommand(ydbConnection) { CommandText = "SELECT Version();" }.ExecuteScalarAsync().ConfigureAwait(false))!
+        var ydbVersion = (await new YdbCommand(ydbConnection) { CommandText = "SELECT Version();" }
+            .ExecuteScalarAsync()
+            .ConfigureAwait(false))!
             .ToString();
 
         var table = new DataTable("DataSourceInformation");

--- a/src/Ydb.Sdk/src/Ado/YdbSchema.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbSchema.cs
@@ -294,9 +294,7 @@ internal static class YdbSchema
     private static async Task<DataTable> GetDataSourceInformation(YdbConnection ydbConnection)
     {
         var ydbVersion = (await new YdbCommand(ydbConnection) { CommandText = "SELECT Version();" }
-            .ExecuteScalarAsync()
-            .ConfigureAwait(false))!
-            .ToString();
+            .ExecuteScalarAsync().ConfigureAwait(false))!.ToString();
 
         var table = new DataTable("DataSourceInformation");
         var row = table.Rows.Add();

--- a/src/Ydb.Sdk/src/Ado/YdbSchema.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbSchema.cs
@@ -64,7 +64,7 @@ internal static class YdbSchema
                 IncludeTableStats = settings.IncludeTableStats
             },
             new GrpcRequestSettings { CancellationToken = cancellationToken }
-        );
+        ).ConfigureAwait(false);
 
         if (describeResponse.Operation.Status.IsNotSuccess())
             throw YdbException.FromServer(describeResponse.Operation.Status, describeResponse.Operation.Issues);
@@ -94,7 +94,7 @@ internal static class YdbSchema
 
         if (tableName == null) // tableName isn't set
         {
-            foreach (var tupleTable in await ListTables(ydbConnection, tableType, cancellationToken))
+            foreach (var tupleTable in await ListTables(ydbConnection, tableType, cancellationToken).ConfigureAwait(false))
             {
                 table.Rows.Add(tupleTable.TableName, tupleTable.TableType);
             }
@@ -107,7 +107,7 @@ internal static class YdbSchema
                 tableType: tableType,
                 (_, type) => { table.Rows.Add(tableName, type); },
                 cancellationToken: cancellationToken
-            );
+            ).ConfigureAwait(false);
         }
 
         return table;
@@ -136,7 +136,7 @@ internal static class YdbSchema
 
         if (tableName == null) // tableName isn't set
         {
-            foreach (var tupleTable in await ListTables(ydbConnection, tableType, cancellationToken))
+            foreach (var tupleTable in await ListTables(ydbConnection, tableType, cancellationToken).ConfigureAwait(false))
             {
                 await AppendDescribeTable(
                     ydbConnection: ydbConnection,
@@ -155,7 +155,7 @@ internal static class YdbSchema
                     },
                     new DescribeTableSettings { IncludeTableStats = true },
                     cancellationToken
-                );
+                ).ConfigureAwait(false);
             }
         }
         else
@@ -177,7 +177,7 @@ internal static class YdbSchema
                 },
                 new DescribeTableSettings { IncludeTableStats = true },
                 cancellationToken: cancellationToken
-            );
+            ).ConfigureAwait(false);
         }
 
         return table;
@@ -204,7 +204,7 @@ internal static class YdbSchema
         var tableNameRestriction = restrictions[0];
         var columnName = restrictions[1];
 
-        var tableNames = await ListTableNames(ydbConnection, tableNameRestriction, cancellationToken);
+        var tableNames = await ListTableNames(ydbConnection, tableNameRestriction, cancellationToken).ConfigureAwait(false);
         foreach (var tableName in tableNames)
         {
             await AppendDescribeTable(
@@ -231,7 +231,7 @@ internal static class YdbSchema
                         row["data_type"] = column.StorageType.ToString();
                         row["family_name"] = column.Family;
                     }
-                }, cancellationToken: cancellationToken);
+                }, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         return table;
@@ -245,7 +245,7 @@ internal static class YdbSchema
         DescribeTableSettings settings = default,
         CancellationToken cancellationToken = default)
     {
-        var ydbTable = await DescribeTable(ydbConnection.Session.Driver, tableName, settings, cancellationToken);
+        var ydbTable = await DescribeTable(ydbConnection.Session.Driver, tableName, settings, cancellationToken).ConfigureAwait(false);
         var type = ydbTable.IsSystem
             ? "SYSTEM_TABLE"
             : ydbTable.Type switch
@@ -267,15 +267,15 @@ internal static class YdbSchema
         CancellationToken cancellationToken
     ) => tableName != null
         ? new List<string> { tableName }
-        : from table in await ListTables(ydbConnection, cancellationToken: cancellationToken)
-        select table.TableName;
+        : from table in await ListTables(ydbConnection, cancellationToken: cancellationToken).ConfigureAwait(false)
+          select table.TableName;
 
     private static async Task<IEnumerable<(string TableName, string TableType)>> ListTables(
         YdbConnection ydbConnection,
         string? tableType = null,
         CancellationToken cancellationToken = default
-    ) => from ydbObject in await SchemaObjects(ydbConnection, cancellationToken)
-        let type = ydbObject.IsSystem
+    ) => from ydbObject in await SchemaObjects(ydbConnection, cancellationToken).ConfigureAwait(false)
+         let type = ydbObject.IsSystem
             ? "SYSTEM_TABLE"
             : ydbObject.Type switch
             {
@@ -290,7 +290,7 @@ internal static class YdbSchema
     private static async Task<DataTable> GetDataSourceInformation(YdbConnection ydbConnection)
     {
         var ydbVersion =
-            (await new YdbCommand(ydbConnection) { CommandText = "SELECT Version();" }.ExecuteScalarAsync())!
+            (await new YdbCommand(ydbConnection) { CommandText = "SELECT Version();" }.ExecuteScalarAsync().ConfigureAwait(false))!
             .ToString();
 
         var table = new DataTable("DataSourceInformation");
@@ -397,7 +397,7 @@ internal static class YdbSchema
                 SchemeService.ListDirectoryMethod,
                 new ListDirectoryRequest { Path = fullPath },
                 new GrpcRequestSettings { CancellationToken = cancellationToken }
-            );
+            ).ConfigureAwait(false);
 
             var operation = response.Operation;
             if (operation.Status.IsNotSuccess())
@@ -419,7 +419,7 @@ internal static class YdbSchema
                                 databasePath,
                                 fullPath + entry.Name,
                                 cancellationToken
-                            )
+                            ).ConfigureAwait(false)
                         );
                         break;
                     case Entry.Types.Type.Table:

--- a/src/Ydb.Sdk/src/Ado/YdbTransaction.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbTransaction.cs
@@ -229,11 +229,11 @@ public sealed class YdbTransaction : DbTransaction
 
             if (isCommit)
             {
-                await DbConnection.Session.CommitTransaction(TxId, dbActivity, cancellationToken);
+                await DbConnection.Session.CommitTransaction(TxId, dbActivity, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                await DbConnection.Session.RollbackTransaction(TxId, dbActivity, cancellationToken);
+                await DbConnection.Session.RollbackTransaction(TxId, dbActivity, cancellationToken).ConfigureAwait(false);
             }
         }
         catch (YdbException e)
@@ -286,7 +286,7 @@ public sealed class YdbTransaction : DbTransaction
 
         if (!Completed)
         {
-            await RollbackAsync();
+            await RollbackAsync().ConfigureAwait(false);
         }
 
         _isDisposed = true;

--- a/src/Ydb.Sdk/src/Ado/YdbTransaction.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbTransaction.cs
@@ -233,7 +233,8 @@ public sealed class YdbTransaction : DbTransaction
             }
             else
             {
-                await DbConnection.Session.RollbackTransaction(TxId, dbActivity, cancellationToken).ConfigureAwait(false);
+                await DbConnection.Session.RollbackTransaction(TxId, dbActivity, cancellationToken)
+                    .ConfigureAwait(false);
             }
         }
         catch (YdbException e)

--- a/src/Ydb.Sdk/src/Auth/CachedCredentialsProvider.cs
+++ b/src/Ydb.Sdk/src/Auth/CachedCredentialsProvider.cs
@@ -32,7 +32,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
     }
 
     public async ValueTask<string> GetAuthInfoAsync() =>
-        (await _tokenState.Validate(_clock.UtcNow)).TokenResponse.Token;
+        (await _tokenState.Validate(_clock.UtcNow).ConfigureAwait(false)).TokenResponse.Token;
 
     private Task<TokenResponse> FetchToken() => _authClient.FetchToken();
 
@@ -89,7 +89,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
 
             return await _cachedCredentialsProvider
                 .UpdateState(this, new SyncState(_cachedCredentialsProvider))
-                .Validate(now);
+                .Validate(now).ConfigureAwait(false);
         }
     }
 
@@ -111,7 +111,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
         {
             try
             {
-                var tokenResponse = await _fetchTokenResponseTcs.Task;
+                var tokenResponse = await _fetchTokenResponseTcs.Task.ConfigureAwait(false);
 
                 _cachedCredentialsProvider.Logger.LogDebug(
                     "Successfully fetched token. ExpiredAt: {ExpiredAt}, RefreshAt: {RefreshAt}",
@@ -133,7 +133,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
         {
             try
             {
-                var tokenResponse = await _cachedCredentialsProvider.FetchToken();
+                var tokenResponse = await _cachedCredentialsProvider.FetchToken().ConfigureAwait(false);
 
                 _fetchTokenResponseTcs.SetResult(tokenResponse);
             }
@@ -173,7 +173,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
                 return now >= TokenResponse.ExpiredAt
                     ? await _cachedCredentialsProvider
                         .UpdateState(this, new SyncState(_cachedCredentialsProvider))
-                        .Validate(now)
+                        .Validate(now).ConfigureAwait(false)
                     : _cachedCredentialsProvider
                         .UpdateState(this, new BackgroundState(TokenResponse, _cachedCredentialsProvider));
             }
@@ -181,7 +181,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
             if (fetchTokenTask.IsCompleted)
             {
                 return _cachedCredentialsProvider
-                    .UpdateState(this, new ActiveState(await fetchTokenTask, _cachedCredentialsProvider));
+                    .UpdateState(this, new ActiveState(await fetchTokenTask.ConfigureAwait(false), _cachedCredentialsProvider));
             }
 
             if (now < TokenResponse.ExpiredAt)
@@ -191,7 +191,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
 
             try
             {
-                var tokenResponse = await fetchTokenTask;
+                var tokenResponse = await fetchTokenTask.ConfigureAwait(false);
 
                 _cachedCredentialsProvider.Logger.LogDebug(
                     "Successfully fetched token. ExpiredAt: {ExpiredAt}, RefreshAt: {RefreshAt}",
@@ -213,7 +213,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
         {
             try
             {
-                var tokenResponse = await _cachedCredentialsProvider.FetchToken();
+                var tokenResponse = await _cachedCredentialsProvider.FetchToken().ConfigureAwait(false);
 
                 _fetchTokenResponseTcs.SetResult(tokenResponse);
             }

--- a/src/Ydb.Sdk/src/Auth/CachedCredentialsProvider.cs
+++ b/src/Ydb.Sdk/src/Auth/CachedCredentialsProvider.cs
@@ -119,7 +119,13 @@ public class CachedCredentialsProvider : ICredentialsProvider
         {
             try
             {
-                var tokenResponse = await cachedCredentialsProvider.FetchToken().ConfigureAwait(false);
+                // CA2007 deliberately not applied: this is a fire-and-forget async void background fetch.
+                // The token state machine relies on the awaiter's continuation completing this TCS, and the
+                // SDK always reaches this code off any UI SynchronizationContext (earlier layers use
+                // ConfigureAwait(false)), so capturing the context here is harmless and not a deadlock risk.
+#pragma warning disable CA2007
+                var tokenResponse = await cachedCredentialsProvider.FetchToken();
+#pragma warning restore CA2007
 
                 _fetchTokenResponseTcs.SetResult(tokenResponse);
             }
@@ -192,7 +198,13 @@ public class CachedCredentialsProvider : ICredentialsProvider
         {
             try
             {
-                var tokenResponse = await cachedCredentialsProvider.FetchToken().ConfigureAwait(false);
+                // CA2007 deliberately not applied: this is a fire-and-forget async void background fetch.
+                // The token state machine relies on the awaiter's continuation completing this TCS, and the
+                // SDK always reaches this code off any UI SynchronizationContext (earlier layers use
+                // ConfigureAwait(false)), so capturing the context here is harmless and not a deadlock risk.
+#pragma warning disable CA2007
+                var tokenResponse = await cachedCredentialsProvider.FetchToken();
+#pragma warning restore CA2007
 
                 _fetchTokenResponseTcs.SetResult(tokenResponse);
             }

--- a/src/Ydb.Sdk/src/Auth/CachedCredentialsProvider.cs
+++ b/src/Ydb.Sdk/src/Auth/CachedCredentialsProvider.cs
@@ -57,52 +57,38 @@ public class CachedCredentialsProvider : ICredentialsProvider
         }
     }
 
-    private class ActiveState : ITokenState
+    private class ActiveState(TokenResponse tokenResponse, CachedCredentialsProvider cachedCredentialsProvider)
+        : ITokenState
     {
-        private readonly CachedCredentialsProvider _cachedCredentialsProvider;
-
-        public ActiveState(TokenResponse tokenResponse, CachedCredentialsProvider cachedCredentialsProvider)
-        {
-            TokenResponse = tokenResponse;
-            _cachedCredentialsProvider = cachedCredentialsProvider;
-        }
-
-        public TokenResponse TokenResponse { get; }
+        public TokenResponse TokenResponse { get; } = tokenResponse;
 
         public async ValueTask<ITokenState> Validate(DateTime now)
         {
             if (now < TokenResponse.ExpiredAt)
             {
                 return now >= TokenResponse.RefreshAt
-                    ? _cachedCredentialsProvider.UpdateState(
+                    ? cachedCredentialsProvider.UpdateState(
                         this,
-                        new BackgroundState(TokenResponse, _cachedCredentialsProvider)
+                        new BackgroundState(TokenResponse, cachedCredentialsProvider)
                     )
                     : this;
             }
 
-            _cachedCredentialsProvider.Logger.LogWarning(
+            cachedCredentialsProvider.Logger.LogWarning(
                 "Token has expired. ExpiredAt: {ExpiredAt}, CurrentTime: {CurrentTime}. " +
                 "Switching to synchronous state to fetch a new token",
                 TokenResponse.ExpiredAt, now
             );
 
-            return await _cachedCredentialsProvider
-                .UpdateState(this, new SyncState(_cachedCredentialsProvider))
+            return await cachedCredentialsProvider
+                .UpdateState(this, new SyncState(cachedCredentialsProvider))
                 .Validate(now).ConfigureAwait(false);
         }
     }
 
-    private class SyncState : ITokenState
+    private class SyncState(CachedCredentialsProvider cachedCredentialsProvider) : ITokenState
     {
         private readonly TaskCompletionSource<TokenResponse> _fetchTokenResponseTcs = new();
-
-        private readonly CachedCredentialsProvider _cachedCredentialsProvider;
-
-        public SyncState(CachedCredentialsProvider cachedCredentialsProvider)
-        {
-            _cachedCredentialsProvider = cachedCredentialsProvider;
-        }
 
         public TokenResponse TokenResponse =>
             throw new InvalidOperationException("Get token for unfinished sync state");
@@ -113,19 +99,19 @@ public class CachedCredentialsProvider : ICredentialsProvider
             {
                 var tokenResponse = await _fetchTokenResponseTcs.Task.ConfigureAwait(false);
 
-                _cachedCredentialsProvider.Logger.LogDebug(
+                cachedCredentialsProvider.Logger.LogDebug(
                     "Successfully fetched token. ExpiredAt: {ExpiredAt}, RefreshAt: {RefreshAt}",
                     tokenResponse.ExpiredAt, tokenResponse.RefreshAt
                 );
 
-                return _cachedCredentialsProvider.UpdateState(this,
-                    new ActiveState(tokenResponse, _cachedCredentialsProvider));
+                return cachedCredentialsProvider.UpdateState(this,
+                    new ActiveState(tokenResponse, cachedCredentialsProvider));
             }
             catch (Exception e)
             {
-                _cachedCredentialsProvider.Logger.LogCritical(e, "Error on authentication token update");
+                cachedCredentialsProvider.Logger.LogCritical(e, "Error on authentication token update");
 
-                return _cachedCredentialsProvider.UpdateState(this, new ErrorState(e, _cachedCredentialsProvider));
+                return cachedCredentialsProvider.UpdateState(this, new ErrorState(e, cachedCredentialsProvider));
             }
         }
 
@@ -133,7 +119,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
         {
             try
             {
-                var tokenResponse = await _cachedCredentialsProvider.FetchToken().ConfigureAwait(false);
+                var tokenResponse = await cachedCredentialsProvider.FetchToken().ConfigureAwait(false);
 
                 _fetchTokenResponseTcs.SetResult(tokenResponse);
             }
@@ -144,20 +130,12 @@ public class CachedCredentialsProvider : ICredentialsProvider
         }
     }
 
-    private class BackgroundState : ITokenState
+    private class BackgroundState(TokenResponse tokenResponse, CachedCredentialsProvider cachedCredentialsProvider)
+        : ITokenState
     {
         private readonly TaskCompletionSource<TokenResponse> _fetchTokenResponseTcs = new();
 
-        private readonly CachedCredentialsProvider _cachedCredentialsProvider;
-
-        public BackgroundState(TokenResponse tokenResponse,
-            CachedCredentialsProvider cachedCredentialsProvider)
-        {
-            TokenResponse = tokenResponse;
-            _cachedCredentialsProvider = cachedCredentialsProvider;
-        }
-
-        public TokenResponse TokenResponse { get; }
+        public TokenResponse TokenResponse { get; } = tokenResponse;
 
         public async ValueTask<ITokenState> Validate(DateTime now)
         {
@@ -165,23 +143,24 @@ public class CachedCredentialsProvider : ICredentialsProvider
 
             if (fetchTokenTask.IsCanceled || fetchTokenTask.IsFaulted)
             {
-                _cachedCredentialsProvider.Logger.LogWarning(
+                cachedCredentialsProvider.Logger.LogWarning(
                     "Fetching token task failed. Status: {Status}, Retrying login...",
                     fetchTokenTask.IsCanceled ? "Canceled" : "Faulted"
                 );
 
                 return now >= TokenResponse.ExpiredAt
-                    ? await _cachedCredentialsProvider
-                        .UpdateState(this, new SyncState(_cachedCredentialsProvider))
+                    ? await cachedCredentialsProvider
+                        .UpdateState(this, new SyncState(cachedCredentialsProvider))
                         .Validate(now).ConfigureAwait(false)
-                    : _cachedCredentialsProvider
-                        .UpdateState(this, new BackgroundState(TokenResponse, _cachedCredentialsProvider));
+                    : cachedCredentialsProvider
+                        .UpdateState(this, new BackgroundState(TokenResponse, cachedCredentialsProvider));
             }
 
             if (fetchTokenTask.IsCompleted)
             {
-                return _cachedCredentialsProvider
-                    .UpdateState(this, new ActiveState(await fetchTokenTask.ConfigureAwait(false), _cachedCredentialsProvider));
+                return cachedCredentialsProvider
+                    .UpdateState(this,
+                        new ActiveState(await fetchTokenTask.ConfigureAwait(false), cachedCredentialsProvider));
             }
 
             if (now < TokenResponse.ExpiredAt)
@@ -193,19 +172,19 @@ public class CachedCredentialsProvider : ICredentialsProvider
             {
                 var tokenResponse = await fetchTokenTask.ConfigureAwait(false);
 
-                _cachedCredentialsProvider.Logger.LogDebug(
+                cachedCredentialsProvider.Logger.LogDebug(
                     "Successfully fetched token. ExpiredAt: {ExpiredAt}, RefreshAt: {RefreshAt}",
                     tokenResponse.ExpiredAt, tokenResponse.RefreshAt
                 );
 
-                return _cachedCredentialsProvider.UpdateState(this,
-                    new ActiveState(tokenResponse, _cachedCredentialsProvider));
+                return cachedCredentialsProvider.UpdateState(this,
+                    new ActiveState(tokenResponse, cachedCredentialsProvider));
             }
             catch (Exception e)
             {
-                _cachedCredentialsProvider.Logger.LogCritical(e, "Error on authentication token update");
+                cachedCredentialsProvider.Logger.LogCritical(e, "Error on authentication token update");
 
-                return _cachedCredentialsProvider.UpdateState(this, new ErrorState(e, _cachedCredentialsProvider));
+                return cachedCredentialsProvider.UpdateState(this, new ErrorState(e, cachedCredentialsProvider));
             }
         }
 
@@ -213,7 +192,7 @@ public class CachedCredentialsProvider : ICredentialsProvider
         {
             try
             {
-                var tokenResponse = await _cachedCredentialsProvider.FetchToken().ConfigureAwait(false);
+                var tokenResponse = await cachedCredentialsProvider.FetchToken().ConfigureAwait(false);
 
                 _fetchTokenResponseTcs.SetResult(tokenResponse);
             }
@@ -224,21 +203,13 @@ public class CachedCredentialsProvider : ICredentialsProvider
         }
     }
 
-    private class ErrorState : ITokenState
+    private class ErrorState(Exception exception, CachedCredentialsProvider managerCredentialsProvider)
+        : ITokenState
     {
-        private readonly Exception _exception;
-        private readonly CachedCredentialsProvider _managerCredentialsProvider;
+        public TokenResponse TokenResponse => throw exception;
 
-        public ErrorState(Exception exception, CachedCredentialsProvider managerCredentialsProvider)
-        {
-            _exception = exception;
-            _managerCredentialsProvider = managerCredentialsProvider;
-        }
-
-        public TokenResponse TokenResponse => throw _exception;
-
-        public ValueTask<ITokenState> Validate(DateTime now) => _managerCredentialsProvider
-            .UpdateState(this, new SyncState(_managerCredentialsProvider))
+        public ValueTask<ITokenState> Validate(DateTime now) => managerCredentialsProvider
+            .UpdateState(this, new SyncState(managerCredentialsProvider))
             .Validate(now);
     }
 }

--- a/src/Ydb.Sdk/src/Auth/StaticCredentialsAuthClient.cs
+++ b/src/Ydb.Sdk/src/Auth/StaticCredentialsAuthClient.cs
@@ -24,7 +24,7 @@ internal class StaticCredentialsAuthClient : IAuthClient
 
     public Task<TokenResponse> FetchToken() => RetryPolicyExecutor.ExecuteAsync(async _ =>
     {
-        var token = await Login();
+        var token = await Login().ConfigureAwait(false);
 
         return new TokenResponse(token, new JwtSecurityToken(token).ValidTo);
     });
@@ -41,7 +41,7 @@ internal class StaticCredentialsAuthClient : IAuthClient
         using var channel = _grpcChannelFactory.CreateChannel(_config.Endpoint);
 
         var response = await new AuthService.AuthServiceClient(channel)
-            .LoginAsync(request, _config.GetCallMetadata);
+            .LoginAsync(request, _config.GetCallMetadata).ResponseAsync.ConfigureAwait(false);
 
         var operation = response.Operation;
 

--- a/src/Ydb.Sdk/src/Auth/TokenProvider.cs
+++ b/src/Ydb.Sdk/src/Auth/TokenProvider.cs
@@ -7,18 +7,7 @@
 /// TokenProvider provides authentication using a static access token.
 /// This is suitable for scenarios where you have a pre-obtained token.
 /// </remarks>
-public class TokenProvider : ICredentialsProvider
+public class TokenProvider(string token) : ICredentialsProvider
 {
-    private readonly string _token;
-
-    /// <summary>
-    /// Initializes a new instance of the TokenProvider class.
-    /// </summary>
-    /// <param name="token">The access token to use for authentication.</param>
-    public TokenProvider(string token)
-    {
-        _token = token;
-    }
-
-    public ValueTask<string> GetAuthInfoAsync() => ValueTask.FromResult(_token);
+    public ValueTask<string> GetAuthInfoAsync() => ValueTask.FromResult(token);
 }

--- a/src/Ydb.Sdk/src/Driver.cs
+++ b/src/Ydb.Sdk/src/Driver.cs
@@ -52,7 +52,7 @@ public sealed class Driver : BaseDriver
     public static async Task<Driver> CreateInitialized(DriverConfig config, ILoggerFactory? loggerFactory = null)
     {
         var driver = new Driver(config, loggerFactory);
-        await driver.Initialize();
+        await driver.Initialize().ConfigureAwait(false);
         return driver;
     }
 
@@ -70,21 +70,21 @@ public sealed class Driver : BaseDriver
 
         await DiscoveryRetryPolicy.ExecuteAsync(async _ =>
         {
-            await DiscoverEndpoints();
+            await DiscoverEndpoints().ConfigureAwait(false);
             _discoveryTimer = new Timer(
                 OnDiscoveryTimer,
                 null,
                 Config.EndpointDiscoveryInterval,
                 Config.EndpointDiscoveryInterval
             );
-        });
+        }).ConfigureAwait(false);
     }
 
     private async void OnDiscoveryTimer(object? state)
     {
         try
         {
-            await DiscoverEndpoints();
+            await DiscoverEndpoints().ConfigureAwait(false);
         }
         catch (YdbException e)
         {
@@ -145,7 +145,7 @@ public sealed class Driver : BaseDriver
     {
         if (_discoveryTimer != null)
         {
-            await _discoveryTimer.DisposeAsync();
+            await _discoveryTimer.DisposeAsync().ConfigureAwait(false);
         }
     }
 
@@ -162,12 +162,13 @@ public sealed class Driver : BaseDriver
 
             // Discovery is the only call site without a natural per-call ClientInfo; merge the
             // active component chain (registered before driver creation) directly into metadata.
-            var options = await GetCallOptions(grpcSettings, Config.EndpointInfo);
+            var options = await GetCallOptions(grpcSettings, Config.EndpointInfo).ConfigureAwait(false);
             options.Headers?.Add(Metadata.RpcSdkInfoHeader, SdkClientInfoRegistry.Chain is null
                 ? Config.SdkVersion
                 : $"{Config.SdkVersion};{SdkClientInfoRegistry.Chain}");
 
-            var response = await client.ListEndpointsAsync(request: request, options: options);
+            var response = await client.ListEndpointsAsync(request: request, options: options)
+                .ResponseAsync.ConfigureAwait(false);
 
             var operation = response.Operation;
             if (operation.Status.IsNotSuccess())
@@ -188,7 +189,7 @@ public sealed class Driver : BaseDriver
                     var detectedLocation = await _endpointLocalDcDetector.DetectNearestLocationDc(
                         discoveredEndpoints,
                         Config.ConnectTimeout
-                    );
+                    ).ConfigureAwait(false);
 
                     if (!string.IsNullOrEmpty(detectedLocation))
                     {
@@ -226,7 +227,7 @@ public sealed class Driver : BaseDriver
             await ChannelPool.RemoveChannels(_endpointPool.Reset(
                 discoveredEndpoints,
                 preferredLocation
-            ));
+            )).ConfigureAwait(false);
         }
         catch (RpcException e)
         {

--- a/src/Ydb.Sdk/src/IDriver.cs
+++ b/src/Ydb.Sdk/src/IDriver.cs
@@ -220,11 +220,11 @@ public abstract class BaseDriver : IDriver
             using var call = callInvoker.AsyncUnaryCall(
                 method: method,
                 host: null,
-                options: await GetCallOptions(settings, endpointInfo),
+                options: await GetCallOptions(settings, endpointInfo).ConfigureAwait(false),
                 request: request
             );
 
-            return await call.ResponseAsync;
+            return await call.ResponseAsync.ConfigureAwait(false);
         }
         catch (RpcException e)
         {
@@ -253,7 +253,7 @@ public abstract class BaseDriver : IDriver
         var call = callInvoker.AsyncServerStreamingCall(
             method: method,
             host: null,
-            options: await GetCallOptions(settings, endpointInfo),
+            options: await GetCallOptions(settings, endpointInfo).ConfigureAwait(false),
             request: request);
 
         return new ServerStream<TResponse>(call, e => { OnRpcError(endpointInfo, e); });
@@ -273,7 +273,7 @@ public abstract class BaseDriver : IDriver
         var call = callInvoker.AsyncDuplexStreamingCall(
             method: method,
             host: null,
-            options: await GetCallOptions(settings, endpointInfo));
+            options: await GetCallOptions(settings, endpointInfo).ConfigureAwait(false));
 
         return new BidirectionalStream<TRequest, TResponse>(
             call,
@@ -292,7 +292,7 @@ public abstract class BaseDriver : IDriver
 
         if (_credentialsProvider != null)
         {
-            meta.Add(Metadata.RpcAuthHeader, await _credentialsProvider.GetAuthInfoAsync());
+            meta.Add(Metadata.RpcAuthHeader, await _credentialsProvider.GetAuthInfoAsync().ConfigureAwait(false));
         }
 
         if (settings.TraceId.Length > 0)
@@ -385,8 +385,8 @@ public abstract class BaseDriver : IDriver
             }
         }
 
-        await DisposeAsyncCore();
-        await ChannelPool.DisposeAsync();
+        await DisposeAsyncCore().ConfigureAwait(false);
+        await ChannelPool.DisposeAsync().ConfigureAwait(false);
 
         GC.SuppressFinalize(this);
     }
@@ -409,7 +409,7 @@ public sealed class ServerStream<TResponse> : IServerStream<TResponse>
     {
         try
         {
-            return await _stream.ResponseStream.MoveNext(cancellationToken);
+            return await _stream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false);
         }
         catch (RpcException e)
         {
@@ -448,7 +448,7 @@ internal class BidirectionalStream<TRequest, TResponse> : IBidirectionalStream<T
     {
         try
         {
-            await _stream.RequestStream.WriteAsync(request);
+            await _stream.RequestStream.WriteAsync(request).ConfigureAwait(false);
         }
         catch (RpcException e)
         {
@@ -466,7 +466,7 @@ internal class BidirectionalStream<TRequest, TResponse> : IBidirectionalStream<T
     {
         try
         {
-            return await _stream.ResponseStream.MoveNext(CancellationToken.None);
+            return await _stream.ResponseStream.MoveNext(CancellationToken.None).ConfigureAwait(false);
         }
         catch (RpcException e)
         {
@@ -483,14 +483,14 @@ internal class BidirectionalStream<TRequest, TResponse> : IBidirectionalStream<T
     public TResponse Current => _stream.ResponseStream.Current;
 
     public async ValueTask<string?> AuthToken() => _credentialsProvider != null
-        ? await _credentialsProvider.GetAuthInfoAsync()
+        ? await _credentialsProvider.GetAuthInfoAsync().ConfigureAwait(false)
         : null;
 
     public async Task RequestStreamComplete()
     {
         try
         {
-            await _stream.RequestStream.CompleteAsync();
+            await _stream.RequestStream.CompleteAsync().ConfigureAwait(false);
         }
         catch (RpcException e)
         {

--- a/src/Ydb.Sdk/src/Metadata.cs
+++ b/src/Ydb.Sdk/src/Metadata.cs
@@ -20,6 +20,7 @@ internal static class Metadata
     //Incoming hints
     public const string GracefulShutdownHint = "session-close";
 
+    internal static readonly string AdoNetClientInfo = $"ado-net/{YdbSdkVersion.Value}";
     internal static readonly string TopicWriterClientInfo = $"topic-writer/{YdbSdkVersion.Value}";
     internal static readonly string TopicReaderClientInfo = $"topic-reader/{YdbSdkVersion.Value}";
 }

--- a/src/Ydb.Sdk/src/Pool/ChannelPool.cs
+++ b/src/Ydb.Sdk/src/Pool/ChannelPool.cs
@@ -8,21 +8,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Ydb.Sdk.Pool;
 
-internal class ChannelPool<T> : IAsyncDisposable where T : ChannelBase, IDisposable
+internal class ChannelPool<T>(ILoggerFactory loggerFactory, IChannelFactory<T> channelFactory) : IAsyncDisposable
+    where T : ChannelBase, IDisposable
 {
     private readonly ConcurrentDictionary<string, Lazy<T>> _channels = new();
 
-    private readonly ILogger<ChannelPool<T>> _logger;
-    private readonly IChannelFactory<T> _channelFactory;
-
-    public ChannelPool(ILoggerFactory loggerFactory, IChannelFactory<T> channelFactory)
-    {
-        _logger = loggerFactory.CreateLogger<ChannelPool<T>>();
-        _channelFactory = channelFactory;
-    }
+    private readonly ILogger<ChannelPool<T>> _logger = loggerFactory.CreateLogger<ChannelPool<T>>();
 
     public T GetChannel(EndpointInfo endpointInfo) => _channels.GetOrAdd(endpointInfo.Endpoint,
-        new Lazy<T>(() => _channelFactory.CreateChannel(endpointInfo.Endpoint))).Value;
+        new Lazy<T>(() => channelFactory.CreateChannel(endpointInfo.Endpoint))).Value;
 
     public async ValueTask RemoveChannels(IReadOnlyList<EndpointInfo> removedEndpoints)
     {
@@ -43,10 +37,11 @@ internal class ChannelPool<T> : IAsyncDisposable where T : ChannelBase, IDisposa
     {
         GC.SuppressFinalize(this);
 
-        await ShutdownChannels(_channels.Values
-            .Where(lazyChannel => lazyChannel.IsValueCreated)
-            .Select(lazyChannel => lazyChannel.Value)
-            .ToImmutableArray()
+        await ShutdownChannels([
+                .._channels.Values
+                    .Where(lazyChannel => lazyChannel.IsValueCreated)
+                    .Select(lazyChannel => lazyChannel.Value)
+            ]
         ).ConfigureAwait(false);
     }
 

--- a/src/Ydb.Sdk/src/Pool/ChannelPool.cs
+++ b/src/Ydb.Sdk/src/Pool/ChannelPool.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Grpc.Core;

--- a/src/Ydb.Sdk/src/Pool/ChannelPool.cs
+++ b/src/Ydb.Sdk/src/Pool/ChannelPool.cs
@@ -36,7 +36,7 @@ internal class ChannelPool<T> : IAsyncDisposable where T : ChannelBase, IDisposa
             }
         }
 
-        await ShutdownChannels(shutdownGrpcChannels);
+        await ShutdownChannels(shutdownGrpcChannels).ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
@@ -47,7 +47,7 @@ internal class ChannelPool<T> : IAsyncDisposable where T : ChannelBase, IDisposa
             .Where(lazyChannel => lazyChannel.IsValueCreated)
             .Select(lazyChannel => lazyChannel.Value)
             .ToImmutableArray()
-        );
+        ).ConfigureAwait(false);
     }
 
     private async ValueTask ShutdownChannels(ICollection<T> channels)
@@ -56,7 +56,7 @@ internal class ChannelPool<T> : IAsyncDisposable where T : ChannelBase, IDisposa
         {
             try
             {
-                await channel.ShutdownAsync();
+                await channel.ShutdownAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
+++ b/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
@@ -57,7 +57,8 @@ internal sealed class EndpointLocalDcDetector(ILoggerFactory loggerFactory, ITcp
             );
         }
 
-        var fastestEndpoint = await DetectFastestEndpoint(endpointsToTest, timeout, cancellationToken).ConfigureAwait(false);
+        var fastestEndpoint = await DetectFastestEndpoint(endpointsToTest, timeout, cancellationToken)
+            .ConfigureAwait(false);
         if (fastestEndpoint is null)
         {
             _logger.LogDebug("Failed to detect nearest DC via TCP race: no endpoint connected in time");
@@ -102,7 +103,8 @@ internal sealed class EndpointLocalDcDetector(ILoggerFactory loggerFactory, ITcp
     {
         try
         {
-            await _tcpConnector.ConnectAsync(endpoint.Host, checked((int)endpoint.Port), cts.Token).ConfigureAwait(false);
+            await _tcpConnector.ConnectAsync(endpoint.Host, checked((int)endpoint.Port), cts.Token)
+                .ConfigureAwait(false);
 
             if (winner.TrySetResult(endpoint))
             {

--- a/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
+++ b/src/Ydb.Sdk/src/Pool/EndpointLocalDcDetector.cs
@@ -57,7 +57,7 @@ internal sealed class EndpointLocalDcDetector(ILoggerFactory loggerFactory, ITcp
             );
         }
 
-        var fastestEndpoint = await DetectFastestEndpoint(endpointsToTest, timeout, cancellationToken);
+        var fastestEndpoint = await DetectFastestEndpoint(endpointsToTest, timeout, cancellationToken).ConfigureAwait(false);
         if (fastestEndpoint is null)
         {
             _logger.LogDebug("Failed to detect nearest DC via TCP race: no endpoint connected in time");
@@ -81,7 +81,7 @@ internal sealed class EndpointLocalDcDetector(ILoggerFactory loggerFactory, ITcp
 
         try
         {
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
@@ -89,7 +89,7 @@ internal sealed class EndpointLocalDcDetector(ILoggerFactory loggerFactory, ITcp
 
         if (winner.Task.IsCompletedSuccessfully)
         {
-            return await winner.Task;
+            return await winner.Task.ConfigureAwait(false);
         }
 
         return null;
@@ -102,7 +102,7 @@ internal sealed class EndpointLocalDcDetector(ILoggerFactory loggerFactory, ITcp
     {
         try
         {
-            await _tcpConnector.ConnectAsync(endpoint.Host, checked((int)endpoint.Port), cts.Token);
+            await _tcpConnector.ConnectAsync(endpoint.Host, checked((int)endpoint.Port), cts.Token).ConfigureAwait(false);
 
             if (winner.TrySetResult(endpoint))
             {
@@ -160,7 +160,7 @@ internal sealed class SocketTcpConnector : ITcpConnector
 {
     public async Task ConnectAsync(string host, int port, CancellationToken cancellationToken)
     {
-        var addresses = await Dns.GetHostAddressesAsync(host, cancellationToken);
+        var addresses = await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
         if (addresses.Length == 0)
         {
             throw new SocketException((int)SocketError.HostNotFound);
@@ -174,7 +174,7 @@ internal sealed class SocketTcpConnector : ITcpConnector
             try
             {
                 using var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-                await socket.ConnectAsync(new IPEndPoint(address, port), cancellationToken);
+                await socket.ConnectAsync(new IPEndPoint(address, port), cancellationToken).ConfigureAwait(false);
                 return;
             }
             catch (SocketException e)

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -110,7 +110,8 @@ internal class Reader<TValue> : IReader<TValue>
             _logger.LogInformation("Reader session initialization started. ReaderConfig: {ReaderConfig}", _config);
 
             var stream = await (_driver ??= await PoolManager.GetDriver(_driverFactory).ConfigureAwait(false))
-                .BidirectionalStreamCall(TopicService.StreamReadMethod, _readerGrpcRequestSettings).ConfigureAwait(false);
+                .BidirectionalStreamCall(TopicService.StreamReadMethod, _readerGrpcRequestSettings)
+                .ConfigureAwait(false);
 
             var initRequest = new StreamReadMessage.Types.InitRequest();
             if (_config.ConsumerName != null)
@@ -328,13 +329,15 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                         await HandleReadResponse(messageFromServer.ReadResponse).ConfigureAwait(false);
                         break;
                     case ServerMessageOneofCase.StartPartitionSessionRequest:
-                        await HandleStartPartitionSessionRequest(messageFromServer.StartPartitionSessionRequest).ConfigureAwait(false);
+                        await HandleStartPartitionSessionRequest(messageFromServer.StartPartitionSessionRequest)
+                            .ConfigureAwait(false);
                         break;
                     case ServerMessageOneofCase.CommitOffsetResponse:
                         HandleCommitOffsetResponse(messageFromServer.CommitOffsetResponse);
                         break;
                     case ServerMessageOneofCase.StopPartitionSessionRequest:
-                        await StopPartitionSessionRequest(messageFromServer.StopPartitionSessionRequest).ConfigureAwait(false);
+                        await StopPartitionSessionRequest(messageFromServer.StopPartitionSessionRequest)
+                            .ConfigureAwait(false);
                         break;
                     case ServerMessageOneofCase.PartitionSessionStatusResponse:
                     case ServerMessageOneofCase.UpdateTokenResponse:
@@ -366,7 +369,8 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     {
         try
         {
-            await foreach (var messageFromClient in _channelFromClientMessageSending.Reader.ReadAllAsync().ConfigureAwait(false))
+            await foreach (var messageFromClient in _channelFromClientMessageSending.Reader.ReadAllAsync()
+                               .ConfigureAwait(false))
             {
                 await SendMessage(messageFromClient).ConfigureAwait(false);
             }
@@ -394,8 +398,10 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
 
         if (Interlocked.CompareExchange(ref _readRequestBytes, 0, readRequestBytes) == readRequestBytes)
         {
-            await _channelFromClientMessageSending.Writer.WriteAsync(new MessageFromClient
-                { ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = readRequestBytes } }).ConfigureAwait(false);
+            await _channelFromClientMessageSending.Writer
+                .WriteAsync(new MessageFromClient
+                    { ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = readRequestBytes } })
+                .ConfigureAwait(false);
         }
     }
 

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -225,7 +225,7 @@ internal class Reader<TValue> : IReader<TValue>
         _receivedMessagesChannel.Writer.TryComplete();
         _disposeCts.Cancel();
 
-        await ((_currentReaderSession?.DisposeAsync() ?? ValueTask.CompletedTask).ConfigureAwait(false));
+        await (_currentReaderSession?.DisposeAsync() ?? ValueTask.CompletedTask).ConfigureAwait(false);
         if (_driver != null)
         {
             await _driver.DisposeAsync().ConfigureAwait(false);

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -55,7 +55,7 @@ internal class Reader<TValue> : IReader<TValue>
 
     public async ValueTask<Message<TValue>> ReadAsync(CancellationToken cancellationToken = default)
     {
-        while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken))
+        while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
             if (_receivedMessagesChannel.Reader.TryPeek(out var batchInternalMessage))
             {
@@ -80,7 +80,7 @@ internal class Reader<TValue> : IReader<TValue>
 
     public async ValueTask<BatchMessages<TValue>> ReadBatchAsync(CancellationToken cancellationToken = default)
     {
-        while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken))
+        while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
             if (!_receivedMessagesChannel.Reader.TryRead(out var batchInternalMessage))
             {
@@ -109,8 +109,8 @@ internal class Reader<TValue> : IReader<TValue>
 
             _logger.LogInformation("Reader session initialization started. ReaderConfig: {ReaderConfig}", _config);
 
-            var stream = await (_driver ??= await PoolManager.GetDriver(_driverFactory))
-                .BidirectionalStreamCall(TopicService.StreamReadMethod, _readerGrpcRequestSettings);
+            var stream = await (_driver ??= await PoolManager.GetDriver(_driverFactory).ConfigureAwait(false))
+                .BidirectionalStreamCall(TopicService.StreamReadMethod, _readerGrpcRequestSettings).ConfigureAwait(false);
 
             var initRequest = new StreamReadMessage.Types.InitRequest();
             if (_config.ConsumerName != null)
@@ -150,8 +150,8 @@ internal class Reader<TValue> : IReader<TValue>
 
             _logger.LogDebug("Sending initialization request for the read stream: {InitRequest}", initRequest);
 
-            await stream.Write(new MessageFromClient { InitRequest = initRequest });
-            if (!await stream.MoveNextAsync())
+            await stream.Write(new MessageFromClient { InitRequest = initRequest }).ConfigureAwait(false);
+            if (!await stream.MoveNextAsync().ConfigureAwait(false))
             {
                 _logger.LogError("Stream unexpectedly closed by YDB server. Current InitRequest: {InitRequest}",
                     initRequest);
@@ -193,14 +193,14 @@ internal class Reader<TValue> : IReader<TValue>
             await stream.Write(new MessageFromClient
             {
                 ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = _config.MemoryUsageMaxBytes }
-            });
+            }).ConfigureAwait(false);
 
             _currentReaderSession = new ReaderSession<TValue>(
                 _config,
                 stream,
                 initResponse.SessionId,
                 Initialize,
-                await stream.AuthToken(),
+                await stream.AuthToken().ConfigureAwait(false),
                 _logger,
                 _receivedMessagesChannel.Writer,
                 _deserializer
@@ -224,10 +224,10 @@ internal class Reader<TValue> : IReader<TValue>
         _receivedMessagesChannel.Writer.TryComplete();
         _disposeCts.Cancel();
 
-        await (_currentReaderSession?.DisposeAsync() ?? ValueTask.CompletedTask);
+        await ((_currentReaderSession?.DisposeAsync() ?? ValueTask.CompletedTask).ConfigureAwait(false));
         if (_driver != null)
         {
-            await _driver.DisposeAsync();
+            await _driver.DisposeAsync().ConfigureAwait(false);
         }
 
         SdkClientInfoRegistry.Unregister(Sdk.Metadata.TopicReaderClientInfo);
@@ -310,7 +310,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     {
         try
         {
-            while (await Stream.MoveNextAsync())
+            while (await Stream.MoveNextAsync().ConfigureAwait(false))
             {
                 var messageFromServer = Stream.Current;
 
@@ -325,16 +325,16 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                 switch (messageFromServer.ServerMessageCase)
                 {
                     case ServerMessageOneofCase.ReadResponse:
-                        await HandleReadResponse(messageFromServer.ReadResponse);
+                        await HandleReadResponse(messageFromServer.ReadResponse).ConfigureAwait(false);
                         break;
                     case ServerMessageOneofCase.StartPartitionSessionRequest:
-                        await HandleStartPartitionSessionRequest(messageFromServer.StartPartitionSessionRequest);
+                        await HandleStartPartitionSessionRequest(messageFromServer.StartPartitionSessionRequest).ConfigureAwait(false);
                         break;
                     case ServerMessageOneofCase.CommitOffsetResponse:
                         HandleCommitOffsetResponse(messageFromServer.CommitOffsetResponse);
                         break;
                     case ServerMessageOneofCase.StopPartitionSessionRequest:
-                        await StopPartitionSessionRequest(messageFromServer.StopPartitionSessionRequest);
+                        await StopPartitionSessionRequest(messageFromServer.StopPartitionSessionRequest).ConfigureAwait(false);
                         break;
                     case ServerMessageOneofCase.PartitionSessionStatusResponse:
                     case ServerMessageOneofCase.UpdateTokenResponse:
@@ -366,9 +366,9 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     {
         try
         {
-            await foreach (var messageFromClient in _channelFromClientMessageSending.Reader.ReadAllAsync())
+            await foreach (var messageFromClient in _channelFromClientMessageSending.Reader.ReadAllAsync().ConfigureAwait(false))
             {
-                await SendMessage(messageFromClient);
+                await SendMessage(messageFromClient).ConfigureAwait(false);
             }
         }
         catch (Exception e)
@@ -395,7 +395,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         if (Interlocked.CompareExchange(ref _readRequestBytes, 0, readRequestBytes) == readRequestBytes)
         {
             await _channelFromClientMessageSending.Writer.WriteAsync(new MessageFromClient
-                { ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = readRequestBytes } });
+                { ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = readRequestBytes } }).ConfigureAwait(false);
         }
     }
 
@@ -424,7 +424,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                 PartitionSessionId = partitionSession.PartitionSessionId
                 /* Simple client doesn't have read_offset or commit_offset settings */
             }
-        });
+        }).ConfigureAwait(false);
     }
 
     private void HandleCommitOffsetResponse(StreamReadMessage.Types.CommitOffsetResponse commitOffsetResponse)
@@ -466,7 +466,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                 {
                     StopPartitionSessionResponse = new StreamReadMessage.Types.StopPartitionSessionResponse
                         { PartitionSessionId = partitionSession.PartitionSessionId }
-                });
+                }).ConfigureAwait(false);
             }
         }
         else
@@ -483,7 +483,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
 
         await using var register = _lifecycleReaderSessionCts.Token.Register(() =>
             tcsCommit.TrySetException(new ReaderException($"ReaderSession[{SessionId}] was deactivated"))
-        );
+        ).ConfigureAwait(false);
 
         var commitSending = new CommitSending(offsetsRange, tcsCommit);
 
@@ -507,7 +507,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                             }
                         }
                     }
-                );
+                ).ConfigureAwait(false);
             }
             catch (ChannelClosedException)
             {
@@ -523,7 +523,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
             Utils.SetPartitionClosedException(commitSending, partitionSessionId);
         }
 
-        await tcsCommit.Task;
+        await tcsCommit.Task.ConfigureAwait(false);
     }
 
     private async Task HandleReadResponse(StreamReadMessage.Types.ReadResponse readResponse)
@@ -560,7 +560,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                             ),
                             _deserializer
                         )
-                    );
+                    ).ConfigureAwait(false);
                 }
             }
             else
@@ -590,11 +590,11 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
 
         try
         {
-            await _runProcessingStreamRequest;
-            await Stream.RequestStreamComplete();
+            await _runProcessingStreamRequest.ConfigureAwait(false);
+            await Stream.RequestStreamComplete().ConfigureAwait(false);
             Logger.LogInformation("ReaderSession[{SessionId}]: RequestStream is closed", SessionId);
 
-            await _runProcessingStreamResponse; // waiting all ack's commits
+            await _runProcessingStreamResponse.ConfigureAwait(false); // waiting all ack's commits
         }
         catch (Exception e)
         {

--- a/src/Ydb.Sdk/src/Topic/TopicClient.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicClient.cs
@@ -92,7 +92,9 @@ public sealed class TopicClient : IAsyncDisposable
             protoSettings.Consumers.Add(protoConsumer);
         }
 
-        var response = await _driver.UnaryCall(TopicService.CreateTopicMethod, protoSettings, settings).ConfigureAwait(false);
+        var response = await _driver
+            .UnaryCall(TopicService.CreateTopicMethod, protoSettings, settings)
+            .ConfigureAwait(false);
 
         if (response.Operation.Status.IsNotSuccess())
         {

--- a/src/Ydb.Sdk/src/Topic/TopicClient.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicClient.cs
@@ -92,7 +92,7 @@ public sealed class TopicClient : IAsyncDisposable
             protoSettings.Consumers.Add(protoConsumer);
         }
 
-        var response = await _driver.UnaryCall(TopicService.CreateTopicMethod, protoSettings, settings);
+        var response = await _driver.UnaryCall(TopicService.CreateTopicMethod, protoSettings, settings).ConfigureAwait(false);
 
         if (response.Operation.Status.IsNotSuccess())
         {
@@ -108,7 +108,7 @@ public sealed class TopicClient : IAsyncDisposable
         };
 
         var response = await _driver.UnaryCall(TopicService.DropTopicMethod, protoSettings,
-            settings ?? new GrpcRequestSettings());
+            settings ?? new GrpcRequestSettings()).ConfigureAwait(false);
 
         if (response.Operation.Status.IsNotSuccess())
         {

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -2,30 +2,20 @@ using Microsoft.Extensions.Logging;
 
 namespace Ydb.Sdk.Topic;
 
-internal abstract class TopicSession<TFromClient, TFromServer> : IAsyncDisposable
+internal abstract class TopicSession<TFromClient, TFromServer>(
+    IBidirectionalStream<TFromClient, TFromServer> stream,
+    ILogger logger,
+    string sessionId,
+    Func<Task> initialize,
+    string? lastToken
+) : IAsyncDisposable
 {
-    private readonly Func<Task> _initialize;
-
-    protected readonly IBidirectionalStream<TFromClient, TFromServer> Stream;
-    protected readonly ILogger Logger;
-    protected readonly string SessionId;
+    protected readonly IBidirectionalStream<TFromClient, TFromServer> Stream = stream;
+    protected readonly ILogger Logger = logger;
+    protected readonly string SessionId = sessionId;
 
     private int _isActive = 1;
-    private string? _lastToken;
-
-    protected TopicSession(
-        IBidirectionalStream<TFromClient, TFromServer> stream,
-        ILogger logger,
-        string sessionId,
-        Func<Task> initialize,
-        string? lastToken)
-    {
-        Stream = stream;
-        Logger = logger;
-        SessionId = sessionId;
-        _initialize = initialize;
-        _lastToken = lastToken;
-    }
+    private string? _lastToken = lastToken;
 
     public bool IsActive => Volatile.Read(ref _isActive) == 1;
 
@@ -40,7 +30,7 @@ internal abstract class TopicSession<TFromClient, TFromServer> : IAsyncDisposabl
 
         Logger.LogDebug("TopicSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
 
-        _ = Task.Run(() => _initialize());
+        _ = Task.Run(initialize);
     }
 
     protected async Task SendMessage(TFromClient fromClient)

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -45,7 +45,7 @@ internal abstract class TopicSession<TFromClient, TFromServer> : IAsyncDisposabl
 
     protected async Task SendMessage(TFromClient fromClient)
     {
-        var curAuthToken = await Stream.AuthToken();
+        var curAuthToken = await Stream.AuthToken().ConfigureAwait(false);
 
         if (!string.Equals(_lastToken, curAuthToken) && curAuthToken != null)
         {
@@ -53,10 +53,10 @@ internal abstract class TopicSession<TFromClient, TFromServer> : IAsyncDisposabl
 
             _lastToken = curAuthToken;
 
-            await Stream.Write(updateTokenRequest);
+            await Stream.Write(updateTokenRequest).ConfigureAwait(false);
         }
 
-        await Stream.Write(fromClient);
+        await Stream.Write(fromClient).ConfigureAwait(false);
     }
 
     protected abstract TFromClient GetSendUpdateTokenRequest(string token);

--- a/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
@@ -58,11 +58,12 @@ internal class Writer<TValue> : IWriter<TValue>
         TaskCompletionSource<WriteResult> tcs = new();
         await using var registrationUserCancellationTokenRegistration = cancellationToken.Register(
             () => tcs.TrySetCanceled(), useSynchronizationContext: false
-        );
-        await using var writerDisposedCancellationTokenRegistration = _disposeCts.Token.Register(
+        ).ConfigureAwait(false);
+        var writerDisposedCancellationTokenRegistration = _disposeCts.Token.Register(
             () => tcs.TrySetException(new WriterException($"Writer[{_config}] is disposed")),
             useSynchronizationContext: false
         );
+        await using var _ = writerDisposedCancellationTokenRegistration.ConfigureAwait(false);
 
         byte[] data;
         try
@@ -115,7 +116,7 @@ internal class Writer<TValue> : IWriter<TValue>
 
             try
             {
-                await WaitBufferAvailable(cancellationToken);
+                await WaitBufferAvailable(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -125,7 +126,7 @@ internal class Writer<TValue> : IWriter<TValue>
 
         try
         {
-            var writeResult = await tcs.Task;
+            var writeResult = await tcs.Task.ConfigureAwait(false);
 
             return writeResult;
         }
@@ -141,7 +142,7 @@ internal class Writer<TValue> : IWriter<TValue>
     {
         var tcsBufferAvailableEvent = _tcsBufferAvailableEvent;
 
-        await tcsBufferAvailableEvent.Task.WaitAsync(cancellationToken);
+        await tcsBufferAvailableEvent.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         Interlocked.CompareExchange(
             ref _tcsBufferAvailableEvent,
@@ -158,7 +159,7 @@ internal class Writer<TValue> : IWriter<TValue>
             {
                 try
                 {
-                    _driver = await PoolManager.GetDriver(_driverFactory);
+                    _driver = await PoolManager.GetDriver(_driverFactory).ConfigureAwait(false);
                     break;
                 }
                 catch (Exception e)
@@ -169,13 +170,13 @@ internal class Writer<TValue> : IWriter<TValue>
                 }
             }
 
-            await Initialize();
+            await Initialize().ConfigureAwait(false);
 
             try
             {
                 while (!_disposeCts.IsCancellationRequested)
                 {
-                    await _tcsWakeUp.Task.WaitAsync(_disposeCts.Token);
+                    await _tcsWakeUp.Task.WaitAsync(_disposeCts.Token).ConfigureAwait(false);
                     _tcsWakeUp = new TaskCompletionSource();
 
                     if (_toSendBuffer.IsEmpty)
@@ -183,12 +184,12 @@ internal class Writer<TValue> : IWriter<TValue>
                         continue;
                     }
 
-                    await _sendInFlightMessagesSemaphoreSlim.WaitAsync(_disposeCts.Token);
+                    await _sendInFlightMessagesSemaphoreSlim.WaitAsync(_disposeCts.Token).ConfigureAwait(false);
                     try
                     {
                         if (_session.IsActive)
                         {
-                            await _session.Write(_toSendBuffer);
+                            await _session.Write(_toSendBuffer).ConfigureAwait(false);
                         }
                     }
                     finally
@@ -226,7 +227,7 @@ internal class Writer<TValue> : IWriter<TValue>
             _logger.LogInformation("Writer session initialization started. WriterConfig: {WriterConfig}", _config);
 
             var stream =
-                await _driver!.BidirectionalStreamCall(TopicService.StreamWriteMethod, _writerGrpcRequestSettings);
+                await _driver!.BidirectionalStreamCall(TopicService.StreamWriteMethod, _writerGrpcRequestSettings).ConfigureAwait(false);
 
             var initRequest = new StreamWriteMessage.Types.InitRequest { Path = _config.TopicPath };
             if (_config.ProducerId != null)
@@ -241,8 +242,8 @@ internal class Writer<TValue> : IWriter<TValue>
 
             _logger.LogDebug("Sending initialization request for the write stream: {InitRequest}", initRequest);
 
-            await stream.Write(new MessageFromClient { InitRequest = initRequest });
-            if (!await stream.MoveNextAsync())
+            await stream.Write(new MessageFromClient { InitRequest = initRequest }).ConfigureAwait(false);
+            if (!await stream.MoveNextAsync().ConfigureAwait(false))
             {
                 _logger.LogError("Stream unexpectedly closed by YDB server. Current InitRequest: {initRequest}",
                     initRequest);
@@ -292,7 +293,7 @@ internal class Writer<TValue> : IWriter<TValue>
                 return;
             }
 
-            await _sendInFlightMessagesSemaphoreSlim.WaitAsync();
+            await _sendInFlightMessagesSemaphoreSlim.WaitAsync().ConfigureAwait(false);
             try
             {
                 var copyInFlightMessages = new ConcurrentQueue<MessageSending>();
@@ -325,14 +326,14 @@ internal class Writer<TValue> : IWriter<TValue>
                     lastSeqNo: lastSeqNo,
                     sessionId: initResponse.SessionId,
                     initialize: Initialize,
-                    await stream.AuthToken(),
+                    await stream.AuthToken().ConfigureAwait(false),
                     logger: _logger,
                     inFlightMessages: _inFlightMessages
                 );
 
                 if (!copyInFlightMessages.IsEmpty)
                 {
-                    await newSession.Write(copyInFlightMessages); // retry prev in flight messages    
+                    await newSession.Write(copyInFlightMessages).ConfigureAwait(false); // retry prev in flight messages    
                 }
 
                 _session = newSession;
@@ -362,7 +363,7 @@ internal class Writer<TValue> : IWriter<TValue>
             return;
         }
 
-        await _sendInFlightMessagesSemaphoreSlim.WaitAsync();
+        await _sendInFlightMessagesSemaphoreSlim.WaitAsync().ConfigureAwait(false);
         try
         {
             _logger.LogDebug("Signaling cancellation token to stop writing new messages");
@@ -380,7 +381,7 @@ internal class Writer<TValue> : IWriter<TValue>
         {
             try
             {
-                await inFlightMessage.Tcs.Task;
+                await inFlightMessage.Tcs.Task.ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -391,10 +392,10 @@ internal class Writer<TValue> : IWriter<TValue>
 
         _isStopped = true;
 
-        await _session.DisposeAsync();
+        await _session.DisposeAsync().ConfigureAwait(false);
         if (_driver != null)
         {
-            await _driver.DisposeAsync();
+            await _driver.DisposeAsync().ConfigureAwait(false);
         }
 
         SdkClientInfoRegistry.Unregister(Sdk.Metadata.TopicWriterClientInfo);
@@ -526,7 +527,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
             }
 
             Volatile.Write(ref _seqNum, currentSeqNum);
-            await SendMessage(new MessageFromClient { WriteRequest = writeMessage });
+            await SendMessage(new MessageFromClient { WriteRequest = writeMessage }).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -543,7 +544,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         {
             Logger.LogInformation("WriterSession[{SessionId}] is running processing writeAck", SessionId);
 
-            while (await Stream.MoveNextAsync())
+            while (await Stream.MoveNextAsync().ConfigureAwait(false))
             {
                 var messageFromServer = Stream.Current;
 
@@ -646,8 +647,8 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         {
             Logger.LogDebug("WriterSession[{SessionId}]: start dispose process", SessionId);
 
-            await Stream.RequestStreamComplete();
-            await _processingResponseStream;
+            await Stream.RequestStreamComplete().ConfigureAwait(false);
+            await _processingResponseStream.ConfigureAwait(false);
         }
         catch (Exception e)
         {

--- a/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
@@ -227,7 +227,8 @@ internal class Writer<TValue> : IWriter<TValue>
             _logger.LogInformation("Writer session initialization started. WriterConfig: {WriterConfig}", _config);
 
             var stream =
-                await _driver!.BidirectionalStreamCall(TopicService.StreamWriteMethod, _writerGrpcRequestSettings).ConfigureAwait(false);
+                await _driver!.BidirectionalStreamCall(TopicService.StreamWriteMethod, _writerGrpcRequestSettings)
+                    .ConfigureAwait(false);
 
             var initRequest = new StreamWriteMessage.Types.InitRequest { Path = _config.TopicPath };
             if (_config.ProducerId != null)
@@ -333,7 +334,8 @@ internal class Writer<TValue> : IWriter<TValue>
 
                 if (!copyInFlightMessages.IsEmpty)
                 {
-                    await newSession.Write(copyInFlightMessages).ConfigureAwait(false); // retry prev in flight messages    
+                    await newSession.Write(copyInFlightMessages)
+                        .ConfigureAwait(false); // retry prev in flight messages    
                 }
 
                 _session = newSession;

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/ConfigureAwaitDeadlockTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/ConfigureAwaitDeadlockTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
+using Xunit;
+
+namespace Ydb.Sdk.Ado.Tests;
+
+/// <summary>
+/// Regression tests for https://github.com/ydb-platform/ydb-dotnet-sdk/issues/647
+///
+/// The SDK exposes synchronous APIs (e.g. <see cref="YdbConnection.Open"/>) that are implemented
+/// as sync-over-async (<c>OpenAsync().GetAwaiter().GetResult()</c>). If any <c>await</c> inside the
+/// async implementation does not call <c>ConfigureAwait(false)</c>, the continuation is posted back
+/// to the captured <see cref="SynchronizationContext"/>. When a caller blocks that single-threaded
+/// context (the classic WPF/WinForms UI thread scenario), the continuation can never run and the
+/// thread deadlocks.
+///
+/// Each test runs a blocking SDK call on a dedicated thread that owns a single-threaded
+/// <see cref="SynchronizationContext"/> and fails if the call does not finish in time.
+/// </summary>
+public class ConfigureAwaitDeadlockTests : TestBase
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public void Open_OnSingleThreadedSynchronizationContext_DoesNotDeadlock()
+    {
+        AssertNoDeadlock(() =>
+        {
+            using var connection = CreateConnection();
+            connection.Open();
+        });
+    }
+
+    [Fact]
+    public void ExecuteScalar_OnSingleThreadedSynchronizationContext_DoesNotDeadlock()
+    {
+        AssertNoDeadlock(() =>
+        {
+            using var connection = CreateConnection();
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1;";
+
+            Assert.Equal(1, command.ExecuteScalar());
+        });
+    }
+
+    private static void AssertNoDeadlock(Action blockingCall)
+    {
+        using var context = new SingleThreadSynchronizationContext();
+
+        var completed = context.TryRun(blockingCall, Timeout, out var error);
+
+        Assert.True(completed,
+            "Detected a deadlock: a synchronous SDK call did not complete within the timeout while running on a " +
+            "single-threaded SynchronizationContext. This usually means an 'await' is missing 'ConfigureAwait(false)'.");
+
+        if (error != null)
+        {
+            ExceptionDispatchInfo.Capture(error).Throw();
+        }
+    }
+
+    /// <summary>
+    /// A minimal single-threaded <see cref="SynchronizationContext"/> backed by one dedicated thread
+    /// that pumps a queue of callbacks, mimicking a UI message loop.
+    /// </summary>
+    private sealed class SingleThreadSynchronizationContext : SynchronizationContext, IDisposable
+    {
+        private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _queue = new();
+        private readonly Thread _thread;
+
+        public SingleThreadSynchronizationContext()
+        {
+            _thread = new Thread(PumpMessages) { IsBackground = true, Name = nameof(SingleThreadSynchronizationContext) };
+            _thread.Start();
+        }
+
+        public override void Post(SendOrPostCallback d, object? state) => _queue.Add((d, state));
+
+        public override void Send(SendOrPostCallback d, object? state) =>
+            throw new NotSupportedException("Synchronous Send is not supported by this context.");
+
+        /// <summary>
+        /// Queues <paramref name="action"/> onto the single thread and blocks the caller until it finishes
+        /// or <paramref name="timeout"/> elapses. The action itself runs on the dedicated thread, so any
+        /// continuation that captures this context can only run if that thread is free to pump — which is
+        /// exactly what a sync-over-async call without ConfigureAwait(false) would prevent.
+        /// </summary>
+        public bool TryRun(Action action, TimeSpan timeout, out Exception? error)
+        {
+            using var finished = new ManualResetEventSlim(false);
+            Exception? captured = null;
+
+            Post(_ =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception e)
+                {
+                    captured = e;
+                }
+                finally
+                {
+                    finished.Set();
+                }
+            }, null);
+
+            var completed = finished.Wait(timeout);
+            error = captured;
+
+            return completed;
+        }
+
+        private void PumpMessages()
+        {
+            SetSynchronizationContext(this);
+
+            foreach (var (callback, state) in _queue.GetConsumingEnumerable())
+            {
+                callback(state);
+            }
+        }
+
+        public void Dispose() => _queue.CompleteAdding();
+    }
+}

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/ConfigureAwaitDeadlockTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/ConfigureAwaitDeadlockTests.cs
@@ -22,18 +22,15 @@ public class ConfigureAwaitDeadlockTests : TestBase
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
 
     [Fact]
-    public void Open_OnSingleThreadedSynchronizationContext_DoesNotDeadlock()
-    {
+    public void Open_OnSingleThreadedSynchronizationContext_DoesNotDeadlock() =>
         AssertNoDeadlock(() =>
         {
             using var connection = CreateConnection();
             connection.Open();
         });
-    }
 
     [Fact]
-    public void ExecuteScalar_OnSingleThreadedSynchronizationContext_DoesNotDeadlock()
-    {
+    public void ExecuteScalar_OnSingleThreadedSynchronizationContext_DoesNotDeadlock() =>
         AssertNoDeadlock(() =>
         {
             using var connection = CreateConnection();
@@ -44,7 +41,6 @@ public class ConfigureAwaitDeadlockTests : TestBase
 
             Assert.Equal(1, command.ExecuteScalar());
         });
-    }
 
     private static void AssertNoDeadlock(Action blockingCall)
     {
@@ -69,12 +65,12 @@ public class ConfigureAwaitDeadlockTests : TestBase
     private sealed class SingleThreadSynchronizationContext : SynchronizationContext, IDisposable
     {
         private readonly BlockingCollection<(SendOrPostCallback Callback, object? State)> _queue = new();
-        private readonly Thread _thread;
 
         public SingleThreadSynchronizationContext()
         {
-            _thread = new Thread(PumpMessages) { IsBackground = true, Name = nameof(SingleThreadSynchronizationContext) };
-            _thread.Start();
+            var thread = new Thread(PumpMessages)
+                { IsBackground = true, Name = nameof(SingleThreadSynchronizationContext) };
+            thread.Start();
         }
 
         public override void Post(SendOrPostCallback d, object? state) => _queue.Add((d, state));
@@ -105,6 +101,7 @@ public class ConfigureAwaitDeadlockTests : TestBase
                 }
                 finally
                 {
+                    // ReSharper disable once AccessToDisposedClosure
                     finished.Set();
                 }
             }, null);


### PR DESCRIPTION
Blocking on the SDK synchronous APIs (e.g. YdbConnection.Open) from a thread with a SynchronizationContext (WPF/WinForms) could deadlock because awaited continuations were posted back to the captured, blocked context.

- Enable CA2007 for the library source and add ConfigureAwait(false) to all Task/ValueTask awaits.
- Fix raw gRPC AsyncUnaryCall awaits (Discovery, Login) that CA2007 cannot detect, by awaiting .ResponseAsync.ConfigureAwait(false).
- Add a regression test that runs blocking calls on a single-threaded SynchronizationContext and fails on deadlock.