### PR TITLE
feat: allow configuring an explicit proxy for the gRPC channel via DriverConfig.Proxy

### DIFF
--- a/src/Ydb.Sdk/src/DriverConfig.cs
+++ b/src/Ydb.Sdk/src/DriverConfig.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using Ydb.Sdk.Auth;
 using Ydb.Sdk.Internal;
@@ -84,6 +85,20 @@ public class DriverConfig
     /// endpoints from the fastest datacenter. Default value: false.
     /// </remarks>
     public bool EnablePreferNearestDcBalancing { get; init; }
+
+    /// <summary>
+    /// Gets or sets the proxy used for the gRPC connections established by the driver, including
+    /// proxy authentication credentials if required (see <see cref="WebProxy.Credentials"/>).
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="null"/> (default), the standard .NET proxy resolution applies:
+    /// <see cref="System.Net.Http.SocketsHttpHandler.Proxy"/> is left unset, so
+    /// <see cref="System.Net.Http.HttpClient.DefaultProxy"/> (and, transitively, the
+    /// <c>HTTP_PROXY</c>/<c>HTTPS_PROXY</c> environment variables or OS proxy settings) is used if configured.
+    /// Set this property when the proxy for YDB traffic needs to differ from that process-wide default,
+    /// e.g. an authenticated corporate proxy that should apply only to the YDB channel.
+    /// </remarks>
+    public IWebProxy? Proxy { get; init; }
 
     internal X509Certificate2Collection CustomServerCertificates { get; } = [];
     internal TimeSpan EndpointDiscoveryInterval = TimeSpan.FromMinutes(1);

--- a/src/Ydb.Sdk/src/Pool/ChannelPool.cs
+++ b/src/Ydb.Sdk/src/Pool/ChannelPool.cs
@@ -104,6 +104,11 @@ internal class GrpcChannelFactory : IChannelFactory<GrpcChannel>
             EnableMultipleHttp2Connections = _config.EnableMultipleHttp2Connections
         };
 
+        if (_config.Proxy is not null)
+        {
+            httpHandler.Proxy = _config.Proxy;
+        }
+
         // https://github.com/grpc/grpc-dotnet/issues/2312#issuecomment-1790661801
         httpHandler.Properties["__GrpcLoadBalancingDisabled"] = true;
 


### PR DESCRIPTION
## What

Adds an optional `Proxy` (`System.Net.IWebProxy`) property to `DriverConfig`. When set, it's assigned to the internal `SocketsHttpHandler.Proxy` used by `GrpcChannelFactory.CreateChannel` (`src/Ydb.Sdk/src/Pool/ChannelPool.cs`) for the gRPC channel(s) the driver opens.

## Why

`DriverConfig`/`Driver` currently have no way to scope an authenticated proxy to YDB traffic. `GrpcChannelFactory.CreateChannel` builds `SocketsHttpHandler` without ever touching `Proxy`/`UseProxy`, so the only way to reach YDB through a proxy today is the process-wide static `System.Net.Http.HttpClient.DefaultProxy` (which works since #219 stopped disabling default proxy resolution, but affects every `HttpClient`/`SocketsHttpHandler` in the process, not just YDB).

This came up from a user who needs to reach YDB through a corporate proxy that requires authentication, without routing all other outbound traffic in the app through that same proxy.

I couldn't find an open issue for this specific request (checked issue titles for proxy/http/handler/channel/custom keywords — only the closed #218/#219 pair, which is about *not breaking* default proxy support, not about scoped configuration). Happy to open one and link it back if that's the preferred flow — opened the PR directly since the change is small and self-contained.

## Change

- `DriverConfig`: `public IWebProxy? Proxy { get; init; }` (defaults to `null`, fully backward compatible — behavior is unchanged unless the property is explicitly set).
- `ChannelPool.cs`: `if (_config.Proxy is not null) httpHandler.Proxy = _config.Proxy;`

## Testing

Not able to run the local build/test suite in the environment this PR was prepared in (no .NET SDK available), so this hasn't been verified against `dotnet build`/`dotnet test` locally — relying on CI. Let me know if anything doesn't compile and I'll fix it up.
