### PR TITLE
test(efcore): enable TPH inheritance bulk update tests in CI

### DIFF
--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesYdbFixture.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesYdbFixture.cs
@@ -1,6 +1,6 @@
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
-internal class TphFiltersInheritanceBulkUpdatesYdbFixture : TPHInheritanceBulkUpdatesYdbFixture
+public class TphFiltersInheritanceBulkUpdatesYdbFixture : TPHInheritanceBulkUpdatesYdbFixture
 {
     public override bool EnableFilters => true;
 }

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHFiltersInheritanceBulkUpdatesYdbTest.cs
@@ -1,14 +1,12 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
+using Xunit;
 using Xunit.Abstractions;
 using static EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities.SharedTestMethods;
 
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
-// TODO: following error
-// Error: Primary key is required for ydb tables.
-// Probably use Name+CountryId, but...
 // ReSharper disable once InconsistentNaming
-internal class TPHFiltersInheritanceBulkUpdatesYdbTest(
+public class TPHFiltersInheritanceBulkUpdatesYdbTest(
     TphFiltersInheritanceBulkUpdatesYdbFixture fixture,
     ITestOutputHelper testOutputHelper
 ) : FiltersInheritanceBulkUpdatesRelationalTestBase<
@@ -49,6 +47,8 @@ internal class TPHFiltersInheritanceBulkUpdatesYdbTest(
             async
         );
 
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
     public override Task Delete_where_using_hierarchy(bool async)
         => AssertYdb(
             base.Delete_where_using_hierarchy,
@@ -56,12 +56,14 @@ internal class TPHFiltersInheritanceBulkUpdatesYdbTest(
             async
         );
 
-    // public override Task Delete_where_using_hierarchy_derived(bool async)
-    //     => AssertYdb(
-    //         base.Delete_where_using_hierarchy_derived,
-    //         Fixture.TestSqlLoggerFactory,
-    //         async
-    //     );
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Delete_where_using_hierarchy_derived(bool async)
+        => AssertYdb(
+            base.Delete_where_using_hierarchy_derived,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
 
     public override Task Delete_GroupBy_Where_Select_First(bool async)
         => AssertYdb(
@@ -77,6 +79,8 @@ internal class TPHFiltersInheritanceBulkUpdatesYdbTest(
             async
         );
 
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
     public override Task Delete_GroupBy_Where_Select_First_3(bool async)
         => AssertYdb(
             base.Delete_GroupBy_Where_Select_First_3,
@@ -126,6 +130,8 @@ internal class TPHFiltersInheritanceBulkUpdatesYdbTest(
             async
         );
 
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
     public override Task Update_where_using_hierarchy(bool async)
         => AssertYdb(
             base.Update_where_using_hierarchy,
@@ -133,6 +139,8 @@ internal class TPHFiltersInheritanceBulkUpdatesYdbTest(
             async
         );
 
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
     public override Task Update_where_using_hierarchy_derived(bool async)
         => AssertYdb(
             base.Update_where_using_hierarchy_derived,

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesYdbFixture.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesYdbFixture.cs
@@ -1,13 +1,30 @@
 using EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.BulkUpdates;
+using Microsoft.EntityFrameworkCore.TestModels.InheritanceModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
-internal class TPHInheritanceBulkUpdatesYdbFixture : TPHInheritanceBulkUpdatesFixture
+public class TPHInheritanceBulkUpdatesYdbFixture : TPHInheritanceBulkUpdatesFixture
 {
     protected override ITestStoreFactory TestStoreFactory
         => YdbTestStoreFactory.Instance;
 
     public override bool UseGeneratedKeys => false;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        // YDB requires a primary key for tables; map keyless query types to a view instead.
+        modelBuilder
+            .Entity<AnimalQuery>()
+            .HasNoKey()
+            .ToView(
+                """
+                SELECT * FROM `Animals`
+                """
+            );
+    }
 }

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/TPHInheritanceBulkUpdatesYdbTest.cs
@@ -1,10 +1,167 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
+using Xunit;
 using Xunit.Abstractions;
+using static EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities.SharedTestMethods;
 
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
-// TODO: Primary key required for ydb tables
-internal class TPHInheritanceBulkUpdatesYdbTest(
+#pragma warning disable xUnit1000
+public class TPHInheritanceBulkUpdatesYdbTest(
+#pragma warning restore xUnit1000
     TPHInheritanceBulkUpdatesYdbFixture fixture,
-    ITestOutputHelper testOutputHelper)
-    : TPHInheritanceBulkUpdatesTestBase<TPHInheritanceBulkUpdatesYdbFixture>(fixture, testOutputHelper);
+    ITestOutputHelper testOutputHelper
+) : TPHInheritanceBulkUpdatesTestBase<TPHInheritanceBulkUpdatesYdbFixture>(fixture, testOutputHelper)
+{
+    public override Task Delete_where_keyless_entity_mapped_to_sql_query(bool async)
+        => AssertYdb(
+            base.Delete_where_keyless_entity_mapped_to_sql_query,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_where_keyless_entity_mapped_to_sql_query(bool async)
+        => AssertYdb(
+            base.Update_where_keyless_entity_mapped_to_sql_query,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Delete_where_hierarchy(bool async)
+        => AssertYdb(
+            base.Delete_where_hierarchy,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Delete_where_hierarchy_subquery(bool async)
+        => AssertYdb(
+            base.Delete_where_hierarchy_subquery,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Delete_where_hierarchy_derived(bool async)
+        => AssertYdb(
+            base.Delete_where_hierarchy_derived,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Delete_where_using_hierarchy(bool async)
+        => AssertYdb(
+            base.Delete_where_using_hierarchy,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Delete_where_using_hierarchy_derived(bool async)
+        => AssertYdb(
+            base.Delete_where_using_hierarchy_derived,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Delete_GroupBy_Where_Select_First(bool async)
+        => AssertYdb(
+            base.Delete_GroupBy_Where_Select_First,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Delete_GroupBy_Where_Select_First_2(bool async)
+        => AssertYdb(
+            base.Delete_GroupBy_Where_Select_First_2,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Delete_GroupBy_Where_Select_First_3(bool async)
+        => AssertYdb(
+            base.Delete_GroupBy_Where_Select_First_3,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_base_type(bool async)
+        => AssertYdb(
+            base.Update_base_type,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_base_type_with_OfType(bool async)
+        => AssertYdb(
+            base.Update_base_type_with_OfType,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_where_hierarchy_subquery(bool async)
+        => AssertYdb(
+            base.Update_where_hierarchy_subquery,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_base_property_on_derived_type(bool async)
+        => AssertYdb(
+            base.Update_base_property_on_derived_type,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_derived_property_on_derived_type(bool async)
+        => AssertYdb(
+            base.Update_derived_property_on_derived_type,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_base_and_derived_types(bool async)
+        => AssertYdb(
+            base.Update_base_and_derived_types,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Update_where_using_hierarchy(bool async)
+        => AssertYdb(
+            base.Update_where_using_hierarchy,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    [ConditionalTheory(Skip = "https://github.com/ydb-platform/ydb/issues/15177")]
+    [MemberData(nameof(IsAsyncData))]
+    public override Task Update_where_using_hierarchy_derived(bool async)
+        => AssertYdb(
+            base.Update_where_using_hierarchy_derived,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_with_interface_in_property_expression(bool async)
+        => AssertYdb(
+            base.Update_with_interface_in_property_expression,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    public override Task Update_with_interface_in_EF_Property_in_property_expression(bool async)
+        => AssertYdb(
+            base.Update_with_interface_in_EF_Property_in_property_expression,
+            Fixture.TestSqlLoggerFactory,
+            async
+        );
+
+    protected override void ClearLog()
+        => Fixture.TestSqlLoggerFactory.Clear();
+}


### PR DESCRIPTION
## Summary
- Enable TPH inheritance bulk update tests in CI by making test classes and fixtures public
- Fix YDB schema setup: map keyless `AnimalQuery` to a view instead of a table without primary key
- Wire tests through `AssertYdb`; skip hierarchy scenarios blocked by CAST SQL limitations (ydb#15177)

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~TPHInheritanceBulkUpdatesYdbTest|FullyQualifiedName~TPHFiltersInheritanceBulkUpdatesYdbTest|FullyQualifiedName~TpcInheritanceBulkUpdatesYdbTest|FullyQualifiedName~TpcFiltersInheritanceBulkUpdatesYdbTest|FullyQualifiedName~ComplexTypeBulkUpdatesYdbTest"` — 118 passed, 32 skipped
- [ ] CI green
