### PR TITLE
Add Codecov coverage status gates

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto       # do not drop below the current level...
+        threshold: 1%      # ...by more than 1%
+    patch:
+      default:
+        target: 80%        # new/changed code in the PR diff must be >= 80% covered
+
 # Cross-repo uniform metric: every YDB SDK repo defines this same component_id,
 # so native-SDK coverage is queryable identically via the Codecov API
 # (?component_id=native-sdk), regardless of how each repo tags its uploads.

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -27,3 +27,13 @@ component_management:
       name: EF Core provider
       paths:
         - "src/EFCore.Ydb/src/**"
+
+# ydb-sdk and efcore-ydb coverage come from separate jobs, each uploaded from a
+# single matrix leg. Carry the last known value forward so a flaky or fail-fast
+# cancelled leg that skips its upload does not collapse the total and false-fail
+# the project status above.
+flags:
+  ydb-sdk:
+    carryforward: true
+  efcore-ydb:
+    carryforward: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ permissions:
 jobs:
   ydb-sdk-tests:
     strategy:
-      fail-fast: false
       matrix:
         ydb-version: [ 'latest', 'trunk' ]
         dotnet-version: [ 8.0.x, 9.0.x ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   ydb-sdk-tests:
     strategy:
+      fail-fast: false
       matrix:
         ydb-version: [ 'latest', 'trunk' ]
         dotnet-version: [ 8.0.x, 9.0.x ]


### PR DESCRIPTION
Makes each PR fail its Codecov status check on a coverage regression, and keeps the gate reliable on this multi-flag repo.

- **`codecov.yml` status**: adds a `coverage.status` block - `project` fails when overall coverage drops by more than 1% versus the base branch (`target: auto`, `threshold: 1%`), and `patch` requires the PR diff to be at least 80% covered. Mirrors ydb-python-sdk.
- **`codecov.yml` flags**: marks `ydb-sdk` and `efcore-ydb` as `carryforward: true`, so a job that skips its coverage upload (e.g. a flaky/cancelled matrix leg) carries the last known value forward instead of collapsing the total and false-failing the gate.