### PR TITLE
feat(efcore): support correlated ExecuteDelete with DELETE ON

### DIFF
--- a/src/EFCore.Ydb/CHANGELOG.md
+++ b/src/EFCore.Ydb/CHANGELOG.md
@@ -1,5 +1,6 @@
 - Added string concatenation support in LINQ (`||` in YQL).
 - Fixed LINQ `Skip`/`Take` pagination: default `LIMIT` for offset-only queries uses `int.MaxValue` instead of `ulong.MaxValue`.
+- Fixed correlated `ExecuteDelete` queries by generating YDB `DELETE ON` from the original join selection.
 - Dev: `ef-core/{V}` client info is now reported in `x-ydb-sdk-build-info` on every call (previously only on Driver Discovery).
 - Bumped `Ydb.Sdk` to `0.33.3`.
 

--- a/src/EFCore.Ydb/src/EntityFrameworkCore.Ydb.csproj
+++ b/src/EFCore.Ydb/src/EntityFrameworkCore.Ydb.csproj
@@ -14,6 +14,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" PrivateAssets="none"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" PrivateAssets="none"/>
+        <Compile Remove="Query/Internal/YdbQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.Ef10.cs"/>
     </ItemGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
@@ -23,6 +24,7 @@
     <ItemGroup Condition="'$(TargetFramework)' != 'net8.0' AND '$(TargetFramework)' != 'net9.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" PrivateAssets="none"/>
+        <Compile Remove="Query/Internal/YdbQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.Ef9.cs"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EFCore.Ydb/src/Query/Internal/YdbQuerySqlGenerator.cs
+++ b/src/EFCore.Ydb/src/Query/Internal/YdbQuerySqlGenerator.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace EntityFrameworkCore.Ydb.Query.Internal;
 
-public class YdbQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : QuerySqlGenerator(dependencies)
+public sealed class YdbQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : QuerySqlGenerator(dependencies)
 {
     private bool SkipAliases { get; set; }
     private ISqlGenerationHelper SqlGenerationHelper => Dependencies.SqlGenerationHelper;
@@ -77,7 +77,7 @@ public class YdbQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : 
         var selectExpression = deleteExpression.SelectExpression;
 
         return selectExpression.Tables is [TableExpression table]
-               && table.Alias == deleteExpression.Table.Alias
+               && table.Equals(deleteExpression.Table)
                && selectExpression.Orderings.Count == 0
                && selectExpression.Offset is null
                && selectExpression.Limit is null
@@ -213,7 +213,7 @@ public class YdbQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : 
         return projectionExpression;
     }
 
-    protected virtual Expression VisitILike(YdbILikeExpression likeExpression, bool negated = false)
+    private Expression VisitILike(YdbILikeExpression likeExpression, bool negated = false)
     {
         Visit(likeExpression.Match);
 

--- a/src/EFCore.Ydb/src/Query/Internal/YdbQuerySqlGenerator.cs
+++ b/src/EFCore.Ydb/src/Query/Internal/YdbQuerySqlGenerator.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using EntityFrameworkCore.Ydb.Query.Expressions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -49,11 +51,69 @@ public class YdbQuerySqlGenerator(QuerySqlGeneratorDependencies dependencies) : 
 
     protected override Expression VisitDelete(DeleteExpression deleteExpression)
     {
+        if (CanUseBaseDelete(deleteExpression))
+        {
+            SkipAliases = true;
+            base.VisitDelete(deleteExpression);
+            SkipAliases = false;
+
+            return deleteExpression;
+        }
+
+        Sql.Append("DELETE FROM ");
+
         SkipAliases = true;
-        base.VisitDelete(deleteExpression);
+        Visit(deleteExpression.Table);
         SkipAliases = false;
 
+        Sql.Append(" ON ");
+        Visit(WithPrimaryKeyProjection(deleteExpression));
+
         return deleteExpression;
+    }
+
+    private static bool CanUseBaseDelete(DeleteExpression deleteExpression)
+    {
+        var selectExpression = deleteExpression.SelectExpression;
+
+        return selectExpression.Tables is [TableExpression table]
+               && table.Alias == deleteExpression.Table.Alias
+               && selectExpression.Orderings.Count == 0
+               && selectExpression.Offset is null
+               && selectExpression.Limit is null
+               && selectExpression.GroupBy.Count == 0
+               && selectExpression.Having is null
+               && selectExpression.Projection.Count == 0;
+    }
+
+    private static SelectExpression WithPrimaryKeyProjection(DeleteExpression deleteExpression)
+    {
+        var table = deleteExpression.Table;
+        if (table.Table is not ITable { PrimaryKey: { } primaryKey })
+        {
+            throw new InvalidOperationException(
+                $"Could not determine primary key columns for DELETE ON over `{table.Name}`.");
+        }
+
+        var select = deleteExpression.SelectExpression;
+        return select.Update(
+            select.Tables,
+            select.Predicate,
+            select.GroupBy,
+            select.Having,
+            primaryKey.Columns
+                .Select(column => new ProjectionExpression(
+                    new ColumnExpression(
+                        column.Name,
+                        table.Alias,
+                        column.ProviderClrType,
+                        column.StoreTypeMapping,
+                        column.IsNullable),
+                    column.Name))
+                .ToArray(),
+            select.Orderings,
+            select.Offset,
+            select.Limit);
     }
 
     protected override Expression VisitUpdate(UpdateExpression updateExpression)

--- a/src/EFCore.Ydb/src/Query/Internal/YdbQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.Ef10.cs
+++ b/src/EFCore.Ydb/src/Query/Internal/YdbQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.Ef10.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace EntityFrameworkCore.Ydb.Query.Internal;
+
+public partial class YdbQueryableMethodTranslatingExpressionVisitor
+{
+    protected override bool IsValidSelectExpressionForExecuteDelete(SelectExpression selectExpression)
+        => CanGenerateModificationOn(selectExpression);
+}

--- a/src/EFCore.Ydb/src/Query/Internal/YdbQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.Ef9.cs
+++ b/src/EFCore.Ydb/src/Query/Internal/YdbQueryableMethodTranslatingExpressionVisitor.ExecuteDelete.Ef9.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace EntityFrameworkCore.Ydb.Query.Internal;
+
+public partial class YdbQueryableMethodTranslatingExpressionVisitor
+{
+    protected override bool IsValidSelectExpressionForExecuteDelete(
+        SelectExpression selectExpression,
+        StructuralTypeShaperExpression shaper,
+        [NotNullWhen(true)] out TableExpression? tableExpression)
+    {
+        if (!CanGenerateModificationOn(selectExpression))
+        {
+            tableExpression = null;
+            return false;
+        }
+
+        var projectionBindingExpression = (ProjectionBindingExpression)shaper.ValueBufferExpression;
+        var entityProjectionExpression =
+            (StructuralTypeProjectionExpression)selectExpression.GetProjection(projectionBindingExpression);
+        var column = entityProjectionExpression.BindProperty(shaper.StructuralType.GetProperties().First());
+
+        tableExpression = selectExpression.Tables
+            .Select(table => table.UnwrapJoin())
+            .OfType<TableExpression>()
+            .SingleOrDefault(table => table.Alias == column.TableAlias);
+
+        return tableExpression is not null;
+    }
+}

--- a/src/EFCore.Ydb/src/Query/Internal/YdbQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Ydb/src/Query/Internal/YdbQueryableMethodTranslatingExpressionVisitor.cs
@@ -1,9 +1,11 @@
+using System.Linq;
 using EntityFrameworkCore.Ydb.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace EntityFrameworkCore.Ydb.Query.Internal;
 
-public class YdbQueryableMethodTranslatingExpressionVisitor
+public partial class YdbQueryableMethodTranslatingExpressionVisitor
     : RelationalQueryableMethodTranslatingExpressionVisitor
 {
     private readonly RelationalQueryCompilationContext _queryCompilationContext;
@@ -31,4 +33,9 @@ public class YdbQueryableMethodTranslatingExpressionVisitor
 
     protected override QueryableMethodTranslatingExpressionVisitor CreateSubqueryVisitor()
         => new YdbQueryableMethodTranslatingExpressionVisitor(this);
+
+    private static bool CanGenerateModificationOn(SelectExpression selectExpression)
+        => selectExpression.Tables.Count > 0
+           && selectExpression.Tables.All(table => table is
+               TableExpression or InnerJoinExpression or LeftJoinExpression or CrossJoinExpression);
 }

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/CorrelatedExecuteDeleteYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/CorrelatedExecuteDeleteYdbTest.cs
@@ -38,7 +38,8 @@ public class CorrelatedExecuteDeleteYdbTest
     [Fact]
     public async Task Delete_with_navigation_uses_delete_on_instead_of_correlated_subquery()
     {
-        await using var testStore = CreateStore(nameof(Delete_with_navigation_uses_delete_on_instead_of_correlated_subquery));
+        await using var testStore =
+            CreateStore(nameof(Delete_with_navigation_uses_delete_on_instead_of_correlated_subquery));
         using var sqlLoggerFactory = YdbTestStoreFactory.Instance.CreateListLoggerFactory(_ => false);
         await using var context = new CorrelatedDeleteContext(sqlLoggerFactory);
         await InitializeAsync(testStore, context);

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/CorrelatedExecuteDeleteYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/CorrelatedExecuteDeleteYdbTest.cs
@@ -1,0 +1,189 @@
+using EntityFrameworkCore.Ydb.Extensions;
+using EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
+
+public class CorrelatedExecuteDeleteYdbTest
+{
+    [Fact]
+    public async Task Delete_without_correlation_uses_base_sql()
+    {
+        await using var testStore = CreateStore(nameof(Delete_without_correlation_uses_base_sql));
+        using var sqlLoggerFactory = YdbTestStoreFactory.Instance.CreateListLoggerFactory(_ => false);
+        await using var context = new CorrelatedDeleteContext(sqlLoggerFactory);
+        await InitializeAsync(testStore, context);
+
+        context.Orders.Add(new Order { Id = 1, CustomerId = 1, Status = "Cancelled" });
+        context.Customers.Add(new Customer { Id = 1, Name = "Acme" });
+        await context.SaveChangesAsync();
+
+        var logger = (TestSqlLoggerFactory)sqlLoggerFactory;
+        logger.Clear();
+
+        await context.Orders
+            .Where(order => order.Status == "Cancelled")
+            .ExecuteDeleteAsync();
+
+        AssertSql(logger, """
+                          DELETE FROM `Orders`
+                          WHERE `Status` = 'Cancelled'u
+                          """);
+        logger.Clear();
+        Assert.Empty(await context.Orders.AsNoTracking().ToListAsync());
+    }
+
+    [Fact]
+    public async Task Delete_with_navigation_uses_delete_on_instead_of_correlated_subquery()
+    {
+        await using var testStore = CreateStore(nameof(Delete_with_navigation_uses_delete_on_instead_of_correlated_subquery));
+        using var sqlLoggerFactory = YdbTestStoreFactory.Instance.CreateListLoggerFactory(_ => false);
+        await using var context = new CorrelatedDeleteContext(sqlLoggerFactory);
+        await InitializeAsync(testStore, context);
+
+        context.Customers.AddRange(
+            new Customer { Id = 1, Name = "Acme" },
+            new Customer { Id = 2, Name = "Keep" });
+        context.Orders.AddRange(
+            new Order { Id = 10, CustomerId = 1, Status = "Pending" },
+            new Order { Id = 20, CustomerId = 2, Status = "Pending" });
+        await context.SaveChangesAsync();
+
+        var logger = (TestSqlLoggerFactory)sqlLoggerFactory;
+        logger.Clear();
+
+        await context.Orders
+            .Where(order => order.Customer!.Name == "Acme")
+            .ExecuteDeleteAsync();
+
+        AssertSql(logger, """
+                          DELETE FROM `Orders` ON SELECT `o`.`Id` AS `Id`
+                          FROM `Orders` AS `o`
+                          INNER JOIN `Customers` AS `c` ON `o`.`CustomerId` = `c`.`Id`
+                          WHERE `c`.`Name` = 'Acme'u
+                          """);
+        Assert.DoesNotContain("EXISTS", logger.SqlStatements[0]);
+        logger.Clear();
+        Assert.Equal([20], await context.Orders.AsNoTracking().Select(order => order.Id).ToListAsync());
+    }
+
+    [Fact]
+    public async Task Delete_with_navigation_projects_every_composite_key_column()
+    {
+        await using var testStore = CreateStore(nameof(Delete_with_navigation_projects_every_composite_key_column));
+        using var sqlLoggerFactory = YdbTestStoreFactory.Instance.CreateListLoggerFactory(_ => false);
+        await using var context = new CorrelatedDeleteContext(sqlLoggerFactory);
+        await InitializeAsync(testStore, context);
+
+        context.Customers.Add(new Customer { Id = 1, Name = "Acme" });
+        context.Orders.Add(new Order { Id = 10, CustomerId = 1, Status = "Pending" });
+        context.OrderLines.AddRange(
+            new OrderLine { OrderId = 10, LineId = 1, Product = "Delete" },
+            new OrderLine { OrderId = 10, LineId = 2, Product = "Delete" });
+        await context.SaveChangesAsync();
+
+        var logger = (TestSqlLoggerFactory)sqlLoggerFactory;
+        logger.Clear();
+
+        await context.OrderLines
+            .Where(line => line.Order!.Customer!.Name == "Acme")
+            .ExecuteDeleteAsync();
+
+        AssertSql(logger, """
+                          DELETE FROM `OrderLines` ON SELECT `o`.`OrderKey` AS `OrderKey`, `o`.`LineKey` AS `LineKey`
+                          FROM `OrderLines` AS `o`
+                          INNER JOIN `Orders` AS `o0` ON `o`.`OrderKey` = `o0`.`Id`
+                          INNER JOIN `Customers` AS `c` ON `o0`.`CustomerId` = `c`.`Id`
+                          WHERE `c`.`Name` = 'Acme'u
+                          """);
+        logger.Clear();
+        Assert.Empty(await context.OrderLines.AsNoTracking().ToListAsync());
+    }
+
+    private static async Task InitializeAsync(TestStore testStore, DbContext context)
+    {
+        await testStore.CleanAsync(context);
+        await context.Database.EnsureCreatedAsync();
+    }
+
+    private static TestStore CreateStore(string testName)
+        => YdbTestStoreFactory.Instance.Create($"{nameof(CorrelatedExecuteDeleteYdbTest)}_{testName}");
+
+    private static void AssertSql(TestSqlLoggerFactory logger, string expected)
+    {
+        if (logger.SqlStatements.Count == 1 && logger.SqlStatements[0] == expected)
+        {
+            return;
+        }
+
+        logger.AssertBaseline([expected], assertOrder: false);
+    }
+
+    private sealed class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private sealed class Order
+    {
+        public int Id { get; set; }
+        public int CustomerId { get; set; }
+        public Customer? Customer { get; set; }
+        public string Status { get; set; } = "";
+    }
+
+    private sealed class OrderLine
+    {
+        public int OrderId { get; set; }
+        public int LineId { get; set; }
+        public Order? Order { get; set; }
+        public string Product { get; set; } = "";
+    }
+
+    private sealed class CorrelatedDeleteContext(ListLoggerFactory sqlLoggerFactory) : DbContext
+    {
+        public DbSet<Customer> Customers => Set<Customer>();
+        public DbSet<Order> Orders => Set<Order>();
+        public DbSet<OrderLine> OrderLines => Set<OrderLine>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(builder =>
+            {
+                builder.ToTable("Customers");
+                builder.HasKey(customer => customer.Id);
+                builder.Property(customer => customer.Id).ValueGeneratedNever();
+            });
+
+            modelBuilder.Entity<Order>(builder =>
+            {
+                builder.ToTable("Orders");
+                builder.HasKey(order => order.Id);
+                builder.Property(order => order.Id).ValueGeneratedNever();
+                builder.HasOne(order => order.Customer)
+                    .WithMany()
+                    .HasForeignKey(order => order.CustomerId);
+            });
+
+            modelBuilder.Entity<OrderLine>(builder =>
+            {
+                builder.ToTable("OrderLines");
+                builder.HasKey(line => new { line.OrderId, line.LineId });
+                builder.Property(line => line.OrderId).HasColumnName("OrderKey").ValueGeneratedNever();
+                builder.Property(line => line.LineId).HasColumnName("LineKey").ValueGeneratedNever();
+                builder.HasOne(line => line.Order)
+                    .WithMany()
+                    .HasForeignKey(line => line.OrderId);
+            });
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseYdb("Host=localhost;Port=2136;Database=/local;UseTls=false")
+                .UseLoggerFactory(sqlLoggerFactory)
+                .EnableServiceProviderCaching(false);
+    }
+}

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesYdbFixture.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesYdbFixture.cs
@@ -12,13 +12,10 @@ public class NorthwindBulkUpdatesYdbFixture<TModelCustomizer> :
     where TModelCustomizer : ITestModelCustomizer, new()
 {
     protected override ITestStoreFactory TestStoreFactory => YdbNorthwindTestStoreFactory.Instance;
-}
 
-public sealed class YdbNorthwindModelCustomizer : NoopModelCustomizer
-{
-    public override void Customize(ModelBuilder modelBuilder, DbContext context)
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
     {
-        base.Customize(modelBuilder, context);
+        base.OnModelCreating(modelBuilder, context);
         modelBuilder.Entity<OrderDetail>().ToTable("Order_Details");
     }
 }

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesYdbFixture.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesYdbFixture.cs
@@ -1,13 +1,24 @@
 using EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.BulkUpdates;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
-internal class
-    NorthwindBulkUpdatesYdbFixture<TModelCustomizer> : NorthwindBulkUpdatesRelationalFixture<TModelCustomizer>
+public class NorthwindBulkUpdatesYdbFixture<TModelCustomizer> :
+    NorthwindBulkUpdatesRelationalFixture<TModelCustomizer>
     where TModelCustomizer : ITestModelCustomizer, new()
 {
     protected override ITestStoreFactory TestStoreFactory => YdbNorthwindTestStoreFactory.Instance;
+}
+
+public sealed class YdbNorthwindModelCustomizer : NoopModelCustomizer
+{
+    public override void Customize(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.Customize(modelBuilder, context);
+        modelBuilder.Entity<OrderDetail>().ToTable("Order_Details");
+    }
 }

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesYdbTest.cs
@@ -1,14 +1,13 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
-using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit.Abstractions;
 
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
-// TODO: Await Norhhwind
+// Internal harness; public provider tests expose only the supported Microsoft scenarios.
 internal class NorthwindBulkUpdatesYdbTest(
-    NorthwindBulkUpdatesYdbFixture<NoopModelCustomizer> fixture,
+    NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer> fixture,
     ITestOutputHelper testOutputHelper
-) : NorthwindBulkUpdatesRelationalTestBase<NorthwindBulkUpdatesYdbFixture<NoopModelCustomizer>>(
+) : NorthwindBulkUpdatesRelationalTestBase<NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer>>(
     fixture,
     testOutputHelper
 );

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindBulkUpdatesYdbTest.cs
@@ -1,13 +1,14 @@
 using Microsoft.EntityFrameworkCore.BulkUpdates;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit.Abstractions;
 
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
 // Internal harness; public provider tests expose only the supported Microsoft scenarios.
 internal class NorthwindBulkUpdatesYdbTest(
-    NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer> fixture,
+    NorthwindBulkUpdatesYdbFixture<NoopModelCustomizer> fixture,
     ITestOutputHelper testOutputHelper
-) : NorthwindBulkUpdatesRelationalTestBase<NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer>>(
+) : NorthwindBulkUpdatesRelationalTestBase<NorthwindBulkUpdatesYdbFixture<NoopModelCustomizer>>(
     fixture,
     testOutputHelper
 );

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindCorrelatedDeleteYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindCorrelatedDeleteYdbTest.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
 using static EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities.SharedTestMethods;
@@ -5,13 +6,13 @@ using static EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities.SharedTestMet
 namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
 
 public sealed class NorthwindCorrelatedDeleteYdbTest :
-    IClassFixture<NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer>>
+    IClassFixture<NorthwindBulkUpdatesYdbFixture<NoopModelCustomizer>>
 {
-    private readonly NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer> _fixture;
+    private readonly NorthwindBulkUpdatesYdbFixture<NoopModelCustomizer> _fixture;
     private readonly NorthwindBulkUpdatesYdbTest _microsoftTests;
 
     public NorthwindCorrelatedDeleteYdbTest(
-        NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer> fixture,
+        NorthwindBulkUpdatesYdbFixture<NoopModelCustomizer> fixture,
         ITestOutputHelper testOutputHelper)
     {
         _fixture = fixture;

--- a/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindCorrelatedDeleteYdbTest.cs
+++ b/src/EFCore.Ydb/test/EntityFrameworkCore.Ydb.FunctionalTests/BulkUpdates/NorthwindCorrelatedDeleteYdbTest.cs
@@ -1,0 +1,36 @@
+using Xunit;
+using Xunit.Abstractions;
+using static EntityFrameworkCore.Ydb.FunctionalTests.TestUtilities.SharedTestMethods;
+
+namespace EntityFrameworkCore.Ydb.FunctionalTests.BulkUpdates;
+
+public sealed class NorthwindCorrelatedDeleteYdbTest :
+    IClassFixture<NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer>>
+{
+    private readonly NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer> _fixture;
+    private readonly NorthwindBulkUpdatesYdbTest _microsoftTests;
+
+    public NorthwindCorrelatedDeleteYdbTest(
+        NorthwindBulkUpdatesYdbFixture<YdbNorthwindModelCustomizer> fixture,
+        ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _microsoftTests = new NorthwindBulkUpdatesYdbTest(fixture, testOutputHelper);
+    }
+
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public Task Delete_Where_using_navigation_2(bool async)
+        => AssertYdb(
+            _microsoftTests.Delete_Where_using_navigation_2,
+            _fixture.TestSqlLoggerFactory,
+            async,
+            """
+            DELETE FROM `Order_Details` ON SELECT `o`.`OrderID` AS `OrderID`, `o`.`ProductID` AS `ProductID`
+            FROM `Order_Details` AS `o`
+            INNER JOIN `Orders` AS `o0` ON `o`.`OrderID` = `o0`.`OrderID`
+            LEFT JOIN `Customers` AS `c` ON `o0`.`CustomerID` = `c`.`CustomerID`
+            WHERE `c`.`CustomerID` LIKE 'F%'u
+            """);
+}

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderConfig.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderConfig.cs
@@ -2,27 +2,19 @@ using System.Text;
 
 namespace Ydb.Sdk.Topic.Reader;
 
-internal class ReaderConfig
+internal class ReaderConfig(
+    List<SubscribeSettings> subscribeSettings,
+    string? consumerName,
+    string? readerName,
+    long memoryUsageMaxBytes)
 {
-    public ReaderConfig(
-        List<SubscribeSettings> subscribeSettings,
-        string? consumerName,
-        string? readerName,
-        long memoryUsageMaxBytes)
-    {
-        SubscribeSettings = subscribeSettings;
-        ConsumerName = consumerName;
-        ReaderName = readerName;
-        MemoryUsageMaxBytes = memoryUsageMaxBytes;
-    }
+    public List<SubscribeSettings> SubscribeSettings { get; } = subscribeSettings;
 
-    public List<SubscribeSettings> SubscribeSettings { get; }
+    public string? ConsumerName { get; } = consumerName;
 
-    public string? ConsumerName { get; }
+    public string? ReaderName { get; } = readerName;
 
-    public string? ReaderName { get; }
-
-    public long MemoryUsageMaxBytes { get; }
+    public long MemoryUsageMaxBytes { get; } = memoryUsageMaxBytes;
 
     public override string ToString()
     {


### PR DESCRIPTION
## Summary

- keep the base EF Core DELETE SQL generation for non-correlated single-table queries
- preserve supported join shapes during translation and generate YDB DELETE FROM ... ON SELECT ... for correlated ExecuteDelete
- project every physical primary-key column, including renamed composite keys
- isolate the incompatible EF Core 9/10 delete validation hooks in target-specific adapter files
- add a dedicated correlated delete test suite for EF Core 9 and 10
- include the pre-existing local ReaderConfig primary-constructor cleanup as a separate commit

## Validation

- CorrelatedExecuteDeleteYdbTest: 3/3 passed on net9.0
- CorrelatedExecuteDeleteYdbTest: 3/3 passed on net10.0
- existing simple DELETE bulk tests: 4/4 passed on net9.0 and 2/2 on net10.0
- full YdbSdk.sln build passed
- scoped dotnet format --verify-no-changes passed for all changed C# files

Replaces the DELETE part of #667.