### PR TITLE
chore(efcore): use Ydb.Sdk 0.33.3 from NuGet

### DIFF
--- a/src/EFCore.Ydb/CHANGELOG.md
+++ b/src/EFCore.Ydb/CHANGELOG.md
@@ -1,7 +1,7 @@
 - Added string concatenation support in LINQ (`||` in YQL).
 - Fixed LINQ `Skip`/`Take` pagination: default `LIMIT` for offset-only queries uses `int.MaxValue` instead of `ulong.MaxValue`.
 - Dev: `ef-core/{V}` client info is now reported in `x-ydb-sdk-build-info` on every call (previously only on Driver Discovery).
-- Bumped `Ydb.Sdk` to `0.33.2`.
+- Bumped `Ydb.Sdk` to `0.33.3`.
 
 ## v0.5.0
 

--- a/src/EFCore.Ydb/src/EntityFrameworkCore.Ydb.csproj
+++ b/src/EFCore.Ydb/src/EntityFrameworkCore.Ydb.csproj
@@ -26,6 +26,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Ydb.Sdk" Version="0.33.2"/>
+        <PackageReference Include="Ydb.Sdk" Version="0.33.3"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump `EntityFrameworkCore.Ydb` NuGet dependency on `Ydb.Sdk` from `0.33.2` to `0.33.3`.
- Update EFCore changelog accordingly.

## Test plan
- [ ] CI green on this PR
- [ ] Confirm `Ydb.Sdk` 0.33.3 resolves from NuGet in EFCore restore


Made with [Cursor](https://cursor.com)