### PR TITLE
feat: report session closures on shutdown hints

### DIFF
--- a/src/Ydb.Sdk.OpenTelemetry/README.md
+++ b/src/Ydb.Sdk.OpenTelemetry/README.md
@@ -70,8 +70,8 @@ Every `ydb.query.session.*` metric includes **`ydb.query.session.pool.name`** (v
 
 Supported `ydb.query.session.closed` reasons:
 
-- `node_shutdown_hint` — the server sends a node shutdown hint.
-- `session_shutdown_hint` — the server sends a session shutdown hint.
+- `node_shutdown` — the server sends a node shutdown hint.
+- `session_shutdown` — the server sends a session shutdown hint.
 
 ## Example
 

--- a/src/Ydb.Sdk.OpenTelemetry/README.md
+++ b/src/Ydb.Sdk.OpenTelemetry/README.md
@@ -59,6 +59,7 @@ Every `ydb.query.session.*` metric includes **`ydb.query.session.pool.name`** (v
 | `ydb.client.operation.duration`      | Histogram         | `s`           | `database`, `endpoint`, `operation.name`                                   | Latency of each actual `ExecuteQuery`, `Commit`, or `Rollback` attempt.                             |
 | `ydb.client.operation.failed`        | Counter           | `{operation}` | `database`, `endpoint`, `operation.name`, `status_code`                    | Unsuccessful operation attempts.                                                                    |
 | `ydb.query.session.create_time`      | Histogram         | `s`           | `ydb.query.session.pool.name`                                              | Cost of session creation (CreateSession + first AttachStream message).                              |
+| `ydb.query.session.closed`           | Counter           | `{session}`   | `ydb.query.session.pool.name`, `reason`                                    | Sessions closed after a server shutdown hint.                                                       |
 | `ydb.query.session.pending_requests` | Counter           | `{request}`   | `ydb.query.session.pool.name`                                              | Increments when a caller starts waiting for a session; use **rate** (not level) for queue pressure. |
 | `ydb.query.session.timeouts`         | Counter           | `{timeout}`   | `ydb.query.session.pool.name`                                              | Pool could not satisfy demand within the acquisition timeout.                                       |
 | `ydb.query.session.count`            | ObservableGauge   | `{session}`   | `ydb.query.session.pool.name`, `ydb.query.session.state` (`idle` / `used`) | Current pool occupancy.                                                                             |
@@ -66,6 +67,11 @@ Every `ydb.query.session.*` metric includes **`ydb.query.session.pool.name`** (v
 | `ydb.query.session.min`              | ObservableGauge   | `{session}`   | `ydb.query.session.pool.name`                                              | Configured `MinPoolSize` (context).                                                                 |
 
 `database` is the YDB database path; `endpoint` is `host:port` from the connection string.
+
+Supported `ydb.query.session.closed` reasons:
+
+- `node_shutdown_hint` — the server sends a node shutdown hint.
+- `session_shutdown_hint` — the server sends a session shutdown hint.
 
 ## Example
 

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,7 +1,7 @@
 - Feat ADO.NET metrics: added the `ydb.query.session.closed` counter (unit `{session}`) with
   `ydb.query.session.pool.name` and `reason` attributes for server shutdown hints:
-  - `node_shutdown_hint` for `NodeShutdown`.
-  - `session_shutdown_hint` for `SessionShutdown`.
+  - `node_shutdown` for `NodeShutdown`.
+  - `session_shutdown` for `SessionShutdown`.
 
 ## v0.35.0
 

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,5 +1,3 @@
-## Unreleased
-
 - Feat ADO.NET metrics: added the `ydb.query.session.closed` counter (unit `{session}`) with
   `ydb.query.session.pool.name` and `reason` attributes for server shutdown hints:
   - `node_shutdown_hint` for `NodeShutdown`.

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- Feat ADO.NET metrics: added the `ydb.query.session.closed` counter (unit `{session}`) with
+  `ydb.query.session.pool.name` and `reason` attributes for server shutdown hints:
+  - `node_shutdown_hint` for `NodeShutdown`.
+  - `session_shutdown_hint` for `SessionShutdown`.
+
 ## v0.35.0
 
 - Feat ADO.NET: HTTP proxy support via code-only `YdbConnectionStringBuilder.Proxy` (`IWebProxy` / `WebProxy`).

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
@@ -192,13 +192,13 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                             switch (sessionState.SessionHintCase)
                             {
                                 case SessionState.SessionHintOneofCase.NodeShutdown:
-                                    MetricsReporter.ReportSessionClosed("node_shutdown_hint");
+                                    MetricsReporter.ReportSessionClosed("node_shutdown");
                                     Driver.PessimizeNode(NodeId);
                                     _isBadSession = true;
                                     _isBroken = true;
                                     break;
                                 case SessionState.SessionHintOneofCase.SessionShutdown:
-                                    MetricsReporter.ReportSessionClosed("session_shutdown_hint");
+                                    MetricsReporter.ReportSessionClosed("session_shutdown");
                                     _isBadSession = true;
                                     _isBroken = true;
                                     break;

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
@@ -192,11 +192,13 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                             switch (sessionState.SessionHintCase)
                             {
                                 case SessionState.SessionHintOneofCase.NodeShutdown:
+                                    MetricsReporter.ReportSessionClosed("node_shutdown_hint");
                                     Driver.PessimizeNode(NodeId);
                                     _isBadSession = true;
                                     _isBroken = true;
                                     break;
                                 case SessionState.SessionHintOneofCase.SessionShutdown:
+                                    MetricsReporter.ReportSessionClosed("session_shutdown_hint");
                                     _isBadSession = true;
                                     _isBroken = true;
                                     break;

--- a/src/Ydb.Sdk/src/Ado/YdbMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbMetricsReporter.cs
@@ -26,10 +26,11 @@ internal sealed class YdbMetricsReporter : IDisposable
     private static readonly Histogram<double> RetryDuration;
     private static readonly Histogram<int> RetryAttempts;
 
-    // Pool metrics: connection lifecycle (count, timeouts, pending requests, create time)
+    // Pool metrics: connection lifecycle (count, timeouts, pending requests, create/close)
     // create_time covers CreateSession RPC + first AttachStream message
     private static readonly Counter<int> ConnectionTimeouts;
     private static readonly Counter<int> PendingConnectionRequests;
+    private static readonly Counter<int> SessionsClosed;
     private static readonly Histogram<double> ConnectionCreateTime;
 
     private static readonly List<YdbMetricsReporter> Reporters = [];
@@ -86,6 +87,11 @@ internal sealed class YdbMetricsReporter : IDisposable
             unit: "{request}",
             description:
             "Increments when a connection request begins waiting for a free session; use rate to observe wait pressure.");
+
+        SessionsClosed = meter.CreateCounter<int>(
+            "ydb.query.session.closed",
+            unit: "{session}",
+            description: "The number of sessions removed from the pool, grouped by the reason attribute.");
 
         ConnectionCreateTime = meter.CreateHistogram(
             "ydb.query.session.create_time",
@@ -165,6 +171,7 @@ internal sealed class YdbMetricsReporter : IDisposable
         RetryAttempts.Enabled ||
         ConnectionTimeouts.Enabled ||
         PendingConnectionRequests.Enabled ||
+        SessionsClosed.Enabled ||
         ConnectionCreateTime.Enabled;
 
     internal void ReportCommandStop(long startTimestamp, string operationName)
@@ -188,6 +195,9 @@ internal sealed class YdbMetricsReporter : IDisposable
     }
 
     internal void ReportPendingConnectionRequestStart() => PendingConnectionRequests.Add(1, _poolNameTag);
+
+    internal void ReportSessionClosed(string reason) =>
+        SessionsClosed.Add(1, _poolNameTag, new KeyValuePair<string, object?>("reason", reason));
 
     internal static long ReportConnectionCreateTimeStart() =>
         ConnectionCreateTime.Enabled ? Stopwatch.GetTimestamp() : 0;

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbMetricTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbMetricTests.cs
@@ -233,8 +233,8 @@ public class YdbMetricTests : TestBase
     }
 
     [Theory]
-    [InlineData(SessionState.SessionHintOneofCase.NodeShutdown, "node_shutdown_hint")]
-    [InlineData(SessionState.SessionHintOneofCase.SessionShutdown, "session_shutdown_hint")]
+    [InlineData(SessionState.SessionHintOneofCase.NodeShutdown, "node_shutdown")]
+    [InlineData(SessionState.SessionHintOneofCase.SessionShutdown, "session_shutdown")]
     public async Task SessionClosed_WhenAttachStreamSendsShutdownHint_ReportsReason(
         SessionState.SessionHintOneofCase hint,
         string reason)

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbMetricTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbMetricTests.cs
@@ -232,6 +232,76 @@ public class YdbMetricTests : TestBase
         Assert.Equal(settings.PoolName, ToDictionary(point.Tags)["ydb.query.session.pool.name"]);
     }
 
+    [Theory]
+    [InlineData(SessionState.SessionHintOneofCase.NodeShutdown, "node_shutdown_hint")]
+    [InlineData(SessionState.SessionHintOneofCase.SessionShutdown, "session_shutdown_hint")]
+    public async Task SessionClosed_WhenAttachStreamSendsShutdownHint_ReportsReason(
+        SessionState.SessionHintOneofCase hint,
+        string reason)
+    {
+        const string sessionId = "sessionId";
+        const long nodeId = 3;
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+
+        var settings = CreateConnectionSettings(builder =>
+        {
+            builder.MaxPoolSize = 1;
+            builder.PoolName = $"ado-metrics-session-closed-{reason}";
+        });
+        var lifecycleState = new SessionState { Status = StatusIds.Types.StatusCode.Success };
+        if (hint == SessionState.SessionHintOneofCase.NodeShutdown)
+            lifecycleState.NodeShutdown = new NodeShutdownHint();
+        else
+            lifecycleState.SessionShutdown = new SessionShutdownHint();
+
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachStream = new Mock<IServerStream<SessionState>>(MockBehavior.Strict);
+        attachStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(true);
+        attachStream.SetupSequence(stream => stream.Current)
+            .Returns(new SessionState { Status = StatusIds.Types.StatusCode.Success })
+            .Returns(lifecycleState);
+        attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
+
+        var driver = CreateMockDriver();
+        driver.Setup(d => d.UnaryCall(
+                QueryService.CreateSessionMethod,
+                It.IsAny<CreateSessionRequest>(),
+                It.Is<GrpcRequestSettings>(s => s.ClientCapabilities.Contains("session-balancer"))))
+            .ReturnsAsync(new CreateSessionResponse
+            {
+                Status = StatusIds.Types.StatusCode.Success,
+                SessionId = sessionId,
+                NodeId = nodeId
+            });
+        driver.Setup(d => d.ServerStreamCall(
+                QueryService.AttachSessionMethod,
+                It.Is<AttachSessionRequest>(r => r.SessionId == sessionId),
+                It.Is<GrpcRequestSettings>(s => s.NodeId == nodeId)))
+            .ReturnsAsync(attachStream.Object);
+        driver.Setup(d => d.PessimizeNode(nodeId));
+
+        await using var source = new PoolingSessionSource<PoolingSession>(
+            new PoolingSessionFactory(driver.Object, settings),
+            settings);
+        var session = await source.OpenSession();
+        await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(session.IsBroken);
+        session.Dispose();
+
+        meterProvider.ForceFlush();
+
+        var metric = GetMetric(exportedItems, "ydb.query.session.closed");
+        var point = GetPoolPoints(metric.GetMetricPoints(), settings.PoolName!).Single();
+        var tags = ToDictionary(point.Tags);
+
+        Assert.Equal(1, point.GetSumLong());
+        Assert.Equal(settings.PoolName, tags["ydb.query.session.pool.name"]);
+        Assert.Equal(reason, tags["reason"]);
+    }
+
     [Fact]
     public async Task ConnectionPendingRequests()
     {
@@ -508,7 +578,8 @@ public class YdbMetricTests : TestBase
         "ydb.query.session.min",
         "ydb.query.session.timeouts",
         "ydb.query.session.pending_requests",
-        "ydb.query.session.create_time"
+        "ydb.query.session.create_time",
+        "ydb.query.session.closed"
     ];
 
     private static void AssertNoPoolMetricsForPool(List<Metric> exportedItems, string poolName)


### PR DESCRIPTION
## Summary

- add the `ydb.query.session.closed` counter with unit `{session}`
- report `node_shutdown` and `session_shutdown` directly from the attach-stream hint cases
- expose the `ydb.query.session.pool.name` and `reason` attributes
- document the metric and currently supported reasons in README and CHANGELOG

## Why

The SDK already closes pooled sessions after `NodeShutdown` and `SessionShutdown` hints, but that lifecycle event was not observable through metrics. This PR deliberately covers only the existing shutdown-hint paths; other close reasons will be implemented separately.

Tracker: YDBAPPTEAM-1651 (parent YDB-3470)

## Validation

- `PoolingSessionTests` and `YdbMetricTests`: 41 passed
- CI cleanup profile: passed
- `git diff --check`: passed
