### PR TITLE
test(efcore): enable TPC inheritance bulk update tests in CI

### DIFF
--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesYdbFixture.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesYdbFixture.cs
@@ -1,6 +1,6 @@
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
-internal class TpcFiltersInheritanceBulkUpdatesYdbFixture : TpcInheritanceBulkUpdatesYdbFixture
+public class TpcFiltersInheritanceBulkUpdatesYdbFixture : TpcInheritanceBulkUpdatesYdbFixture
 {
     public override bool EnableFilters => true;
 }

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPCFiltersInheritanceBulkUpdatesYdbTest.cs
@@ -6,7 +6,7 @@ using static EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities.SharedTestMet
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
 #pragma warning disable xUnit1000
-internal class TpcFiltersInheritanceBulkUpdatesYdbTest(
+public class TpcFiltersInheritanceBulkUpdatesYdbTest(
 #pragma warning restore xUnit1000
     TpcFiltersInheritanceBulkUpdatesYdbFixture fixture,
     ITestOutputHelper testOutputHelper
@@ -47,8 +47,6 @@ internal class TpcFiltersInheritanceBulkUpdatesYdbTest(
             async
         );
 
-    [ConditionalTheory(Skip = "TODO: need fix")]
-    [MemberData(nameof(IsAsyncData))]
     public override Task Update_base_type(bool async)
         => AssertYdb(
             base.Update_base_type,
@@ -126,7 +124,7 @@ internal class TpcFiltersInheritanceBulkUpdatesYdbTest(
             """,
             """
             UPDATE `Kiwi`
-            SET `Name` = 'SomeOtherKiwi'
+            SET `Name` = 'SomeOtherKiwi'u
             WHERE `CountryId` = 1
             """
         );
@@ -161,7 +159,7 @@ internal class TpcFiltersInheritanceBulkUpdatesYdbTest(
             """
             UPDATE `Kiwi`
             SET `FoundOn` = 0,
-                `Name` = 'Kiwi'
+                `Name` = 'Kiwi'u
             WHERE `CountryId` = 1
             """
         );

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesYdbFixture.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesYdbFixture.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
-internal class TpcInheritanceBulkUpdatesYdbFixture : TPCInheritanceBulkUpdatesFixture
+public class TpcInheritanceBulkUpdatesYdbFixture : TPCInheritanceBulkUpdatesFixture
 {
     protected override ITestStoreFactory TestStoreFactory => YdbTestStoreFactory.Instance;
 

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPCInheritanceBulkUpdatesYdbTest.cs
@@ -6,7 +6,7 @@ using static EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities.SharedTestMet
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
 #pragma warning disable xUnit1000
-internal class TpcInheritanceBulkUpdatesYdbTest(
+public class TpcInheritanceBulkUpdatesYdbTest(
 #pragma warning restore xUnit1000
     TpcInheritanceBulkUpdatesYdbFixture fixture,
     ITestOutputHelper testOutputHelper
@@ -47,8 +47,6 @@ internal class TpcInheritanceBulkUpdatesYdbTest(
             async
         );
 
-    [ConditionalTheory(Skip = "TODO: need fix")]
-    [MemberData(nameof(IsAsyncData))]
     public override Task Update_base_type(bool async)
         => AssertYdb(
             base.Update_base_type,
@@ -70,7 +68,7 @@ internal class TpcInheritanceBulkUpdatesYdbTest(
             async,
             """
             DELETE FROM `Kiwi`
-            WHERE `Name` = 'Great spotted kiwi'
+            WHERE `Name` = 'Great spotted kiwi'u
             """
         );
 
@@ -124,7 +122,7 @@ internal class TpcInheritanceBulkUpdatesYdbTest(
             """,
             """
             UPDATE `Kiwi`
-            SET `Name` = 'SomeOtherKiwi'
+            SET `Name` = 'SomeOtherKiwi'u
             """
         );
 
@@ -155,7 +153,7 @@ internal class TpcInheritanceBulkUpdatesYdbTest(
             """
             UPDATE `Kiwi`
             SET `FoundOn` = 0,
-                `Name` = 'Kiwi'
+                `Name` = 'Kiwi'u
             """
         );
 

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesYdbFixture.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesYdbFixture.cs
@@ -8,4 +8,6 @@ internal class TPHInheritanceBulkUpdatesYdbFixture : TPHInheritanceBulkUpdatesFi
 {
     protected override ITestStoreFactory TestStoreFactory
         => YdbTestStoreFactory.Instance;
+
+    public override bool UseGeneratedKeys => false;
 }

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPTFiltersInheritanceBulkUpdatesYdbTest.cs
@@ -5,7 +5,7 @@ namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
 // TODO: Refactor later
 #pragma warning disable xUnit1000
-internal class TPTFiltersInheritanceBulkUpdatesSqlServerTest(
+internal class TPTFiltersInheritanceBulkUpdatesYdbTest(
 #pragma warning restore xUnit1000
     TPTFiltersInheritanceBulkUpdatesYdbFixture fixture,
     ITestOutputHelper testOutputHelper

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesYdbFixture.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPTInheritanceBulkUpdatesYdbFixture.cs
@@ -7,4 +7,6 @@ namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 internal class TPTInheritanceBulkUpdatesYdbFixture : TPTInheritanceBulkUpdatesFixture
 {
     protected override ITestStoreFactory TestStoreFactory => YdbTestStoreFactory.Instance;
+
+    public override bool UseGeneratedKeys => false;
 }


### PR DESCRIPTION
## Summary
- Make `TpcInheritanceBulkUpdatesYdbTest` and `TpcFiltersInheritanceBulkUpdatesYdbTest` (and their fixtures) public so xUnit discovers them in CI
- Fix Utf8 SQL baselines (`'...'u` suffix) and unskip `Update_base_type`
- Rename `TPTFiltersInheritanceBulkUpdatesSqlServerTest` → `TPTFiltersInheritanceBulkUpdatesYdbTest`; add `UseGeneratedKeys => false` to TPH/TPT fixtures for follow-up work

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~TpcInheritanceBulkUpdatesYdbTest|FullyQualifiedName~TpcFiltersInheritanceBulkUpdatesYdbTest|FullyQualifiedName~ComplexTypeBulkUpdatesYdbTest"` — 74 passed, 16 skipped
- [ ] CI green


Made with [Cursor](https://cursor.com)