### PR TITLE
Refine query session closure reasons

### DIFF
--- a/src/Ydb.Sdk.OpenTelemetry/README.md
+++ b/src/Ydb.Sdk.OpenTelemetry/README.md
@@ -73,6 +73,21 @@ Every `ydb.query.session.*` metric includes **`ydb.query.session.pool.name`** (v
 | `ydb.query.session.max`              | ObservableGauge   | `{session}`   | `ydb.query.session.pool.name`                                              | Configured `MaxPoolSize` (context).                                                                 |
 | `ydb.query.session.min`              | ObservableGauge   | `{session}`   | `ydb.query.session.pool.name`                                              | Configured `MinPoolSize` (context).                                                                 |
 
+`ydb.query.session.closed` uses these `reason` values:
+
+| Reason                   | Description                                                        |
+|--------------------------|--------------------------------------------------------------------|
+| `pool_idle_timeout`      | The idle-session cleaner removes a session.                        |
+| `pool_graceful_shutdown` | Pool disposal removes a session.                                   |
+| `client_timeout`         | A query stream exceeds its client-side transport timeout.          |
+| `client_cancelled`       | The client closes an unfinished query stream.                      |
+| `attach_closed`          | The server closes the active attach stream.                        |
+| `transport_error`        | A transport failure, including query `Unavailable` or attach failure, retires the session. |
+| `node_shutdown`          | The server sends a node shutdown hint.                             |
+| `session_shutdown`       | The server sends a session shutdown hint.                          |
+| `bad_session`            | The server returns `BadSession` or `SessionExpired`.               |
+| `session_busy`           | The server returns `SessionBusy`.                                  |
+
 `database` is the YDB database path; `endpoint` is `host:port` from the connection string.
 
 ## Example

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -6,13 +6,14 @@
 
   - `pool_idle_timeout` — the idle-session cleaner removes a session.
   - `pool_graceful_shutdown` — pool disposal removes a session.
-  - `client_query_timeout` — a query stream exceeds its client-side transport timeout.
-  - `query_stream_cancelled_by_client` — the client closes an unfinished query stream.
-  - `attach_stream_closed_by_server` — the server closes the active attach stream.
-  - `attach_stream_transport_error` — the active attach stream fails in transport.
+  - `client_timeout` — a query stream exceeds its client-side transport timeout.
+  - `client_cancelled` — the client closes an unfinished query stream.
+  - `attach_closed` — the server closes the active attach stream.
+  - `transport_error` — a transport failure, including query `Unavailable` or an attach stream failure, retires the session.
   - `node_shutdown` — the server sends a node shutdown hint.
   - `session_shutdown` — the server sends a session shutdown hint.
-  - `server_error` — a terminal RPC status retires the session.
+  - `bad_session` — the server returns `BadSession` or `SessionExpired`.
+  - `session_busy` — the server returns `SessionBusy`.
 
   Only pooled query sessions publish this metric. Failure of the initial attach handshake does not count as closing an
   active session, and implicit sessions do not publish pool metrics.

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
@@ -102,29 +102,27 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
 
     public override void OnNotSuccessStatusCode(StatusCode statusCode)
     {
-        _isBadSession = _isBadSession || statusCode is StatusCode.BadSession;
-
-        if (statusCode is
-            StatusCode.BadSession or
-            StatusCode.SessionBusy or
-            StatusCode.SessionExpired or
-            StatusCode.ClientTransportTimeout or
-            StatusCode.ClientTransportUnavailable or
-            StatusCode.ClientTransportResourceExhausted or
-            StatusCode.ClientTransportUnknown or
-            StatusCode.ClientCancelled)
+        var reason = statusCode switch
         {
-            _logger.LogWarning("Session[{SessionId}] is deactivated. Reason Status: {Status}", SessionId, statusCode);
-            BrokenSession(statusCode switch
-            {
-                StatusCode.ClientTransportTimeout => "client_query_timeout",
-                StatusCode.ClientCancelled => "query_stream_cancelled_by_client",
-                _ => "server_error"
-            });
-        }
+            StatusCode.BadSession or StatusCode.SessionExpired => SessionClosedReason.BadSession,
+            StatusCode.SessionBusy => SessionClosedReason.SessionBusy,
+            StatusCode.ClientTransportTimeout => SessionClosedReason.ClientTimeout,
+            StatusCode.ClientCancelled => SessionClosedReason.ClientCancelled,
+            StatusCode.ClientTransportUnavailable or
+                StatusCode.ClientTransportResourceExhausted or
+                StatusCode.ClientTransportUnknown => SessionClosedReason.TransportError,
+            _ => (SessionClosedReason?)null
+        };
+
+        if (reason == null)
+            return;
+
+        _isBadSession = _isBadSession || reason is SessionClosedReason.BadSession;
+        _logger.LogWarning("Session[{SessionId}] is deactivated. Reason Status: {Status}", SessionId, statusCode);
+        BrokenSession(reason.Value);
     }
 
-    private void BrokenSession(string reason)
+    private void BrokenSession(SessionClosedReason reason)
     {
         if (Interlocked.CompareExchange(ref _isBroken, 1, 0) == 0)
             MetricsReporter.ReportSessionClosed(reason);
@@ -215,11 +213,11 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                         case SessionState.SessionHintOneofCase.NodeShutdown:
                             Driver.PessimizeNode(NodeId);
                             _isBadSession = true;
-                            BrokenSession("node_shutdown");
+                            BrokenSession(SessionClosedReason.NodeShutdown);
                             break;
                         case SessionState.SessionHintOneofCase.SessionShutdown:
                             _isBadSession = true;
-                            BrokenSession("session_shutdown");
+                            BrokenSession(SessionClosedReason.SessionShutdown);
                             break;
                         case SessionState.SessionHintOneofCase.None:
                         default:
@@ -240,7 +238,7 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
 
                 _logger.LogDebug("Session[{SessionId}]: Attached stream is closed", SessionId);
 
-                BrokenSession("attach_stream_closed_by_server");
+                BrokenSession(SessionClosedReason.AttachClosed);
             }
             catch (YdbException e)
             {
@@ -252,12 +250,12 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
                 }
 
                 _logger.LogWarning(e, "Session[{SessionId}] is deactivated by transport error", SessionId);
-                BrokenSession("attach_stream_transport_error");
+                BrokenSession(SessionClosedReason.TransportError);
             }
         }
     }
 
-    internal override async Task DeleteSession(string reason)
+    internal override async Task DeleteSession(SessionClosedReason reason)
     {
         try
         {

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSession.cs
@@ -102,24 +102,34 @@ internal class PoolingSession : PoolingSessionBase<PoolingSession>
 
     public override void OnNotSuccessStatusCode(StatusCode statusCode)
     {
-        var reason = statusCode switch
+        SessionClosedReason reason;
+        switch (statusCode)
         {
-            StatusCode.BadSession or StatusCode.SessionExpired => SessionClosedReason.BadSession,
-            StatusCode.SessionBusy => SessionClosedReason.SessionBusy,
-            StatusCode.ClientTransportTimeout => SessionClosedReason.ClientTimeout,
-            StatusCode.ClientCancelled => SessionClosedReason.ClientCancelled,
-            StatusCode.ClientTransportUnavailable or
-                StatusCode.ClientTransportResourceExhausted or
-                StatusCode.ClientTransportUnknown => SessionClosedReason.TransportError,
-            _ => (SessionClosedReason?)null
-        };
+            case StatusCode.BadSession:
+            case StatusCode.SessionExpired:
+                _isBadSession = true;
+                reason = SessionClosedReason.BadSession;
+                break;
+            case StatusCode.SessionBusy:
+                reason = SessionClosedReason.SessionBusy;
+                break;
+            case StatusCode.ClientTransportTimeout:
+                reason = SessionClosedReason.ClientTimeout;
+                break;
+            case StatusCode.ClientCancelled:
+                reason = SessionClosedReason.ClientCancelled;
+                break;
+            case StatusCode.ClientTransportUnavailable:
+            case StatusCode.ClientTransportResourceExhausted:
+            case StatusCode.ClientTransportUnknown:
+                reason = SessionClosedReason.TransportError;
+                break;
+            default:
+                return;
+        }
 
-        if (reason == null)
-            return;
-
-        _isBadSession = _isBadSession || reason is SessionClosedReason.BadSession;
         _logger.LogWarning("Session[{SessionId}] is deactivated. Reason Status: {Status}", SessionId, statusCode);
-        BrokenSession(reason.Value);
+        BrokenSession(reason);
     }
 
     private void BrokenSession(SessionClosedReason reason)

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Ydb.Query;
 
@@ -374,8 +373,20 @@ internal enum SessionClosedReason
 
 internal static class SessionClosedReasonExtensions
 {
-    internal static string ToMetricValue(this SessionClosedReason reason) =>
-        JsonNamingPolicy.SnakeCaseLower.ConvertName(reason.ToString());
+    internal static string ToMetricValue(this SessionClosedReason reason) => reason switch
+    {
+        SessionClosedReason.PoolIdleTimeout => "pool_idle_timeout",
+        SessionClosedReason.PoolGracefulShutdown => "pool_graceful_shutdown",
+        SessionClosedReason.ClientTimeout => "client_timeout",
+        SessionClosedReason.ClientCancelled => "client_cancelled",
+        SessionClosedReason.AttachClosed => "attach_closed",
+        SessionClosedReason.TransportError => "transport_error",
+        SessionClosedReason.NodeShutdown => "node_shutdown",
+        SessionClosedReason.SessionShutdown => "session_shutdown",
+        SessionClosedReason.BadSession => "bad_session",
+        SessionClosedReason.SessionBusy => "session_busy",
+        _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, null)
+    };
 }
 
 internal abstract class PoolingSessionBase<T>(PoolingSessionSource<T> source) : ISession

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
@@ -257,7 +257,9 @@ internal sealed class PoolingSessionSource<T> : ISessionSource where T : Pooling
         if (i == _maxPoolSize)
             return;
 
-        _ = session.DeleteSession(IsDisposed ? "pool_graceful_shutdown" : "pool_idle_timeout");
+        _ = session.DeleteSession(IsDisposed
+            ? SessionClosedReason.PoolGracefulShutdown
+            : SessionClosedReason.PoolIdleTimeout);
 
         Interlocked.Decrement(ref _numSessions);
 
@@ -355,6 +357,20 @@ internal enum PoolingSessionState
     Clean
 }
 
+internal enum SessionClosedReason
+{
+    PoolIdleTimeout,
+    PoolGracefulShutdown,
+    ClientTimeout,
+    ClientCancelled,
+    AttachClosed,
+    TransportError,
+    NodeShutdown,
+    SessionShutdown,
+    BadSession,
+    SessionBusy
+}
+
 internal abstract class PoolingSessionBase<T>(PoolingSessionSource<T> source) : ISession
     where T : PoolingSessionBase<T>
 {
@@ -377,7 +393,7 @@ internal abstract class PoolingSessionBase<T>(PoolingSessionSource<T> source) : 
 
     internal abstract Task Open(CancellationToken cancellationToken);
 
-    internal abstract Task DeleteSession(string reason);
+    internal abstract Task DeleteSession(SessionClosedReason reason);
 
     public abstract ValueTask<IServerStream<ExecuteQueryResponsePart>> ExecuteQuery(
         string query,

--- a/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
+++ b/src/Ydb.Sdk/src/Ado/Session/PoolingSessionSource.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Ydb.Query;
 
@@ -369,6 +370,12 @@ internal enum SessionClosedReason
     SessionShutdown,
     BadSession,
     SessionBusy
+}
+
+internal static class SessionClosedReasonExtensions
+{
+    internal static string ToMetricValue(this SessionClosedReason reason) =>
+        JsonNamingPolicy.SnakeCaseLower.ConvertName(reason.ToString());
 }
 
 internal abstract class PoolingSessionBase<T>(PoolingSessionSource<T> source) : ISession

--- a/src/Ydb.Sdk/src/Ado/YdbMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbMetricsReporter.cs
@@ -198,20 +198,7 @@ internal sealed class YdbMetricsReporter : IDisposable
     internal void ReportPendingConnectionRequestStart() => PendingConnectionRequests.Add(1, _poolNameTag);
 
     internal void ReportSessionClosed(SessionClosedReason reason) => SessionsClosed.Add(1, _poolNameTag,
-        new KeyValuePair<string, object?>("reason", reason switch
-        {
-            SessionClosedReason.PoolIdleTimeout => "pool_idle_timeout",
-            SessionClosedReason.PoolGracefulShutdown => "pool_graceful_shutdown",
-            SessionClosedReason.ClientTimeout => "client_timeout",
-            SessionClosedReason.ClientCancelled => "client_cancelled",
-            SessionClosedReason.AttachClosed => "attach_closed",
-            SessionClosedReason.TransportError => "transport_error",
-            SessionClosedReason.NodeShutdown => "node_shutdown",
-            SessionClosedReason.SessionShutdown => "session_shutdown",
-            SessionClosedReason.BadSession => "bad_session",
-            SessionClosedReason.SessionBusy => "session_busy",
-            _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, null)
-        }));
+        new KeyValuePair<string, object?>("reason", reason.ToMetricValue()));
 
     internal static long ReportConnectionCreateTimeStart() =>
         ConnectionCreateTime.Enabled ? Stopwatch.GetTimestamp() : 0;

--- a/src/Ydb.Sdk/src/Ado/YdbMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbMetricsReporter.cs
@@ -197,8 +197,8 @@ internal sealed class YdbMetricsReporter : IDisposable
 
     internal void ReportPendingConnectionRequestStart() => PendingConnectionRequests.Add(1, _poolNameTag);
 
-    internal void ReportSessionClosed(SessionClosedReason reason) => SessionsClosed.Add(1, _poolNameTag,
-        new KeyValuePair<string, object?>("reason", reason.ToMetricValue()));
+    internal void ReportSessionClosed(SessionClosedReason reason) =>
+        SessionsClosed.Add(1, _poolNameTag, new KeyValuePair<string, object?>("reason", reason.ToMetricValue()));
 
     internal static long ReportConnectionCreateTimeStart() =>
         ConnectionCreateTime.Enabled ? Stopwatch.GetTimestamp() : 0;

--- a/src/Ydb.Sdk/src/Ado/YdbMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Ado/YdbMetricsReporter.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Ydb.Sdk.Ado.Session;
 using Ydb.Sdk.Internal;
 
 namespace Ydb.Sdk.Ado;
@@ -196,8 +197,21 @@ internal sealed class YdbMetricsReporter : IDisposable
 
     internal void ReportPendingConnectionRequestStart() => PendingConnectionRequests.Add(1, _poolNameTag);
 
-    internal void ReportSessionClosed(string reason) =>
-        SessionsClosed.Add(1, _poolNameTag, new KeyValuePair<string, object?>("reason", reason));
+    internal void ReportSessionClosed(SessionClosedReason reason) => SessionsClosed.Add(1, _poolNameTag,
+        new KeyValuePair<string, object?>("reason", reason switch
+        {
+            SessionClosedReason.PoolIdleTimeout => "pool_idle_timeout",
+            SessionClosedReason.PoolGracefulShutdown => "pool_graceful_shutdown",
+            SessionClosedReason.ClientTimeout => "client_timeout",
+            SessionClosedReason.ClientCancelled => "client_cancelled",
+            SessionClosedReason.AttachClosed => "attach_closed",
+            SessionClosedReason.TransportError => "transport_error",
+            SessionClosedReason.NodeShutdown => "node_shutdown",
+            SessionClosedReason.SessionShutdown => "session_shutdown",
+            SessionClosedReason.BadSession => "bad_session",
+            SessionClosedReason.SessionBusy => "session_busy",
+            _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, null)
+        }));
 
     internal static long ReportConnectionCreateTimeStart() =>
         ConnectionCreateTime.Enabled ? Stopwatch.GetTimestamp() : 0;

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Benchmarks/SessionSourceBenchmark.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Benchmarks/SessionSourceBenchmark.cs
@@ -143,7 +143,7 @@ internal class MockPoolingSession(PoolingSessionSource<MockPoolingSession> sourc
     public override bool IsBroken => false;
 
     internal override async Task Open(CancellationToken cancellationToken) => await Task.Yield();
-    internal override Task DeleteSession(string reason) => Task.CompletedTask;
+    internal override Task DeleteSession(SessionClosedReason reason) => Task.CompletedTask;
 
     public override ValueTask<IServerStream<ExecuteQueryResponsePart>> ExecuteQuery(
         string query,

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Session/MockPoolingSessionFactory.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Session/MockPoolingSessionFactory.cs
@@ -62,7 +62,7 @@ internal class MockPoolingSession(
     public override bool IsBroken => _isBroken || mockIsBroken(sessionId);
 
     internal override Task Open(CancellationToken cancellationToken) => mockOpen(sessionId);
-    internal override Task DeleteSession(string reason) => mockDeleteSession();
+    internal override Task DeleteSession(SessionClosedReason reason) => mockDeleteSession();
 
     public override ValueTask<IServerStream<ExecuteQueryResponsePart>> ExecuteQuery(
         string query,

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Session/PoolingSessionTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/Session/PoolingSessionTests.cs
@@ -324,7 +324,7 @@ public class PoolingSessionTests
             It.IsAny<DeleteSessionRequest>(),
             It.IsAny<GrpcRequestSettings>()
         )).ReturnsAsync(new DeleteSessionResponse { Status = StatusIds.Types.StatusCode.Success });
-        await session.DeleteSession("pool_graceful_shutdown");
+        await session.DeleteSession(SessionClosedReason.PoolGracefulShutdown);
         _mockIDriver.Verify(driver => driver.UnaryCall(QueryService.DeleteSessionMethod,
             It.IsAny<DeleteSessionRequest>(), It.IsAny<GrpcRequestSettings>()), Times.Never());
         Assert.True(session.IsBroken);
@@ -337,7 +337,7 @@ public class PoolingSessionTests
             It.Is<DeleteSessionRequest>(request => request.SessionId.Equals(SessionId)),
             It.Is<GrpcRequestSettings>(grpcRequestSettings => grpcRequestSettings.NodeId == NodeId)
         )).ReturnsAsync(new DeleteSessionResponse { Status = StatusIds.Types.StatusCode.Success });
-        await session.DeleteSession("pool_graceful_shutdown");
+        await session.DeleteSession(SessionClosedReason.PoolGracefulShutdown);
         _mockIDriver.Verify(driver => driver.UnaryCall(QueryService.DeleteSessionMethod,
             It.IsAny<DeleteSessionRequest>(), It.IsAny<GrpcRequestSettings>()));
         Assert.True(session.IsBroken);

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbMetricTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Ado.Tests/YdbMetricTests.cs
@@ -282,13 +282,59 @@ public class YdbMetricTests : TestBase
     }
 
     [Theory]
+    [InlineData(StatusCode.BadSession, "bad_session")]
+    [InlineData(StatusCode.SessionExpired, "bad_session")]
+    [InlineData(StatusCode.SessionBusy, "session_busy")]
+    [InlineData(StatusCode.ClientTransportTimeout, "client_timeout")]
+    [InlineData(StatusCode.ClientCancelled, "client_cancelled")]
+    [InlineData(StatusCode.ClientTransportUnavailable, "transport_error")]
+    [InlineData(StatusCode.ClientTransportResourceExhausted, "transport_error")]
+    [InlineData(StatusCode.ClientTransportUnknown, "transport_error")]
+    public async Task SessionClosed_WhenStatusRetiresSession_ReportsReason(StatusCode statusCode, string reason)
+    {
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+
+        var settings = CreateConnectionSettings(builder =>
+        {
+            builder.MaxPoolSize = 1;
+            builder.PoolName = $"ado-metrics-session-status-{statusCode}";
+        });
+        var lifecycleAttach = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachStream = new Mock<IServerStream<SessionState>>(MockBehavior.Strict);
+        attachStream.SetupSequence(stream => stream.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .Returns(lifecycleAttach.Task);
+        attachStream.Setup(stream => stream.Current)
+            .Returns(new SessionState { Status = StatusIds.Types.StatusCode.Success });
+        attachStream.Setup(stream => stream.Dispose()).Callback(() => attachDisposed.TrySetResult());
+
+        var driver = CreatePoolingDriver(attachStream.Object);
+        await using var source = new PoolingSessionSource<PoolingSession>(
+            new PoolingSessionFactory(driver.Object, settings),
+            settings);
+        var session = await source.OpenSession();
+
+        session.OnNotSuccessStatusCode(statusCode);
+        Assert.True(session.IsBroken);
+
+        lifecycleAttach.SetResult(false);
+        await attachDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        session.Dispose();
+
+        meterProvider.ForceFlush();
+        AssertSessionClosed(exportedItems, settings, reason);
+    }
+
+    [Theory]
     [InlineData(false, "eof")]
     [InlineData(false, "hint")]
     [InlineData(false, "error")]
     [InlineData(true, "eof")]
     [InlineData(true, "hint")]
     [InlineData(true, "error")]
-    public async Task SessionClosed_ServerErrorBeforeLateAttachTermination_ReportsOnce(
+    public async Task SessionClosed_SessionBusyBeforeLateAttachTermination_ReportsOnce(
         bool retryable,
         string lateAttachTermination)
     {
@@ -369,7 +415,7 @@ public class YdbMetricTests : TestBase
             await connection.CloseAsync();
             meterProvider.ForceFlush();
 
-            AssertSessionClosed(exportedItems, settings, "server_error");
+            AssertSessionClosed(exportedItems, settings, "session_busy");
             driver.Verify(d => d.UnaryCall(
                 QueryService.DeleteSessionMethod,
                 It.IsAny<DeleteSessionRequest>(),
@@ -382,8 +428,8 @@ public class YdbMetricTests : TestBase
     }
 
     [Theory]
-    [InlineData(false, "attach_stream_closed_by_server")]
-    [InlineData(true, "attach_stream_transport_error")]
+    [InlineData(false, "attach_closed")]
+    [InlineData(true, "transport_error")]
     public async Task SessionClosed_WhenActiveAttachStreamTerminates_ReportsReason(
         bool transportError,
         string reason)
@@ -515,7 +561,7 @@ public class YdbMetricTests : TestBase
             await connection.CloseAsync();
 
             meterProvider.ForceFlush();
-            AssertSessionClosed(exportedItems, settings, "client_query_timeout");
+            AssertSessionClosed(exportedItems, settings, "client_timeout");
         }
         finally
         {
@@ -575,7 +621,7 @@ public class YdbMetricTests : TestBase
             await connection.CloseAsync();
 
             meterProvider.ForceFlush();
-            AssertSessionClosed(exportedItems, settings, "query_stream_cancelled_by_client");
+            AssertSessionClosed(exportedItems, settings, "client_cancelled");
 
             var operationFailed = GetMetric(exportedItems, "ydb.client.operation.failed");
             var point = GetOperationFailedPoint(


### PR DESCRIPTION
## What

- add `ydb.query.session.closed{reason=...}` mappings for the short, shared SDK contract
- map `BadSession` and `SessionExpired` to `bad_session`, and `SessionBusy` to `session_busy`
- map query transport failures (including `Unavailable`) and attach-stream failures to `transport_error`
- keep wire values explicit through an internal enum and exhaustive switch
- update the OpenTelemetry README, changelog, and metric tests

## Checks

- `dotnet format` on the changed C# files
- 61 targeted tests passed
- `git diff --check`

The broader metrics test selection additionally reached 70 passing tests; 7 integration tests require a YDB instance on `localhost:2136` and failed at environment setup.
