### PR TITLE
feat: report query session closure reasons

### DIFF
--- a/src/Ydb.Sdk.OpenTelemetry/README.md
+++ b/src/Ydb.Sdk.OpenTelemetry/README.md
@@ -59,7 +59,7 @@ Every `ydb.query.session.*` metric includes **`ydb.query.session.pool.name`** (v
 | `ydb.client.operation.duration`      | Histogram         | `s`           | `database`, `endpoint`, `operation.name`                                   | Latency of each actual `ExecuteQuery`, `Commit`, or `Rollback` attempt.                             |
 | `ydb.client.operation.failed`        | Counter           | `{operation}` | `database`, `endpoint`, `operation.name`, `status_code`                    | Unsuccessful operation attempts.                                                                    |
 | `ydb.query.session.create_time`      | Histogram         | `s`           | `ydb.query.session.pool.name`                                              | Cost of session creation (CreateSession + first AttachStream message).                              |
-| `ydb.query.session.closed`           | Counter           | `{session}`   | `ydb.query.session.pool.name`, `reason`                                    | Sessions closed after a server shutdown hint.                                                       |
+| `ydb.query.session.closed`           | Counter           | `{session}`   | `ydb.query.session.pool.name`, `reason`                                    | Pooled sessions closed, grouped by lifecycle reason.                                                |
 | `ydb.query.session.pending_requests` | Counter           | `{request}`   | `ydb.query.session.pool.name`                                              | Increments when a caller starts waiting for a session; use **rate** (not level) for queue pressure. |
 | `ydb.query.session.timeouts`         | Counter           | `{timeout}`   | `ydb.query.session.pool.name`                                              | Pool could not satisfy demand within the acquisition timeout.                                       |
 | `ydb.query.session.count`            | ObservableGauge   | `{session}`   | `ydb.query.session.pool.name`, `ydb.query.session.state` (`idle` / `used`) | Current pool occupancy.                                                                             |
@@ -67,11 +67,6 @@ Every `ydb.query.session.*` metric includes **`ydb.query.session.pool.name`** (v
 | `ydb.query.session.min`              | ObservableGauge   | `{session}`   | `ydb.query.session.pool.name`                                              | Configured `MinPoolSize` (context).                                                                 |
 
 `database` is the YDB database path; `endpoint` is `host:port` from the connection string.
-
-Supported `ydb.query.session.closed` reasons:
-
-- `node_shutdown` — the server sends a node shutdown hint.
-- `session_shutdown` — the server sends a session shutdown hint.
 
 ## Example
 

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,7 +1,18 @@
-- Feat ADO.NET metrics: added the `ydb.query.session.closed` counter (unit `{session}`) with
-  `ydb.query.session.pool.name` and `reason` attributes for server shutdown hints:
-  - `node_shutdown` for `NodeShutdown`.
-  - `session_shutdown` for `SessionShutdown`.
+- Added `StatusCode.ClientCancelled` to represent a client closing an unfinished query stream.
+- Supported `ydb.query.session.closed` reasons:
+
+  - `pool_idle_timeout` — the idle-session cleaner removes a session.
+  - `pool_graceful_shutdown` — pool disposal removes a session.
+  - `client_query_timeout` — a query stream exceeds its client-side transport timeout.
+  - `query_stream_cancelled_by_client` — the client closes an unfinished query stream.
+  - `attach_stream_closed_by_server` — the server closes the active attach stream.
+  - `attach_stream_transport_error` — the active attach stream fails in transport.
+  - `node_shutdown` — the server sends a node shutdown hint.
+  - `session_shutdown` — the server sends a session shutdown hint.
+  - `server_error` — a terminal RPC status retires the session.
+
+  Only pooled query sessions publish this metric. Failure of the initial attach handshake does not count as closing an
+  active session, and implicit sessions do not publish pool metrics.
 
 ## v0.35.0
 

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
@@ -21,14 +21,14 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
 
     private readonly CancellationTokenSource _attachStreamLifecycleCts = new();
 
-    private volatile bool _isBroken = true;
+    private int _isBroken = 1;
     private volatile bool _isBadSession;
 
     private string SessionId { get; set; } = string.Empty;
     private long NodeId { get; set; }
 
     public override IDriver Driver { get; }
-    public override bool IsBroken => _isBroken;
+    public override bool IsBroken => Volatile.Read(ref _isBroken) != 0;
 
     internal PoolingSession(
         IDriver driver,
@@ -111,12 +111,23 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
             StatusCode.ClientTransportTimeout or
             StatusCode.ClientTransportUnavailable or
             StatusCode.ClientTransportResourceExhausted or
-            StatusCode.ClientTransportUnknown)
+            StatusCode.ClientTransportUnknown or
+            StatusCode.ClientCancelled)
         {
             _logger.LogWarning("Session[{SessionId}] is deactivated. Reason Status: {Status}", SessionId, statusCode);
-
-            _isBroken = true;
+            BrokenSession(statusCode switch
+            {
+                StatusCode.ClientTransportTimeout => "client_query_timeout",
+                StatusCode.ClientCancelled => "query_stream_cancelled_by_client",
+                _ => "server_error"
+            });
         }
+    }
+
+    private void BrokenSession(string reason)
+    {
+        if (Interlocked.CompareExchange(ref _isBroken, 1, 0) == 0)
+            MetricsReporter.ReportSessionClosed(reason);
     }
 
     internal override async Task Open(CancellationToken cancellationToken)
@@ -143,105 +154,37 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                 throw YdbException.FromServer(response.Status, response.Issues);
             }
 
-            TaskCompletionSource completeTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
             SessionId = response.SessionId;
             NodeId = response.NodeId;
-            _isBroken = false;
 
-            _ = Task.Run(async () =>
+            var stream = await Driver.ServerStreamCall(
+                QueryService.AttachSessionMethod,
+                new AttachSessionRequest { SessionId = SessionId },
+                new GrpcRequestSettings { NodeId = NodeId }
+            ).ConfigureAwait(false);
+
+            try
             {
-                try
+                if (!await stream.MoveNextAsync(cancellationToken).ConfigureAwait(false))
                 {
-                    using var stream = await Driver.ServerStreamCall(
-                        QueryService.AttachSessionMethod,
-                        new AttachSessionRequest { SessionId = SessionId },
-                        new GrpcRequestSettings { NodeId = NodeId }
-                    ).ConfigureAwait(false);
-
-                    if (!await stream.MoveNextAsync(cancellationToken).ConfigureAwait(false))
-                    {
-                        // Session wasn't started!
-                        completeTask.SetException(new YdbException(StatusCode.Cancelled,
-                            "Attach stream is not started!"));
-
-                        return;
-                    }
-
-                    var initSessionState = stream.Current;
-
-                    if (initSessionState.Status.IsNotSuccess())
-                    {
-                        throw YdbException.FromServer(initSessionState.Status, initSessionState.Issues);
-                    }
-
-                    completeTask.SetResult();
-
-                    var lifecycleAttachToken = _attachStreamLifecycleCts.Token;
-
-                    try
-                    {
-                        // ReSharper disable once MethodSupportsCancellation
-                        while (await stream.MoveNextAsync(lifecycleAttachToken).ConfigureAwait(false))
-                        {
-                            var sessionState = stream.Current;
-
-                            var statusCode = sessionState.Status.Code();
-
-                            OnNotSuccessStatusCode(statusCode);
-                            switch (sessionState.SessionHintCase)
-                            {
-                                case SessionState.SessionHintOneofCase.NodeShutdown:
-                                    MetricsReporter.ReportSessionClosed("node_shutdown");
-                                    Driver.PessimizeNode(NodeId);
-                                    _isBadSession = true;
-                                    _isBroken = true;
-                                    break;
-                                case SessionState.SessionHintOneofCase.SessionShutdown:
-                                    MetricsReporter.ReportSessionClosed("session_shutdown");
-                                    _isBadSession = true;
-                                    _isBroken = true;
-                                    break;
-                            }
-
-                            _logger.LogDebug(
-                                "Session[{SessionId}] was received the status from the attach stream: {StatusMessage}",
-                                SessionId, statusCode.ToMessage(sessionState.Issues));
-
-                            if (IsBroken)
-                            {
-                                return;
-                            }
-                        }
-
-                        _logger.LogDebug("Session[{SessionId}]: Attached stream is closed", SessionId);
-
-                        // attach stream is closed
-                    }
-                    catch (YdbException e)
-                    {
-                        if (e.Code == StatusCode.ClientTransportTimeout)
-                        {
-                            _logger.LogDebug("AttachStream is cancelled (possible grpcChannel is closing)");
-
-                            return;
-                        }
-
-                        _logger.LogWarning(e, "Session[{SessionId}] is deactivated by transport error", SessionId);
-                    }
+                    throw new YdbException(StatusCode.Cancelled, "Attach stream is not started!");
                 }
-                catch (Exception e)
+
+                var initSessionState = stream.Current;
+
+                if (initSessionState.Status.IsNotSuccess())
                 {
-                    completeTask.SetException(e);
+                    throw YdbException.FromServer(initSessionState.Status, initSessionState.Issues);
                 }
-                finally
-                {
-                    // Do not set _isBadSession here: attach stream end (EOF) is not BadSession; DeleteSession must still run.
-                    _isBroken = true;
-                }
-            }, cancellationToken);
+            }
+            catch
+            {
+                stream.Dispose();
+                throw;
+            }
 
-            await completeTask.Task.ConfigureAwait(false);
+            Volatile.Write(ref _isBroken, 0);
+            _ = ProcessAttachStream(stream);
         }
         catch (YdbException e)
         {
@@ -255,11 +198,69 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
         }
     }
 
-    internal override async Task DeleteSession()
+    private async Task ProcessAttachStream(IServerStream<SessionState> stream)
+    {
+        using (stream)
+        {
+            try
+            {
+                // ReSharper disable once MethodSupportsCancellation
+                while (await stream.MoveNextAsync(_attachStreamLifecycleCts.Token).ConfigureAwait(false))
+                {
+                    var sessionState = stream.Current;
+                    var statusCode = sessionState.Status.Code();
+
+                    switch (sessionState.SessionHintCase)
+                    {
+                        case SessionState.SessionHintOneofCase.NodeShutdown:
+                            Driver.PessimizeNode(NodeId);
+                            _isBadSession = true;
+                            BrokenSession("node_shutdown");
+                            break;
+                        case SessionState.SessionHintOneofCase.SessionShutdown:
+                            _isBadSession = true;
+                            BrokenSession("session_shutdown");
+                            break;
+                        case SessionState.SessionHintOneofCase.None:
+                        default:
+                            OnNotSuccessStatusCode(statusCode);
+                            break;
+                    }
+
+                    _logger.LogDebug(
+                        "Session[{SessionId}] was received the status from the attach stream: {StatusMessage}, " +
+                        "hint: {Hint}",
+                        SessionId, statusCode.ToMessage(sessionState.Issues), sessionState.SessionHintCase);
+
+                    if (IsBroken)
+                    {
+                        return;
+                    }
+                }
+
+                _logger.LogDebug("Session[{SessionId}]: Attached stream is closed", SessionId);
+
+                BrokenSession("attach_stream_closed_by_server");
+            }
+            catch (YdbException e)
+            {
+                if (e.Code == StatusCode.ClientTransportTimeout)
+                {
+                    _logger.LogDebug("AttachStream is cancelled (possible grpcChannel is closing)");
+
+                    return;
+                }
+
+                _logger.LogWarning(e, "Session[{SessionId}] is deactivated by transport error", SessionId);
+                BrokenSession("attach_stream_transport_error");
+            }
+        }
+    }
+
+    internal override async Task DeleteSession(string reason)
     {
         try
         {
-            _isBroken = true;
             _attachStreamLifecycleCts.CancelAfter(DeleteSessionTimeout);
 
             if (_isBadSession)
@@ -267,6 +268,7 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                 return;
             }
 
+            BrokenSession(reason);
             _isBadSession = true;
             var deleteSessionResponse = await Driver.UnaryCall(
                 QueryService.DeleteSessionMethod,

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
@@ -257,7 +257,7 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
         if (i == _maxPoolSize)
             return;
 
-        _ = session.DeleteSession();
+        _ = session.DeleteSession(IsDisposed ? "pool_graceful_shutdown" : "pool_idle_timeout");
 
         Interlocked.Decrement(ref _numSessions);
 
@@ -296,8 +296,6 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
 
         await _cleanerTimer.DisposeAsync().ConfigureAwait(false);
         await _disposeCts.CancelAsync().ConfigureAwait(false);
-        MetricsReporter.Dispose();
-
         var sw = Stopwatch.StartNew();
         var spinWait = new SpinWait();
         do
@@ -314,6 +312,8 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
 
             spinWait.SpinOnce();
         } while (_numSessions > 0 && sw.Elapsed < TimeSpan.FromSeconds(DisposeTimeoutSeconds));
+
+        MetricsReporter.Dispose();
 
         try
         {
@@ -377,7 +377,7 @@ internal abstract class PoolingSessionBase<T>(PoolingSessionSource<T> source) : 
 
     internal abstract Task Open(CancellationToken cancellationToken);
 
-    internal abstract Task DeleteSession();
+    internal abstract Task DeleteSession(string reason);
 
     public abstract ValueTask<IServerStream<ExecuteQueryResponsePart>> ExecuteQuery(
         string query,

--- a/src/Ydb.Sdk/src/Ado/YdbDataReader.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbDataReader.cs
@@ -851,8 +851,8 @@ public sealed class YdbDataReader : DbDataReader, IAsyncEnumerable<YdbDataRecord
             return;
         }
 
-        _metricsReporter.ReportOperationFailed(StatusCode.SessionBusy, OperationName);
-        _connection.OnNotSuccessStatusCode(StatusCode.SessionBusy);
+        _metricsReporter.ReportOperationFailed(StatusCode.ClientCancelled, OperationName);
+        _connection.OnNotSuccessStatusCode(StatusCode.ClientCancelled);
         _stream.Dispose();
 
         if (_ydbTransaction != null)

--- a/src/Ydb.Sdk/src/StatusCode.cs
+++ b/src/Ydb.Sdk/src/StatusCode.cs
@@ -32,5 +32,6 @@ public enum StatusCode
     ClientTransportUnavailable = StatusRanges.ClientTransportFirst + 20,
     ClientTransportTimeout = StatusRanges.ClientTransportFirst + 30,
     ClientTransportResourceExhausted = StatusRanges.ClientTransportFirst + 40,
-    ClientTransportUnimplemented = StatusRanges.ClientTransportFirst + 50
+    ClientTransportUnimplemented = StatusRanges.ClientTransportFirst + 50,
+    ClientCancelled = StatusRanges.ClientTransportFirst + 60
 }

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Benchmarks/SessionSourceBenchmark.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Benchmarks/SessionSourceBenchmark.cs
@@ -143,7 +143,7 @@ internal class MockPoolingSession(PoolingSessionSource<MockPoolingSession> sourc
     public override bool IsBroken => false;
 
     internal override async Task Open(CancellationToken cancellationToken) => await Task.Yield();
-    internal override Task DeleteSession() => Task.CompletedTask;
+    internal override Task DeleteSession(string reason) => Task.CompletedTask;
 
     public override ValueTask<IServerStream<ExecuteQueryResponsePart>> ExecuteQuery(
         string query,

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/RetryPolicy/YdbRetryPolicyTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/RetryPolicy/YdbRetryPolicyTests.cs
@@ -145,6 +145,7 @@ public class YdbRetryPolicyTests
     [InlineData(StatusCode.Success)]
     [InlineData(StatusCode.ClientTransportTimeout)]
     [InlineData(StatusCode.ClientTransportUnimplemented)]
+    [InlineData(StatusCode.ClientCancelled)]
     public void GetNextDelay_WhenStatusCodeIsNotRetriable_ReturnNull(StatusCode statusCode) =>
         Assert.Null(YdbRetryPolicy.IdempotenceDefault.GetNextDelay(new YdbException(statusCode, "Mock message"), 1));
 }

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Session/MockPoolingSessionFactory.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Session/MockPoolingSessionFactory.cs
@@ -62,7 +62,7 @@ internal class MockPoolingSession(
     public override bool IsBroken => _isBroken || mockIsBroken(sessionId);
 
     internal override Task Open(CancellationToken cancellationToken) => mockOpen(sessionId);
-    internal override Task DeleteSession() => mockDeleteSession();
+    internal override Task DeleteSession(string reason) => mockDeleteSession();
 
     public override ValueTask<IServerStream<ExecuteQueryResponsePart>> ExecuteQuery(
         string query,

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Session/PoolingSessionTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Session/PoolingSessionTests.cs
@@ -38,14 +38,17 @@ public class PoolingSessionTests
     [Theory]
     [InlineData(StatusCode.Aborted, false)]
     [InlineData(StatusCode.BadSession, true)]
+    [InlineData(StatusCode.Cancelled, false)]
     [InlineData(StatusCode.SessionBusy, true)]
     [InlineData(StatusCode.SessionExpired, true)]
     [InlineData(StatusCode.ClientTransportTimeout, true)]
     [InlineData(StatusCode.ClientTransportUnavailable, true)]
     [InlineData(StatusCode.ClientTransportResourceExhausted, true)]
     [InlineData(StatusCode.ClientTransportUnknown, true)]
+    [InlineData(StatusCode.ClientCancelled, true)]
     [InlineData(StatusCode.Overloaded, false)]
-    public async Task OnNotSuccessStatusCode_WhenStatusCodeIsNotSuccess_UpdateIsBroken(StatusCode statusCode,
+    public async Task OnNotSuccessStatusCode_WhenStatusCodeIsNotSuccess_UpdateIsBroken(
+        StatusCode statusCode,
         bool isError)
     {
         SetupSuccessCreateSession();
@@ -103,7 +106,6 @@ public class PoolingSessionTests
         var ydbException = await Assert.ThrowsAsync<YdbException>(() => session.Open(CancellationToken.None));
         Assert.Equal("Transport RPC call error", ydbException.Message);
         Assert.Equal(StatusCode.ClientTransportTimeout, ydbException.Code);
-        await Task.Delay(500);
         Assert.True(session.IsBroken);
     }
 
@@ -116,7 +118,6 @@ public class PoolingSessionTests
         var ydbException = await Assert.ThrowsAsync<YdbException>(() => session.Open(CancellationToken.None));
         Assert.Equal("Attach stream is not started!", ydbException.Message);
         Assert.Equal(StatusCode.Cancelled, ydbException.Code);
-        await Task.Delay(500);
         Assert.True(session.IsBroken);
     }
 
@@ -137,7 +138,6 @@ public class PoolingSessionTests
         var ydbException = await Assert.ThrowsAsync<YdbException>(() => session.Open(CancellationToken.None));
         Assert.Equal("Status: BadSession, Issues:\n[1] Error: Ouch BadSession!", ydbException.Message);
         Assert.Equal(StatusCode.BadSession, ydbException.Code);
-        await Task.Delay(500);
         Assert.True(session.IsBroken);
     }
 
@@ -156,18 +156,19 @@ public class PoolingSessionTests
     }
 
     [Fact]
-    public async Task Open_WhenSuccessOpenThenAttachStreamSendRpcException_IsBroken()
+    public async Task Open_WhenSuccessOpenThenAttachStreamIsCancelled_IsNotBroken()
     {
         SetupSuccessCreateSession();
         var tcsSecondMoveAttachStream = SetupAttachStream();
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _mockAttachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
         var session = _poolingSessionFactory.NewSession(_poolingSessionSource);
         await session.Open(CancellationToken.None);
         Assert.False(session.IsBroken);
         tcsSecondMoveAttachStream.SetException(
-            new YdbException(new RpcException(Status.DefaultCancelled))); // attach stream is closed
-        await Task.Delay(500);
-        Assert.True(session.IsBroken);
-        await CheckIsBrokenAndDeleteSessionOneTime(session);
+            new YdbException(new RpcException(Status.DefaultCancelled)));
+        await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(session.IsBroken);
     }
 
     [Fact]
@@ -203,10 +204,10 @@ public class PoolingSessionTests
         var session = _poolingSessionFactory.NewSession(_poolingSessionSource);
         await session.Open(CancellationToken.None);
         Assert.False(session.IsBroken);
-        session.OnNotSuccessStatusCode(StatusCode.BadSession);
+        tcsSecondMoveAttachStream.TrySetResult(true);
+        await WaitUntilSessionBrokenAfterAttachAsync(session);
         Assert.True(session.IsBroken);
         await CheckIsBrokenAndDeleteSessionNeverTimes(session);
-        tcsSecondMoveAttachStream.TrySetResult(false);
     }
 
     [Fact]
@@ -323,7 +324,7 @@ public class PoolingSessionTests
             It.IsAny<DeleteSessionRequest>(),
             It.IsAny<GrpcRequestSettings>()
         )).ReturnsAsync(new DeleteSessionResponse { Status = StatusIds.Types.StatusCode.Success });
-        await session.DeleteSession();
+        await session.DeleteSession("pool_graceful_shutdown");
         _mockIDriver.Verify(driver => driver.UnaryCall(QueryService.DeleteSessionMethod,
             It.IsAny<DeleteSessionRequest>(), It.IsAny<GrpcRequestSettings>()), Times.Never());
         Assert.True(session.IsBroken);
@@ -336,7 +337,7 @@ public class PoolingSessionTests
             It.Is<DeleteSessionRequest>(request => request.SessionId.Equals(SessionId)),
             It.Is<GrpcRequestSettings>(grpcRequestSettings => grpcRequestSettings.NodeId == NodeId)
         )).ReturnsAsync(new DeleteSessionResponse { Status = StatusIds.Types.StatusCode.Success });
-        await session.DeleteSession();
+        await session.DeleteSession("pool_graceful_shutdown");
         _mockIDriver.Verify(driver => driver.UnaryCall(QueryService.DeleteSessionMethod,
             It.IsAny<DeleteSessionRequest>(), It.IsAny<GrpcRequestSettings>()));
         Assert.True(session.IsBroken);

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbAdoUserPasswordTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbAdoUserPasswordTests.cs
@@ -31,12 +31,24 @@ public class YdbAdoUserPasswordTests : TestBase
     [Fact]
     public async Task DisableDiscovery_WhenUserIsCreatedAndPropertyIsTrue_SimpleWorking()
     {
-        await using var userPasswordConnection = new YdbConnection(
-            $"{ConnectionString};User={_user};Password=password;DisableDiscovery=true");
-        await userPasswordConnection.OpenAsync();
-        var ydbCommand = userPasswordConnection.CreateCommand();
-        ydbCommand.CommandText = "SELECT 1 + 2";
-        Assert.Equal(3, await ydbCommand.ExecuteScalarAsync());
+        for (var attempt = 1;; attempt++)
+        {
+            try
+            {
+                await using var userPasswordConnection = new YdbConnection(
+                    $"{ConnectionString};User={_user};Password=password;DisableDiscovery=true");
+                await userPasswordConnection.OpenAsync();
+                var ydbCommand = userPasswordConnection.CreateCommand();
+                ydbCommand.CommandText = "SELECT 1 + 2";
+                Assert.Equal(3, await ydbCommand.ExecuteScalarAsync());
+
+                return;
+            }
+            catch (YdbException) when (attempt < 5)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+        }
     }
 
     protected override async Task OnInitializeAsync()

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbMetricTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbMetricTests.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Diagnostics;
 using Grpc.Core;
 using Moq;
@@ -16,6 +17,9 @@ namespace Ydb.Sdk.Ado.Tests;
 [Collection("DisableParallelization")]
 public class YdbMetricTests : TestBase
 {
+    private const string MockSessionId = "sessionId";
+    private const long MockNodeId = 3;
+
     private static readonly YdbConnectionStringBuilder BaseConnectionSettings = new(TestUtils.ConnectionString)
     {
         PoolName = "ado-metrics-tests"
@@ -239,8 +243,6 @@ public class YdbMetricTests : TestBase
         SessionState.SessionHintOneofCase hint,
         string reason)
     {
-        const string sessionId = "sessionId";
-        const long nodeId = 3;
         var exportedItems = new List<Metric>();
         using var meterProvider = CreateMeterProvider(exportedItems);
 
@@ -265,23 +267,7 @@ public class YdbMetricTests : TestBase
             .Returns(lifecycleState);
         attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
 
-        var driver = CreateMockDriver();
-        driver.Setup(d => d.UnaryCall(
-                QueryService.CreateSessionMethod,
-                It.IsAny<CreateSessionRequest>(),
-                It.Is<GrpcRequestSettings>(s => s.ClientCapabilities.Contains("session-balancer"))))
-            .ReturnsAsync(new CreateSessionResponse
-            {
-                Status = StatusIds.Types.StatusCode.Success,
-                SessionId = sessionId,
-                NodeId = nodeId
-            });
-        driver.Setup(d => d.ServerStreamCall(
-                QueryService.AttachSessionMethod,
-                It.Is<AttachSessionRequest>(r => r.SessionId == sessionId),
-                It.Is<GrpcRequestSettings>(s => s.NodeId == nodeId)))
-            .ReturnsAsync(attachStream.Object);
-        driver.Setup(d => d.PessimizeNode(nodeId));
+        var driver = CreatePoolingDriver(attachStream.Object);
 
         await using var source = new PoolingSessionSource<PoolingSession>(
             new PoolingSessionFactory(driver.Object, settings),
@@ -292,14 +278,369 @@ public class YdbMetricTests : TestBase
         session.Dispose();
 
         meterProvider.ForceFlush();
+        AssertSessionClosed(exportedItems, settings, reason);
+    }
 
-        var metric = GetMetric(exportedItems, "ydb.query.session.closed");
-        var point = GetPoolPoints(metric.GetMetricPoints(), settings.PoolName!).Single();
-        var tags = ToDictionary(point.Tags);
+    [Theory]
+    [InlineData(false, "eof")]
+    [InlineData(false, "hint")]
+    [InlineData(false, "error")]
+    [InlineData(true, "eof")]
+    [InlineData(true, "hint")]
+    [InlineData(true, "error")]
+    public async Task SessionClosed_ServerErrorBeforeLateAttachTermination_ReportsOnce(
+        bool retryable,
+        string lateAttachTermination)
+    {
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
 
-        Assert.Equal(1, point.GetSumLong());
-        Assert.Equal(settings.PoolName, tags["ydb.query.session.pool.name"]);
-        Assert.Equal(reason, tags["reason"]);
+        var settings = CreateConnectionSettings(builder =>
+        {
+            builder.MaxPoolSize = 1;
+            builder.PoolName = $"ado-metrics-query-error-{retryable}-{lateAttachTermination}";
+        });
+        var lifecycleAttach = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachStream = new Mock<IServerStream<SessionState>>(MockBehavior.Strict);
+        attachStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .Returns(lifecycleAttach.Task);
+        attachStream.SetupSequence(stream => stream.Current)
+            .Returns(new SessionState { Status = StatusIds.Types.StatusCode.Success })
+            .Returns(new SessionState
+            {
+                Status = StatusIds.Types.StatusCode.Success,
+                SessionShutdown = new SessionShutdownHint()
+            });
+        attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
+
+        var queryErrorObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var queryDrain = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var queryStream = new Mock<IServerStream<ExecuteQueryResponsePart>>(MockBehavior.Strict);
+        queryStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .Returns(queryDrain.Task);
+        queryStream.Setup(stream => stream.Current)
+            .Callback(() => queryErrorObserved.TrySetResult())
+            .Returns(new ExecuteQueryResponsePart { Status = StatusIds.Types.StatusCode.SessionBusy });
+
+        var driver = CreatePoolingDriver(attachStream.Object, queryStream.Object);
+
+        await using var source = new PoolingSessionSource<PoolingSession>(
+            new PoolingSessionFactory(driver.Object, settings),
+            settings);
+        Assert.True(PoolManager.Pools.TryAdd(settings.PoolKey, source));
+        try
+        {
+            await using var connection = new YdbConnection(settings);
+            if (retryable)
+                await connection.OpenAsync(new YdbRetryPolicyExecutor(
+                    new YdbRetryPolicy(new YdbRetryPolicyConfig { MaxAttempts = 1 })));
+            else
+                await connection.OpenAsync();
+
+            var queryTask = new YdbCommand("SELECT 1", connection).ExecuteReaderAsync();
+            await queryErrorObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            queryDrain.SetResult(false);
+            var exception = await Assert.ThrowsAsync<YdbException>(() => queryTask);
+            Assert.Equal(StatusCode.SessionBusy, exception.Code);
+            Assert.Equal(retryable ? ConnectionState.Open : ConnectionState.Broken, connection.State);
+
+            switch (lateAttachTermination)
+            {
+                case "eof":
+                    lifecycleAttach.SetResult(false);
+                    break;
+                case "hint":
+                    lifecycleAttach.SetResult(true);
+                    break;
+                case "error":
+                    lifecycleAttach.SetException(
+                        new YdbException(StatusCode.ClientTransportUnavailable, "late attach error"));
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(lateAttachTermination));
+            }
+
+            await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await connection.CloseAsync();
+            meterProvider.ForceFlush();
+
+            AssertSessionClosed(exportedItems, settings, "server_error");
+            driver.Verify(d => d.UnaryCall(
+                QueryService.DeleteSessionMethod,
+                It.IsAny<DeleteSessionRequest>(),
+                It.IsAny<GrpcRequestSettings>()), Times.AtMostOnce());
+        }
+        finally
+        {
+            Assert.True(PoolManager.Pools.TryRemove(settings.PoolKey, out _));
+        }
+    }
+
+    [Theory]
+    [InlineData(false, "attach_stream_closed_by_server")]
+    [InlineData(true, "attach_stream_transport_error")]
+    public async Task SessionClosed_WhenActiveAttachStreamTerminates_ReportsReason(
+        bool transportError,
+        string reason)
+    {
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+
+        var settings = CreateConnectionSettings(builder =>
+        {
+            builder.MaxPoolSize = 1;
+            builder.PoolName = $"ado-metrics-{reason}";
+        });
+        var lifecycleAttach = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachStream = new Mock<IServerStream<SessionState>>(MockBehavior.Strict);
+        attachStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .Returns(lifecycleAttach.Task);
+        attachStream.Setup(stream => stream.Current)
+            .Returns(new SessionState { Status = StatusIds.Types.StatusCode.Success });
+        attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
+
+        var driver = CreatePoolingDriver(attachStream.Object);
+        await using var source = new PoolingSessionSource<PoolingSession>(
+            new PoolingSessionFactory(driver.Object, settings),
+            settings);
+        var session = await source.OpenSession();
+
+        if (transportError)
+        {
+            lifecycleAttach.SetException(
+                new YdbException(StatusCode.ClientTransportUnavailable, "attach transport error"));
+        }
+        else
+        {
+            lifecycleAttach.SetResult(false);
+        }
+
+        await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(session.IsBroken);
+        session.Dispose();
+
+        meterProvider.ForceFlush();
+        AssertSessionClosed(exportedItems, settings, reason);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SessionClosed_WhenPrimaryAttachFails_DoesNotReport(bool transportError)
+    {
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+
+        var settings = CreateConnectionSettings(builder =>
+            builder.PoolName = $"ado-metrics-primary-attach-{transportError}");
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachStream = new Mock<IServerStream<SessionState>>(MockBehavior.Strict);
+        var firstMove = attachStream.Setup(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()));
+        if (transportError)
+        {
+            firstMove.ThrowsAsync(
+                new YdbException(StatusCode.ClientTransportUnavailable, "primary attach transport error"));
+        }
+        else
+        {
+            firstMove.ReturnsAsync(false);
+        }
+
+        attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
+
+        var driver = CreatePoolingDriver(attachStream.Object);
+        await using var source = new PoolingSessionSource<PoolingSession>(
+            new PoolingSessionFactory(driver.Object, settings),
+            settings);
+
+        await Assert.ThrowsAsync<YdbException>(() => source.OpenSession().AsTask());
+        await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        meterProvider.ForceFlush();
+        AssertSessionNotClosed(exportedItems, settings.PoolName!);
+    }
+
+    [Theory]
+    [InlineData(Grpc.Core.StatusCode.DeadlineExceeded)]
+    [InlineData(Grpc.Core.StatusCode.Cancelled)]
+    public async Task SessionClosed_QueryTransportTimeout_ReportsReason(Grpc.Core.StatusCode grpcStatusCode)
+    {
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+
+        var settings = CreateConnectionSettings(builder =>
+        {
+            builder.MaxPoolSize = 1;
+            builder.PoolName = $"ado-metrics-query-timeout-{grpcStatusCode}";
+        });
+        var lifecycleAttach = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachStream = new Mock<IServerStream<SessionState>>(MockBehavior.Strict);
+        attachStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .Returns(lifecycleAttach.Task);
+        attachStream.Setup(stream => stream.Current)
+            .Returns(new SessionState { Status = StatusIds.Types.StatusCode.Success });
+        attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
+
+        var queryStream = new Mock<IServerStream<ExecuteQueryResponsePart>>(MockBehavior.Strict);
+        queryStream.Setup(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new YdbException(new RpcException(new Status(grpcStatusCode, "query transport timeout"))));
+
+        var driver = CreatePoolingDriver(attachStream.Object, queryStream.Object);
+        await using var source = new PoolingSessionSource<PoolingSession>(
+            new PoolingSessionFactory(driver.Object, settings),
+            settings);
+        Assert.True(PoolManager.Pools.TryAdd(settings.PoolKey, source));
+        try
+        {
+            await using var connection = new YdbConnection(settings);
+            await connection.OpenAsync();
+
+            var exception = await Assert.ThrowsAsync<YdbException>(() =>
+                new YdbCommand("SELECT 1", connection).ExecuteReaderAsync());
+            Assert.Equal(StatusCode.ClientTransportTimeout, exception.Code);
+
+            Assert.Equal(ConnectionState.Broken, connection.State);
+
+            lifecycleAttach.SetResult(false);
+            await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await connection.CloseAsync();
+
+            meterProvider.ForceFlush();
+            AssertSessionClosed(exportedItems, settings, "client_query_timeout");
+        }
+        finally
+        {
+            Assert.True(PoolManager.Pools.TryRemove(settings.PoolKey, out _));
+        }
+    }
+
+    [Fact]
+    public async Task SessionClosed_WhenClientClosesUnreadQueryStream_ReportsReason()
+    {
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+
+        var settings = CreateConnectionSettings(builder =>
+        {
+            builder.MaxPoolSize = 1;
+            builder.PoolName = "ado-metrics-query-stream-cancelled";
+        });
+        var lifecycleAttach = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachStream = new Mock<IServerStream<SessionState>>(MockBehavior.Strict);
+        attachStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .Returns(lifecycleAttach.Task);
+        attachStream.Setup(stream => stream.Current)
+            .Returns(new SessionState { Status = StatusIds.Types.StatusCode.Success });
+        attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
+
+        var resultSet = ResultSet.Parser.ParseJson(
+            "{ \"columns\": [ { \"name\": \"column0\", \"type\": { \"typeId\": \"BOOL\" } } ], " +
+            "\"rows\": [ { \"items\": [ { \"boolValue\": true } ] } ] }");
+        var queryStream = new Mock<IServerStream<ExecuteQueryResponsePart>>(MockBehavior.Strict);
+        queryStream.Setup(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        queryStream.Setup(stream => stream.Current).Returns(new ExecuteQueryResponsePart
+        {
+            Status = StatusIds.Types.StatusCode.Success,
+            ResultSet = resultSet
+        });
+        queryStream.Setup(stream => stream.Dispose());
+
+        var driver = CreatePoolingDriver(attachStream.Object, queryStream.Object);
+        await using var source = new PoolingSessionSource<PoolingSession>(
+            new PoolingSessionFactory(driver.Object, settings),
+            settings);
+        Assert.True(PoolManager.Pools.TryAdd(settings.PoolKey, source));
+        try
+        {
+            await using var connection = new YdbConnection(settings);
+            await connection.OpenAsync();
+
+            await using var reader = await new YdbCommand("SELECT 1", connection).ExecuteReaderAsync();
+            await reader.CloseAsync();
+            Assert.Equal(ConnectionState.Broken, connection.State);
+
+            lifecycleAttach.SetResult(false);
+            await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await connection.CloseAsync();
+
+            meterProvider.ForceFlush();
+            AssertSessionClosed(exportedItems, settings, "query_stream_cancelled_by_client");
+
+            var operationFailed = GetMetric(exportedItems, "ydb.client.operation.failed");
+            var point = GetOperationFailedPoint(
+                operationFailed.GetMetricPoints(), settings, "ExecuteQuery", "ClientCancelled");
+            Assert.Equal(1, point.GetSumLong());
+        }
+        finally
+        {
+            Assert.True(PoolManager.Pools.TryRemove(settings.PoolKey, out _));
+        }
+    }
+
+    [Theory]
+    [InlineData(false, "pool_idle_timeout")]
+    [InlineData(true, "pool_graceful_shutdown")]
+    public async Task SessionClosed_WhenPoolClosesIdleSession_ReportsReason(
+        bool disposePool,
+        string reason)
+    {
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+
+        var settings = CreateConnectionSettings(builder =>
+        {
+            builder.MaxPoolSize = 1;
+            builder.SessionIdleTimeout = 1;
+            builder.PoolName = $"ado-metrics-{reason}";
+        });
+        var lifecycleAttach = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deleteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachStream = new Mock<IServerStream<SessionState>>(MockBehavior.Strict);
+        attachStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .Returns(lifecycleAttach.Task);
+        attachStream.Setup(stream => stream.Current)
+            .Returns(new SessionState { Status = StatusIds.Types.StatusCode.Success });
+        attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
+
+        var driver = CreatePoolingDriver(attachStream.Object, deleteSession: () =>
+        {
+            deleteStarted.TrySetResult();
+            lifecycleAttach.TrySetResult(false);
+        });
+        var source = new PoolingSessionSource<PoolingSession>(
+            new PoolingSessionFactory(driver.Object, settings),
+            settings);
+        try
+        {
+            var session = await source.OpenSession();
+            session.Dispose();
+
+            if (disposePool)
+                await source.DisposeAsync();
+
+            await deleteStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            meterProvider.ForceFlush();
+            AssertSessionClosed(exportedItems, settings, reason);
+        }
+        finally
+        {
+            await source.DisposeAsync();
+        }
     }
 
     [Fact]
@@ -401,14 +742,42 @@ public class YdbMetricTests : TestBase
         var exportedItems = new List<Metric>();
         using var meterProvider = CreateMeterProvider(exportedItems);
 
-        var settings = CreateConnectionSettings(builder => { builder.EnableImplicitSession = true; });
+        var settings = CreateConnectionSettings(builder =>
+        {
+            builder.EnableImplicitSession = true;
+            builder.PoolName = "ado-metrics-implicit-query-error";
+        });
+        var queryStream = new Mock<IServerStream<ExecuteQueryResponsePart>>(MockBehavior.Strict);
+        queryStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+        queryStream.Setup(stream => stream.Current)
+            .Returns(new ExecuteQueryResponsePart { Status = StatusIds.Types.StatusCode.SessionBusy });
 
-        await using var dataSource = new YdbDataSource(settings);
-        await using var _ = await dataSource.OpenConnectionAsync();
+        var driver = CreateMockDriver();
+        driver.Setup(d => d.ServerStreamCall(
+                QueryService.ExecuteQueryMethod,
+                It.IsAny<ExecuteQueryRequest>(),
+                It.IsAny<GrpcRequestSettings>()))
+            .ReturnsAsync(queryStream.Object);
 
-        meterProvider.ForceFlush();
+        await using var source = new ImplicitSessionSource(driver.Object, settings);
+        Assert.True(PoolManager.Pools.TryAdd(settings.PoolKey, source));
+        try
+        {
+            await using var connection = new YdbConnection(settings);
+            await connection.OpenAsync();
 
-        AssertNoPoolMetricsForPool(exportedItems, settings.PoolName!);
+            await Assert.ThrowsAsync<YdbException>(() =>
+                new YdbCommand("SELECT 1", connection).ExecuteReaderAsync());
+
+            meterProvider.ForceFlush();
+            AssertNoPoolMetricsForPool(exportedItems, settings.PoolName!);
+        }
+        finally
+        {
+            Assert.True(PoolManager.Pools.TryRemove(settings.PoolKey, out _));
+        }
     }
 
     private const string RetryDurationMetric = "ydb.client.retry.duration";
@@ -623,6 +992,68 @@ public class YdbMetricTests : TestBase
         driver.SetupGet(d => d.LoggerFactory).Returns(TestUtils.LoggerFactory);
         driver.Setup(d => d.DisposeAsync()).Returns(ValueTask.CompletedTask);
         return driver;
+    }
+
+    private static Mock<IDriver> CreatePoolingDriver(
+        IServerStream<SessionState> attachStream,
+        IServerStream<ExecuteQueryResponsePart>? queryStream = null,
+        Action? deleteSession = null)
+    {
+        var driver = CreateMockDriver();
+        driver.Setup(d => d.UnaryCall(
+                QueryService.CreateSessionMethod,
+                It.IsAny<CreateSessionRequest>(),
+                It.Is<GrpcRequestSettings>(s => s.ClientCapabilities.Contains("session-balancer"))))
+            .ReturnsAsync(new CreateSessionResponse
+            {
+                Status = StatusIds.Types.StatusCode.Success,
+                SessionId = MockSessionId,
+                NodeId = MockNodeId
+            });
+        driver.Setup(d => d.ServerStreamCall(
+                QueryService.AttachSessionMethod,
+                It.Is<AttachSessionRequest>(r => r.SessionId == MockSessionId),
+                It.Is<GrpcRequestSettings>(s => s.NodeId == MockNodeId)))
+            .ReturnsAsync(attachStream);
+        driver.Setup(d => d.UnaryCall(
+                QueryService.DeleteSessionMethod,
+                It.Is<DeleteSessionRequest>(r => r.SessionId == MockSessionId),
+                It.Is<GrpcRequestSettings>(s => s.NodeId == MockNodeId)))
+            .Callback(() => deleteSession?.Invoke())
+            .ReturnsAsync(new DeleteSessionResponse { Status = StatusIds.Types.StatusCode.Success });
+        driver.Setup(d => d.PessimizeNode(MockNodeId));
+
+        if (queryStream != null)
+        {
+            driver.Setup(d => d.ServerStreamCall(
+                    QueryService.ExecuteQueryMethod,
+                    It.IsAny<ExecuteQueryRequest>(),
+                    It.Is<GrpcRequestSettings>(s => s.NodeId == MockNodeId)))
+                .ReturnsAsync(queryStream);
+        }
+
+        return driver;
+    }
+
+    private static void AssertSessionClosed(
+        List<Metric> exportedItems,
+        YdbConnectionStringBuilder settings,
+        string reason)
+    {
+        var metric = GetMetric(exportedItems, "ydb.query.session.closed");
+        var point = GetPoolPoints(metric.GetMetricPoints(), settings.PoolName!).Single();
+        var tags = ToDictionary(point.Tags);
+
+        Assert.Equal(1, point.GetSumLong());
+        Assert.Equal(settings.PoolName, tags["ydb.query.session.pool.name"]);
+        Assert.Equal(reason, tags["reason"]);
+    }
+
+    private static void AssertSessionNotClosed(List<Metric> exportedItems, string poolName)
+    {
+        var metric = exportedItems.SingleOrDefault(m => m.Name == "ydb.query.session.closed");
+        if (metric != null)
+            Assert.Empty(GetPoolPoints(metric.GetMetricPoints(), poolName));
     }
 
     private static IEnumerable<MetricPoint> GetConnectionCountPoints(MetricPointsAccessor points, string poolName)


### PR DESCRIPTION
Reports `ydb.query.session.closed` once per pooled session with the actual lifecycle reason. Adds `ClientCancelled` for explicit unread-stream closure and keeps server cancellation separate.

Checks:
- JetBrains Cleanup Code 2025.3.2
- 87 targeted lifecycle/status/metric tests
- `dotnet build src/YdbSdk.sln --no-restore`
