### PR TITLE
feat: add Topic Reader received bytes metric

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,10 +1,11 @@
 - Dev: bumped the metrics observability-chain minor version in `x-ydb-sdk-build-info` from
   `ydb-sdk-metrics/0.1.0` to `ydb-sdk-metrics/0.2.0`.
-- Feat Topic Reader metrics: added four counters and a partition-session gauge on the `Ydb.Sdk.Topic` meter.
+- Feat Topic Reader metrics: added five counters and a partition-session gauge on the `Ydb.Sdk.Topic` meter.
 
   | Metric                                             | Unit        | Description                                                  |
   |----------------------------------------------------|-------------|--------------------------------------------------------------|
   | `ydb.topic.reader.received.messages`               | `{message}` | Messages accepted by the SDK from active partition sessions  |
+  | `ydb.topic.reader.received.bytes`                  | `By`        | Protocol `ReadResponse.bytes_size`, counted once per response |
   | `ydb.topic.reader.delivered.messages`              | `{message}` | Messages delivered by the SDK to application code            |
   | `ydb.topic.reader.commit.queued`                   | `{message}` | Messages in commit ranges accepted by the SDK                |
   | `ydb.topic.reader.commit.acknowledged`             | `{message}` | Messages in ranges completed by successful acknowledgements  |
@@ -13,7 +14,8 @@
   Repeated deliveries and messages in repeated commit ranges are counted again. An acknowledgement counts messages
   in every queued range it completes; stale acknowledgements are ignored.
   All Topic Reader metrics have the `endpoint` and `database` attributes, plus `consumer` and `reader.name` when they
-  are configured; counters also have `topic`. The partition-session gauge is an SDK-local snapshot, not server
+  are configured; message and commit counters also have `topic`. The received-bytes counter covers the whole stream
+  without `topic`, including data for unknown partitions. The partition-session gauge is an SDK-local snapshot, not server
   ownership or processing progress.
 - Added `StatusCode.ClientCancelled` to represent a client closing an unfinished query stream.
 - Supported `ydb.query.session.closed` reasons:

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -559,6 +559,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     private async Task HandleReadResponse(StreamReadMessage.Types.ReadResponse readResponse)
     {
         var bytesSize = readResponse.BytesSize;
+        _metrics.ReportReceivedBytes(bytesSize);
         var partitionCount = readResponse.PartitionData.Count;
 
         for (var partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -14,6 +14,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
     private static readonly List<ReaderMetricsReporter> Reporters = [];
 
     private static readonly Counter<long> ReceivedMessages;
+    private static readonly Counter<long> ReceivedBytes;
     private static readonly Counter<long> DeliveredMessages;
     private static readonly Counter<long> CommitQueued;
     private static readonly Counter<long> CommitAcknowledged;
@@ -35,6 +36,11 @@ internal sealed class ReaderMetricsReporter : IDisposable
             "ydb.topic.reader.received.messages",
             unit: "{message}",
             description: "The number of messages accepted by the SDK for an active partition session.");
+
+        ReceivedBytes = meter.CreateCounter<long>(
+            "ydb.topic.reader.received.bytes",
+            unit: "By",
+            description: "The protocol bytes_size received in read responses.");
 
         DeliveredMessages = meter.CreateCounter<long>(
             "ydb.topic.reader.delivered.messages",
@@ -80,6 +86,8 @@ internal sealed class ReaderMetricsReporter : IDisposable
     }
 
     internal void ReportReceived(long messages, string topic) => Record(ReceivedMessages, messages, topic);
+
+    internal void ReportReceivedBytes(long bytes) => ReceivedBytes.Add(bytes, _commonTags);
 
     internal void ReportDelivered(long messages, string topic) => Record(DeliveredMessages, messages, topic);
 

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -29,40 +29,23 @@ public class ReaderMetricsReporterTests
     ];
 
     [Fact]
-    public async Task ReceivedBytes_CountsResponseOnceAcrossTopicsAndUnknownPartitions()
+    public async Task ReceivedBytes_RecordsResponseSize()
     {
         const string readerName = "received-bytes-reader";
         const string metricName = "ydb.topic.reader.received.bytes";
         var exportedItems = new List<Metric>();
         using var meterProvider = CreateMeterProvider(exportedItems);
         var mockStream = new Mock<ReaderStream>();
-        var processed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var closed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var secondPartition = StartPartitionSessionRequest(partitionSessionId: 2);
-        secondPartition.StartPartitionSessionRequest.PartitionSession.Path = "/other-topic";
-        var response = ReadResponse("first"u8.ToArray());
-        response.ReadResponse.BytesSize = 1234;
-        var secondData = ReadResponse("second"u8.ToArray()).ReadResponse.PartitionData[0];
-        secondData.PartitionSessionId = 2;
-        var unknownData = ReadResponse("discarded"u8.ToArray()).ReadResponse.PartitionData[0];
-        unknownData.PartitionSessionId = 99;
-        response.ReadResponse.PartitionData.Add(secondData);
-        response.ReadResponse.PartitionData.Add(unknownData);
         mockStream.SetupSequence(stream => stream.MoveNextAsync())
             .ReturnsAsync(true)
             .ReturnsAsync(true)
             .ReturnsAsync(true)
-            .ReturnsAsync(true)
-            .Returns(() =>
-            {
-                processed.SetResult();
-                return closed.Task;
-            });
+            .Returns(closed.Task);
         mockStream.SetupSequence(stream => stream.Current)
             .Returns(InitResponse)
             .Returns(StartPartitionSessionRequest())
-            .Returns(secondPartition)
-            .Returns(response);
+            .Returns(ReadResponse("message"u8.ToArray()));
         mockStream.Setup(stream => stream.Write(It.IsAny<FromClient>())).Returns(Task.CompletedTask);
         mockStream.Setup(stream => stream.RequestStreamComplete()).Returns(() =>
         {
@@ -73,16 +56,16 @@ public class ReaderMetricsReporterTests
         {
             ReaderName = readerName,
             ConsumerName = "received-bytes-consumer",
-            SubscribeSettings = { new SubscribeSettings("/topic"), new SubscribeSettings("/other-topic") }
+            SubscribeSettings = { new SubscribeSettings("/topic") }
         }.Build();
 
-        await processed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         meterProvider.ForceFlush();
         var metric = GetMetric(exportedItems, metricName);
         Assert.Equal(MetricType.LongSum, metric.MetricType);
         Assert.Equal("By", metric.Unit);
         var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName));
-        Assert.Equal(1234, point.GetSumLong());
+        Assert.Equal(50, point.GetSumLong());
         AssertTags(point, "received-bytes-consumer", readerName);
     }
 

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -28,6 +28,68 @@ public class ReaderMetricsReporterTests
         "ydb.topic.reader.commit.acknowledged"
     ];
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("received-bytes-reader")]
+    public async Task ReceivedBytes_CountsResponseOnceAcrossTopicsAndUnknownPartitions(string? readerName)
+    {
+        const string metricName = "ydb.topic.reader.received.bytes";
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+        var mockStream = new Mock<ReaderStream>();
+        var processed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var closed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondPartition = StartPartitionSessionRequest(partitionSessionId: 2);
+        secondPartition.StartPartitionSessionRequest.PartitionSession.Path = "/other-topic";
+        var response = ReadResponse("first"u8.ToArray());
+        response.ReadResponse.BytesSize = 1234;
+        var secondData = ReadResponse("second"u8.ToArray()).ReadResponse.PartitionData[0];
+        secondData.PartitionSessionId = 2;
+        var unknownData = ReadResponse("discarded"u8.ToArray()).ReadResponse.PartitionData[0];
+        unknownData.PartitionSessionId = 99;
+        response.ReadResponse.PartitionData.Add(secondData);
+        response.ReadResponse.PartitionData.Add(unknownData);
+        mockStream.SetupSequence(stream => stream.MoveNextAsync())
+            .ReturnsAsync(true)
+            .ReturnsAsync(true)
+            .ReturnsAsync(true)
+            .ReturnsAsync(true)
+            .Returns(() =>
+            {
+                processed.SetResult();
+                return closed.Task;
+            });
+        mockStream.SetupSequence(stream => stream.Current)
+            .Returns(InitResponse)
+            .Returns(StartPartitionSessionRequest())
+            .Returns(secondPartition)
+            .Returns(response);
+        mockStream.Setup(stream => stream.Write(It.IsAny<FromClient>())).Returns(Task.CompletedTask);
+        mockStream.Setup(stream => stream.RequestStreamComplete()).Returns(() =>
+        {
+            closed.TrySetResult(false);
+            return Task.CompletedTask;
+        });
+        await using var reader =
+            new ReaderBuilder<string>(CreateDriverFactory(mockStream, $"received-bytes-{readerName}"))
+            {
+                ReaderName = readerName,
+                ConsumerName = "received-bytes-consumer",
+                SubscribeSettings = { new SubscribeSettings("/topic"), new SubscribeSettings("/other-topic") }
+            }.Build();
+
+        await processed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        meterProvider.ForceFlush();
+        var metric = GetMetric(exportedItems, metricName);
+        Assert.Equal(MetricType.LongSum, metric.MetricType);
+        Assert.Equal("By", metric.Unit);
+        var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName),
+            point => Equals(ToDictionary(point.Tags).GetValueOrDefault("consumer"), "received-bytes-consumer"));
+        Assert.Equal(1234, point.GetSumLong());
+        AssertTags(point, "received-bytes-consumer", readerName);
+    }
+
     [Fact]
     public async Task PartitionSessionCount_TracksSessionsAcrossReconnectAndDispose()
     {
@@ -223,7 +285,7 @@ public class ReaderMetricsReporterTests
     private static IEnumerable<MetricPoint> GetReaderPoints(
         List<Metric> exportedItems,
         string metricName,
-        string readerName)
+        string? readerName)
     {
         foreach (var point in exportedItems
                      .Where(metric => metric.Name == metricName)
@@ -247,15 +309,19 @@ public class ReaderMetricsReporterTests
     private static void AssertTags(
         MetricPoint point,
         string consumer,
-        string readerName,
+        string? readerName,
         string? topic = null)
     {
         var tags = ToDictionary(point.Tags);
-        Assert.Equal(topic is null ? 4 : 5, tags.Count);
+        Assert.Equal(3 + (topic is null ? 0 : 1) + (readerName is null ? 0 : 1), tags.Count);
         Assert.Equal("localhost:2136", tags["endpoint"]);
         Assert.Equal("/local", tags["database"]);
         Assert.Equal(consumer, tags["consumer"]);
-        Assert.Equal(readerName, tags["reader.name"]);
+        if (readerName is not null)
+        {
+            Assert.Equal(readerName, tags["reader.name"]);
+        }
+
         if (topic is not null)
         {
             Assert.Equal(topic, tags["topic"]);

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -28,12 +28,10 @@ public class ReaderMetricsReporterTests
         "ydb.topic.reader.commit.acknowledged"
     ];
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("received-bytes-reader")]
-    public async Task ReceivedBytes_CountsResponseOnceAcrossTopicsAndUnknownPartitions(string? readerName)
+    [Fact]
+    public async Task ReceivedBytes_CountsResponseOnceAcrossTopicsAndUnknownPartitions()
     {
+        const string readerName = "received-bytes-reader";
         const string metricName = "ydb.topic.reader.received.bytes";
         var exportedItems = new List<Metric>();
         using var meterProvider = CreateMeterProvider(exportedItems);
@@ -71,21 +69,19 @@ public class ReaderMetricsReporterTests
             closed.TrySetResult(false);
             return Task.CompletedTask;
         });
-        await using var reader =
-            new ReaderBuilder<string>(CreateDriverFactory(mockStream, $"received-bytes-{readerName}"))
-            {
-                ReaderName = readerName,
-                ConsumerName = "received-bytes-consumer",
-                SubscribeSettings = { new SubscribeSettings("/topic"), new SubscribeSettings("/other-topic") }
-            }.Build();
+        await using var reader = new ReaderBuilder<string>(CreateDriverFactory(mockStream, readerName))
+        {
+            ReaderName = readerName,
+            ConsumerName = "received-bytes-consumer",
+            SubscribeSettings = { new SubscribeSettings("/topic"), new SubscribeSettings("/other-topic") }
+        }.Build();
 
         await processed.Task.WaitAsync(TimeSpan.FromSeconds(5));
         meterProvider.ForceFlush();
         var metric = GetMetric(exportedItems, metricName);
         Assert.Equal(MetricType.LongSum, metric.MetricType);
         Assert.Equal("By", metric.Unit);
-        var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName),
-            point => Equals(ToDictionary(point.Tags).GetValueOrDefault("consumer"), "received-bytes-consumer"));
+        var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName));
         Assert.Equal(1234, point.GetSumLong());
         AssertTags(point, "received-bytes-consumer", readerName);
     }
@@ -285,7 +281,7 @@ public class ReaderMetricsReporterTests
     private static IEnumerable<MetricPoint> GetReaderPoints(
         List<Metric> exportedItems,
         string metricName,
-        string? readerName)
+        string readerName)
     {
         foreach (var point in exportedItems
                      .Where(metric => metric.Name == metricName)
@@ -309,19 +305,15 @@ public class ReaderMetricsReporterTests
     private static void AssertTags(
         MetricPoint point,
         string consumer,
-        string? readerName,
+        string readerName,
         string? topic = null)
     {
         var tags = ToDictionary(point.Tags);
-        Assert.Equal(3 + (topic is null ? 0 : 1) + (readerName is null ? 0 : 1), tags.Count);
+        Assert.Equal(topic is null ? 4 : 5, tags.Count);
         Assert.Equal("localhost:2136", tags["endpoint"]);
         Assert.Equal("/local", tags["database"]);
         Assert.Equal(consumer, tags["consumer"]);
-        if (readerName is not null)
-        {
-            Assert.Equal(readerName, tags["reader.name"]);
-        }
-
+        Assert.Equal(readerName, tags["reader.name"]);
         if (topic is not null)
         {
             Assert.Equal(topic, tags["topic"]);


### PR DESCRIPTION
## Pull request type

- [x] Feature

## What is the current behavior?

Topic Reader metrics expose message counts but do not report protocol byte throughput.

## What is the new behavior?

Adds `ydb.topic.reader.received.bytes` as a `Counter<long>` with unit `By`. Each read response contributes its `bytes_size` once, before processing partitions, including data for unknown partitions. Measurements use the existing Reader attributes without a `topic` attribute, so responses spanning multiple topics are counted once.

## Other information

- All 3 Reader metric tests pass.
- The received-bytes test reads one response with one message and checks the byte count, instrument type/unit and stream attributes.
- ReSharper Custom Cleanup applied; independent review found no actionable issues.
- Integration tests could not complete locally because YDB discovery advertises `702bbc7bdcdb:2136`, which does not resolve from the host.


