### PR TITLE
Add codecov.yml with native-sdk component

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,20 @@
+# Cross-repo uniform metric: every YDB SDK repo defines this same component_id,
+# so native-SDK coverage is queryable identically via the Codecov API
+# (?component_id=native-sdk), regardless of how each repo tags its uploads.
+#
+# This repo is a monorepo. The native-sdk component covers the SDK itself plus its
+# first-party OpenTelemetry integration (mirrors the Python SDK, where the otel
+# plugin lives inside the ydb package and counts as native). The EF Core provider
+# is a separate framework adapter and gets its own component, so it does not dilute
+# the SDK number.
+component_management:
+  individual_components:
+    - component_id: native-sdk
+      name: Native SDK
+      paths:
+        - "src/Ydb.Sdk/src/**"
+        - "src/Ydb.Sdk.OpenTelemetry/src/**"
+    - component_id: efcore
+      name: EF Core provider
+      paths:
+        - "src/EFCore.Ydb/src/**"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,8 +3,7 @@
 # (?component_id=native-sdk), regardless of how each repo tags its uploads.
 #
 # This repo is a monorepo. The native-sdk component covers the SDK itself plus its
-# first-party OpenTelemetry integration (mirrors the Python SDK, where the otel
-# plugin lives inside the ydb package and counts as native). The EF Core provider
+# first-party OpenTelemetry integration. The EF Core provider
 # is a separate framework adapter and gets its own component, so it does not dilute
 # the SDK number.
 component_management:


### PR DESCRIPTION
Adds `.github/codecov.yml` defining a path-based `native-sdk` component (`src/Ydb.Sdk/src/**`), isolating the SDK from the EF Core provider so the SDK number is no longer blended with it. Also adds an `efcore` component for drill-down.

The `native-sdk` `component_id` is shared across all YDB SDK repos so native-SDK coverage is queryable uniformly via the Codecov API (`?component_id=native-sdk`).