### PR TITLE
feat: add Topic Reader session error metric

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,12 +1,13 @@
 - Dev: bumped the metrics observability-chain minor version in `x-ydb-sdk-build-info` from
   `ydb-sdk-metrics/0.1.0` to `ydb-sdk-metrics/0.2.0`.
-- Feat Topic Reader metrics: added five counters, a local-buffer UpDownCounter, and a partition-session gauge on
+- Feat Topic Reader metrics: added six counters, a local-buffer UpDownCounter, and a partition-session gauge on
   the `Ydb.Sdk.Topic` meter.
 
   | Metric                                             | Unit        | Description                                                  |
   |----------------------------------------------------|-------------|--------------------------------------------------------------|
   | `ydb.topic.reader.received.messages`               | `{message}` | Messages accepted by the SDK from active partition sessions  |
   | `ydb.topic.reader.received.bytes`                  | `By`        | Protocol `ReadResponse.bytes_size`, counted once per response |
+  | `ydb.topic.reader.session.errors`                  | `{error}`   | Reader stream-session retry and terminal failure decisions    |
   | `ydb.topic.reader.delivered.messages`              | `{message}` | Messages delivered by the SDK to application code            |
   | `ydb.topic.reader.local_buffer.messages`           | `{message}` | Messages currently accepted but not delivered by the SDK      |
   | `ydb.topic.reader.commit.queued`                   | `{message}` | Messages in commit ranges accepted by the SDK                |
@@ -18,7 +19,8 @@
   All Topic Reader metrics have the `endpoint` and `database` attributes, plus `consumer` and `reader.name` when they
   are configured; message and commit counters also have `topic`. The received-bytes counter covers the whole stream
   without `topic`, including data for unknown partitions. The partition-session gauge is an SDK-local snapshot, not server
-  ownership or processing progress.
+  ownership or processing progress. The session-error counter has `retry_decision`, `status_code`, and `error.type`
+  attributes and does not have `topic`.
   The local-buffer UpDownCounter increments when messages enter the local buffer and decrements when they are delivered.
   Because it is synchronous, a listener attached after a Reader is created is not backfilled with the Reader's
   already-buffered messages.

--- a/src/Ydb.Sdk/src/StatusCode.cs
+++ b/src/Ydb.Sdk/src/StatusCode.cs
@@ -5,6 +5,12 @@ internal static class StatusRanges
     public const int ClientTransportFirst = 600000;
 }
 
+internal static class StatusCodeExtensions
+{
+    internal static bool IsTransportError(this StatusCode statusCode) =>
+        (int)statusCode >= StatusRanges.ClientTransportFirst;
+}
+
 public enum StatusCode
 {
     Unspecified = 0,

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -241,8 +241,8 @@ internal class Reader<TValue> : IReader<TValue>
             return;
         }
 
-        _disposeCts.Cancel();
         _receivedMessagesChannel.Writer.TryComplete();
+        _disposeCts.Cancel();
         _metrics.Dispose();
 
         await (_currentReaderSession?.DisposeAsync() ?? ValueTask.CompletedTask).ConfigureAwait(false);

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -112,9 +112,8 @@ internal class Reader<TValue> : IReader<TValue>
 
     private void Reconnect(StatusCode statusCode)
     {
-        _currentReaderSession = null;
         _metrics.ReportSessionError(statusCode);
-        _ = Task.Run(Initialize);
+        _ = Task.Run(Initialize, _disposeCts.Token);
     }
 
     private async Task Initialize()
@@ -178,8 +177,7 @@ internal class Reader<TValue> : IReader<TValue>
                 _logger.LogError("Stream unexpectedly closed by YDB server. Current InitRequest: {InitRequest}",
                     initRequest);
 
-                _ = Task.Run(Initialize, _disposeCts.Token);
-                _metrics.ReportSessionError(StatusCode.Unspecified);
+                Reconnect(StatusCode.Unspecified);
 
                 return;
             }
@@ -195,8 +193,7 @@ internal class Reader<TValue> : IReader<TValue>
                 {
                     _logger.LogError("Reader initialization failed to start. {StatusMessage}", statusMessage);
 
-                    _ = Task.Run(Initialize, _disposeCts.Token);
-                    _metrics.ReportSessionError(initException.Code);
+                    Reconnect(initException.Code);
                 }
                 else
                 {
@@ -236,8 +233,7 @@ internal class Reader<TValue> : IReader<TValue>
         {
             _logger.LogError(e, "Error on executing ReaderSession");
 
-            _ = Task.Run(Initialize, _disposeCts.Token);
-            _metrics.ReportSessionError(e.Code);
+            Reconnect(e.Code);
         }
     }
 

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -217,7 +217,7 @@ internal class Reader<TValue> : IReader<TValue>
                 ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = _config.MemoryUsageMaxBytes }
             }).ConfigureAwait(false);
 
-            _currentReaderSession = new ReaderSession<TValue>(
+            var readerSession = new ReaderSession<TValue>(
                 _config,
                 stream,
                 initResponse.SessionId,
@@ -228,6 +228,8 @@ internal class Reader<TValue> : IReader<TValue>
                 _deserializer,
                 _metrics
             );
+            _currentReaderSession = readerSession;
+            readerSession.Start();
         }
         catch (YdbException e)
         {
@@ -288,8 +290,8 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     private readonly CancellationTokenSource _lifecycleReaderSessionCts = new();
     private readonly IDeserializer<TValue> _deserializer;
     private readonly ReaderMetricsReporter _metrics;
-    private readonly Task _runProcessingStreamResponse;
-    private readonly Task _runProcessingStreamRequest;
+    private Task _runProcessingStreamResponse = Task.CompletedTask;
+    private Task _runProcessingStreamRequest = Task.CompletedTask;
 
     private readonly Channel<MessageFromClient> _channelFromClientMessageSending =
         Channel.CreateUnbounded<MessageFromClient>(
@@ -326,7 +328,10 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         _channelWriter = channelWriter;
         _deserializer = deserializer;
         _metrics = metrics;
+    }
 
+    internal void Start()
+    {
         _runProcessingStreamResponse = RunProcessingStreamResponse();
         _runProcessingStreamRequest = RunProcessingStreamRequest();
     }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -172,6 +172,7 @@ internal class Reader<TValue> : IReader<TValue>
                     initRequest);
 
                 _ = Task.Run(Initialize, _disposeCts.Token);
+                _metrics.ReportSessionClosed();
 
                 return;
             }
@@ -188,6 +189,7 @@ internal class Reader<TValue> : IReader<TValue>
                     _logger.LogError("Reader initialization failed to start. {StatusMessage}", statusMessage);
 
                     _ = Task.Run(Initialize, _disposeCts.Token);
+                    _metrics.ReportSessionError(initException, retry: true);
                 }
                 else
                 {
@@ -195,6 +197,7 @@ internal class Reader<TValue> : IReader<TValue>
 
                     _receivedMessagesChannel.Writer.Complete(
                         new ReaderException($"Initialization failed! {statusMessage}"));
+                    _metrics.ReportSessionError(initException, retry: false);
                 }
 
                 return;
@@ -222,11 +225,12 @@ internal class Reader<TValue> : IReader<TValue>
                 _metrics
             );
         }
-        catch (Exception e)
+        catch (YdbException e)
         {
             _logger.LogError(e, "Error on executing ReaderSession");
 
             _ = Task.Run(Initialize, _disposeCts.Token);
+            _metrics.ReportSessionError(e, retry: true);
         }
     }
 
@@ -237,8 +241,8 @@ internal class Reader<TValue> : IReader<TValue>
             return;
         }
 
-        _receivedMessagesChannel.Writer.TryComplete();
         _disposeCts.Cancel();
+        _receivedMessagesChannel.Writer.TryComplete();
         _metrics.Dispose();
 
         await (_currentReaderSession?.DisposeAsync() ?? ValueTask.CompletedTask).ConfigureAwait(false);
@@ -340,6 +344,9 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                     Logger.LogError(
                         "ReaderSession[{SessionId}] received unsuccessful status while processing readAck: {Status}",
                         SessionId, messageFromServer.Status.Code().ToMessage(messageFromServer.Issues));
+                    ReconnectSession(() => _metrics.ReportSessionError(
+                        YdbException.FromServer(messageFromServer.Status, messageFromServer.Issues),
+                        retry: true));
                     return;
                 }
 
@@ -372,15 +379,15 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
             }
 
             Logger.LogInformation("ReaderSession[{SessionId}]: ResponseStream is closed", SessionId);
+            ReconnectSession(_metrics.ReportSessionClosed);
         }
-        catch (Exception e)
+        catch (YdbException e)
         {
             Logger.LogError(e, "ReaderSession[{SessionId}] have error on processing server messages", SessionId);
+            ReconnectSession(() => _metrics.ReportSessionError(e, retry: true));
         }
         finally
         {
-            ReconnectSession();
-
             _lifecycleReaderSessionCts.Cancel();
         }
     }
@@ -395,11 +402,11 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                 await SendMessage(messageFromClient).ConfigureAwait(false);
             }
         }
-        catch (Exception e)
+        catch (YdbException e)
         {
             Logger.LogError(e, "ReaderSession[{SessionId}] have error on Write", SessionId);
 
-            ReconnectSession();
+            ReconnectSession(() => _metrics.ReportSessionError(e, retry: true));
 
             _lifecycleReaderSessionCts.Cancel();
         }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -217,7 +217,7 @@ internal class Reader<TValue> : IReader<TValue>
                 ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = _config.MemoryUsageMaxBytes }
             }).ConfigureAwait(false);
 
-            var readerSession = new ReaderSession<TValue>(
+            _currentReaderSession = new ReaderSession<TValue>(
                 _config,
                 stream,
                 initResponse.SessionId,
@@ -228,8 +228,7 @@ internal class Reader<TValue> : IReader<TValue>
                 _deserializer,
                 _metrics
             );
-            _currentReaderSession = readerSession;
-            readerSession.Start();
+            _currentReaderSession.Start();
         }
         catch (YdbException e)
         {

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -172,7 +172,7 @@ internal class Reader<TValue> : IReader<TValue>
                     initRequest);
 
                 _ = Task.Run(Initialize, _disposeCts.Token);
-                _metrics.ReportSessionClosed();
+                _metrics.ReportSessionError(StatusCode.Unspecified, retry: true);
 
                 return;
             }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -331,6 +331,19 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     internal long PartitionSessionCount =>
         _lifecycleReaderSessionCts.IsCancellationRequested ? 0 : _partitionSessions.Count;
 
+    private void ReconnectSession(StatusCode statusCode = StatusCode.Unspecified, bool closedByServer = false) =>
+        base.ReconnectSession(() =>
+        {
+            if (closedByServer)
+            {
+                _metrics.ReportSessionClosed();
+            }
+            else
+            {
+                _metrics.ReportSessionError(statusCode, retry: true);
+            }
+        });
+
     private async Task RunProcessingStreamResponse()
     {
         try
@@ -345,7 +358,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                     Logger.LogError(
                         "ReaderSession[{SessionId}] received unsuccessful status while processing readAck: {Status}",
                         SessionId, statusCode.ToMessage(messageFromServer.Issues));
-                    ReconnectSession(() => _metrics.ReportSessionError(statusCode, retry: true));
+                    ReconnectSession(statusCode);
                     return;
                 }
 
@@ -378,12 +391,12 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
             }
 
             Logger.LogInformation("ReaderSession[{SessionId}]: ResponseStream is closed", SessionId);
-            ReconnectSession(_metrics.ReportSessionClosed);
+            ReconnectSession(closedByServer: true);
         }
         catch (YdbException e)
         {
             Logger.LogError(e, "ReaderSession[{SessionId}] have error on processing server messages", SessionId);
-            ReconnectSession(() => _metrics.ReportSessionError(e.Code, retry: true));
+            ReconnectSession(e.Code);
         }
         finally
         {
@@ -405,7 +418,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         {
             Logger.LogError(e, "ReaderSession[{SessionId}] have error on Write", SessionId);
 
-            ReconnectSession(() => _metrics.ReportSessionError(e.Code, retry: true));
+            ReconnectSession(e.Code);
 
             _lifecycleReaderSessionCts.Cancel();
         }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -112,6 +112,7 @@ internal class Reader<TValue> : IReader<TValue>
 
     private void Reconnect(StatusCode statusCode)
     {
+        _currentReaderSession = null;
         _metrics.ReportSessionError(statusCode);
         _ = Task.Run(Initialize, _disposeCts.Token);
     }
@@ -335,8 +336,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         _runProcessingStreamRequest = RunProcessingStreamRequest();
     }
 
-    internal long PartitionSessionCount =>
-        _lifecycleReaderSessionCts.IsCancellationRequested ? 0 : _partitionSessions.Count;
+    internal long PartitionSessionCount => _partitionSessions.Count;
 
     private async Task RunProcessingStreamResponse()
     {

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -110,6 +110,12 @@ internal class Reader<TValue> : IReader<TValue>
         throw new ReaderException("Reader is disposed");
     }
 
+    private void InternalReconnect(StatusCode statusCode)
+    {
+        _metrics.ReportSessionError(statusCode);
+        _ = Task.Run(Initialize);
+    }
+
     private async Task Initialize()
     {
         try
@@ -217,7 +223,7 @@ internal class Reader<TValue> : IReader<TValue>
                 _config,
                 stream,
                 initResponse.SessionId,
-                Initialize,
+                InternalReconnect,
                 await stream.AuthToken().ConfigureAwait(false),
                 _logger,
                 _receivedMessagesChannel.Writer,
@@ -281,7 +287,6 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     private const double FreeBufferCoefficient = 0.2;
 
     private readonly ReaderConfig _readerConfig;
-    private readonly Func<Task> _initialize;
     private readonly ChannelWriter<InternalBatchMessages<TValue>> _channelWriter;
     private readonly CancellationTokenSource _lifecycleReaderSessionCts = new();
     private readonly IDeserializer<TValue> _deserializer;
@@ -306,7 +311,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         ReaderConfig config,
         ReaderStream stream,
         string sessionId,
-        Func<Task> initialize,
+        Action<StatusCode> internalReconnect,
         string? lastToken,
         ILogger logger,
         ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
@@ -316,11 +321,11 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         stream,
         logger,
         sessionId,
+        internalReconnect,
         lastToken
     )
     {
         _readerConfig = config;
-        _initialize = initialize;
         _channelWriter = channelWriter;
         _deserializer = deserializer;
         _metrics = metrics;
@@ -615,12 +620,6 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                     SessionId, partitionSessionId);
             }
         }
-    }
-
-    protected override void InternalReconnect(StatusCode statusCode)
-    {
-        _metrics.ReportSessionError(statusCode);
-        _ = Task.Run(_initialize);
     }
 
     protected override MessageFromClient GetSendUpdateTokenRequest(string token) =>

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -195,9 +195,9 @@ internal class Reader<TValue> : IReader<TValue>
                 {
                     _logger.LogCritical("Reader initialization failed to start. {StatusMessage}", statusMessage);
 
+                    _metrics.ReportSessionError(initException.Code, retry: false);
                     _receivedMessagesChannel.Writer.Complete(
                         new ReaderException($"Initialization failed! {statusMessage}"));
-                    _metrics.ReportSessionError(initException.Code, retry: false);
                 }
 
                 return;
@@ -281,6 +281,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     private const double FreeBufferCoefficient = 0.2;
 
     private readonly ReaderConfig _readerConfig;
+    private readonly Func<Task> _initialize;
     private readonly ChannelWriter<InternalBatchMessages<TValue>> _channelWriter;
     private readonly CancellationTokenSource _lifecycleReaderSessionCts = new();
     private readonly IDeserializer<TValue> _deserializer;
@@ -315,11 +316,11 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         stream,
         logger,
         sessionId,
-        initialize,
         lastToken
     )
     {
         _readerConfig = config;
+        _initialize = initialize;
         _channelWriter = channelWriter;
         _deserializer = deserializer;
         _metrics = metrics;
@@ -619,7 +620,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     protected override void InternalReconnect(StatusCode statusCode)
     {
         _metrics.ReportSessionError(statusCode);
-        _ = Task.Run(Initialize);
+        _ = Task.Run(_initialize);
     }
 
     protected override MessageFromClient GetSendUpdateTokenRequest(string token) =>

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -110,12 +110,6 @@ internal class Reader<TValue> : IReader<TValue>
         throw new ReaderException("Reader is disposed");
     }
 
-    private void InternalReconnect(StatusCode statusCode)
-    {
-        _metrics.ReportSessionError(statusCode);
-        _ = Task.Run(Initialize);
-    }
-
     private async Task Initialize()
     {
         try
@@ -223,7 +217,7 @@ internal class Reader<TValue> : IReader<TValue>
                 _config,
                 stream,
                 initResponse.SessionId,
-                InternalReconnect,
+                Initialize,
                 await stream.AuthToken().ConfigureAwait(false),
                 _logger,
                 _receivedMessagesChannel.Writer,
@@ -311,7 +305,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         ReaderConfig config,
         ReaderStream stream,
         string sessionId,
-        Action<StatusCode> internalReconnect,
+        Func<Task> initialize,
         string? lastToken,
         ILogger logger,
         ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
@@ -321,7 +315,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         stream,
         logger,
         sessionId,
-        internalReconnect,
+        initialize,
         lastToken
     )
     {
@@ -620,6 +614,12 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                     SessionId, partitionSessionId);
             }
         }
+    }
+
+    protected override void InternalReconnect(StatusCode statusCode)
+    {
+        _metrics.ReportSessionError(statusCode);
+        _ = Task.Run(Initialize);
     }
 
     protected override MessageFromClient GetSendUpdateTokenRequest(string token) =>

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -281,15 +281,21 @@ internal class Reader<TValue> : IReader<TValue>
 /// 5) Let's assume client somehow processes it, and its 200 bytes buffer is free again.
 ///    It should account for excess 10 bytes and send ReadRequest with bytes_size = 210.
 /// </summary>
-internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFromServer>
+internal class ReaderSession<TValue>(
+    ReaderConfig config,
+    ReaderStream stream,
+    string sessionId,
+    Action<StatusCode> reconnect,
+    string? lastToken,
+    ILogger logger,
+    ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
+    IDeserializer<TValue> deserializer,
+    ReaderMetricsReporter metrics
+) : TopicSession<MessageFromClient, MessageFromServer>(stream, logger, sessionId, reconnect, lastToken)
 {
     private const double FreeBufferCoefficient = 0.2;
 
-    private readonly ReaderConfig _readerConfig;
-    private readonly ChannelWriter<InternalBatchMessages<TValue>> _channelWriter;
     private readonly CancellationTokenSource _lifecycleReaderSessionCts = new();
-    private readonly IDeserializer<TValue> _deserializer;
-    private readonly ReaderMetricsReporter _metrics;
     private Task _runProcessingStreamResponse = Task.CompletedTask;
     private Task _runProcessingStreamRequest = Task.CompletedTask;
 
@@ -305,30 +311,6 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     private readonly ConcurrentDictionary<long, PartitionSession> _partitionSessions = new();
 
     private long _readRequestBytes;
-
-    public ReaderSession(
-        ReaderConfig config,
-        ReaderStream stream,
-        string sessionId,
-        Action<StatusCode> reconnect,
-        string? lastToken,
-        ILogger logger,
-        ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
-        IDeserializer<TValue> deserializer,
-        ReaderMetricsReporter metrics
-    ) : base(
-        stream,
-        logger,
-        sessionId,
-        reconnect,
-        lastToken
-    )
-    {
-        _readerConfig = config;
-        _channelWriter = channelWriter;
-        _deserializer = deserializer;
-        _metrics = metrics;
-    }
 
     internal void Start()
     {
@@ -424,7 +406,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     {
         var readRequestBytes = Interlocked.Add(ref _readRequestBytes, bytes);
 
-        if (readRequestBytes < FreeBufferCoefficient * _readerConfig.MemoryUsageMaxBytes)
+        if (readRequestBytes < FreeBufferCoefficient * config.MemoryUsageMaxBytes)
         {
             return;
         }
@@ -473,7 +455,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
             if (_partitionSessions.TryGetValue(partitionsCommittedOffset.PartitionSessionId,
                     out var partitionSession))
             {
-                _metrics.ReportCommitAcknowledged(
+                metrics.ReportCommitAcknowledged(
                     partitionSession.HandleCommitedOffset(partitionsCommittedOffset.CommittedOffset),
                     partitionSession.TopicPath);
             }
@@ -550,7 +532,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                     }
                 ).ConfigureAwait(false);
 
-                _metrics.ReportCommitQueued(
+                metrics.ReportCommitQueued(
                     commitSending.OffsetsRange.End - commitSending.OffsetsRange.Start,
                     partitionSession.TopicPath);
             }
@@ -574,7 +556,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
     private async Task HandleReadResponse(StreamReadMessage.Types.ReadResponse readResponse)
     {
         var bytesSize = readResponse.BytesSize;
-        _metrics.ReportReceivedBytes(bytesSize);
+        metrics.ReportReceivedBytes(bytesSize);
         var partitionCount = readResponse.PartitionData.Count;
 
         for (var partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
@@ -595,8 +577,8 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                 for (var batchIndex = 0; batchIndex < batchCount; batchIndex++)
                 {
                     var batch = batches[batchIndex];
-                    _metrics.ReportLocalBuffer(batch.MessageData.Count, partitionSession.TopicPath);
-                    await _channelWriter.WriteAsync(
+                    metrics.ReportLocalBuffer(batch.MessageData.Count, partitionSession.TopicPath);
+                    await channelWriter.WriteAsync(
                         new InternalBatchMessages<TValue>(
                             batch,
                             partitionSession,
@@ -606,11 +588,11 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                                 countParts: batchCount,
                                 currentIndex: batchIndex
                             ),
-                            _deserializer
+                            deserializer
                         )
                     ).ConfigureAwait(false);
 
-                    _metrics.ReportReceived(batch.MessageData.Count, partitionSession.TopicPath);
+                    metrics.ReportReceived(batch.MessageData.Count, partitionSession.TopicPath);
                 }
             }
             else

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -172,7 +172,7 @@ internal class Reader<TValue> : IReader<TValue>
                     initRequest);
 
                 _ = Task.Run(Initialize, _disposeCts.Token);
-                _metrics.ReportSessionError(StatusCode.Unspecified, retry: true);
+                _metrics.ReportSessionError(StatusCode.Unspecified);
 
                 return;
             }
@@ -189,7 +189,7 @@ internal class Reader<TValue> : IReader<TValue>
                     _logger.LogError("Reader initialization failed to start. {StatusMessage}", statusMessage);
 
                     _ = Task.Run(Initialize, _disposeCts.Token);
-                    _metrics.ReportSessionError(initException.Code, retry: true);
+                    _metrics.ReportSessionError(initException.Code);
                 }
                 else
                 {
@@ -230,7 +230,7 @@ internal class Reader<TValue> : IReader<TValue>
             _logger.LogError(e, "Error on executing ReaderSession");
 
             _ = Task.Run(Initialize, _disposeCts.Token);
-            _metrics.ReportSessionError(e.Code, retry: true);
+            _metrics.ReportSessionError(e.Code);
         }
     }
 

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -112,6 +112,7 @@ internal class Reader<TValue> : IReader<TValue>
 
     private void Reconnect(StatusCode statusCode)
     {
+        _currentReaderSession = null;
         _metrics.ReportSessionError(statusCode);
         _ = Task.Run(Initialize);
     }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -110,7 +110,7 @@ internal class Reader<TValue> : IReader<TValue>
         throw new ReaderException("Reader is disposed");
     }
 
-    private void InternalReconnect(StatusCode statusCode)
+    private void Reconnect(StatusCode statusCode)
     {
         _metrics.ReportSessionError(statusCode);
         _ = Task.Run(Initialize);
@@ -223,7 +223,7 @@ internal class Reader<TValue> : IReader<TValue>
                 _config,
                 stream,
                 initResponse.SessionId,
-                InternalReconnect,
+                Reconnect,
                 await stream.AuthToken().ConfigureAwait(false),
                 _logger,
                 _receivedMessagesChannel.Writer,
@@ -311,7 +311,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         ReaderConfig config,
         ReaderStream stream,
         string sessionId,
-        Action<StatusCode> internalReconnect,
+        Action<StatusCode> reconnect,
         string? lastToken,
         ILogger logger,
         ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
@@ -321,7 +321,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         stream,
         logger,
         sessionId,
-        internalReconnect,
+        reconnect,
         lastToken
     )
     {

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -189,7 +189,7 @@ internal class Reader<TValue> : IReader<TValue>
                     _logger.LogError("Reader initialization failed to start. {StatusMessage}", statusMessage);
 
                     _ = Task.Run(Initialize, _disposeCts.Token);
-                    _metrics.ReportSessionError(initException, retry: true);
+                    _metrics.ReportSessionError(initException.Code, retry: true);
                 }
                 else
                 {
@@ -197,7 +197,7 @@ internal class Reader<TValue> : IReader<TValue>
 
                     _receivedMessagesChannel.Writer.Complete(
                         new ReaderException($"Initialization failed! {statusMessage}"));
-                    _metrics.ReportSessionError(initException, retry: false);
+                    _metrics.ReportSessionError(initException.Code, retry: false);
                 }
 
                 return;
@@ -230,7 +230,7 @@ internal class Reader<TValue> : IReader<TValue>
             _logger.LogError(e, "Error on executing ReaderSession");
 
             _ = Task.Run(Initialize, _disposeCts.Token);
-            _metrics.ReportSessionError(e, retry: true);
+            _metrics.ReportSessionError(e.Code, retry: true);
         }
     }
 
@@ -344,9 +344,8 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
                     Logger.LogError(
                         "ReaderSession[{SessionId}] received unsuccessful status while processing readAck: {Status}",
                         SessionId, messageFromServer.Status.Code().ToMessage(messageFromServer.Issues));
-                    ReconnectSession(() => _metrics.ReportSessionError(
-                        YdbException.FromServer(messageFromServer.Status, messageFromServer.Issues),
-                        retry: true));
+                    ReconnectSession(() =>
+                        _metrics.ReportSessionError(messageFromServer.Status.Code(), retry: true));
                     return;
                 }
 
@@ -384,7 +383,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         catch (YdbException e)
         {
             Logger.LogError(e, "ReaderSession[{SessionId}] have error on processing server messages", SessionId);
-            ReconnectSession(() => _metrics.ReportSessionError(e, retry: true));
+            ReconnectSession(() => _metrics.ReportSessionError(e.Code, retry: true));
         }
         finally
         {
@@ -406,7 +405,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         {
             Logger.LogError(e, "ReaderSession[{SessionId}] have error on Write", SessionId);
 
-            ReconnectSession(() => _metrics.ReportSessionError(e, retry: true));
+            ReconnectSession(() => _metrics.ReportSessionError(e.Code, retry: true));
 
             _lifecycleReaderSessionCts.Cancel();
         }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -341,11 +341,11 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
 
                 if (messageFromServer.Status.IsNotSuccess())
                 {
+                    var statusCode = messageFromServer.Status.Code();
                     Logger.LogError(
                         "ReaderSession[{SessionId}] received unsuccessful status while processing readAck: {Status}",
-                        SessionId, messageFromServer.Status.Code().ToMessage(messageFromServer.Issues));
-                    ReconnectSession(() =>
-                        _metrics.ReportSessionError(messageFromServer.Status.Code(), retry: true));
+                        SessionId, statusCode.ToMessage(messageFromServer.Issues));
+                    ReconnectSession(() => _metrics.ReportSessionError(statusCode, retry: true));
                     return;
                 }
 

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -110,6 +110,12 @@ internal class Reader<TValue> : IReader<TValue>
         throw new ReaderException("Reader is disposed");
     }
 
+    private void InternalReconnect(StatusCode statusCode)
+    {
+        _metrics.ReportSessionError(statusCode);
+        _ = Task.Run(Initialize);
+    }
+
     private async Task Initialize()
     {
         try
@@ -217,7 +223,7 @@ internal class Reader<TValue> : IReader<TValue>
                 _config,
                 stream,
                 initResponse.SessionId,
-                Initialize,
+                InternalReconnect,
                 await stream.AuthToken().ConfigureAwait(false),
                 _logger,
                 _receivedMessagesChannel.Writer,
@@ -305,7 +311,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         ReaderConfig config,
         ReaderStream stream,
         string sessionId,
-        Func<Task> initialize,
+        Action<StatusCode> internalReconnect,
         string? lastToken,
         ILogger logger,
         ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
@@ -315,9 +321,8 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         stream,
         logger,
         sessionId,
-        initialize,
-        lastToken,
-        metrics.ReportSessionError
+        internalReconnect,
+        lastToken
     )
     {
         _readerConfig = config;

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -316,7 +316,8 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
         logger,
         sessionId,
         initialize,
-        lastToken
+        lastToken,
+        metrics.ReportSessionError
     )
     {
         _readerConfig = config;
@@ -330,19 +331,6 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
 
     internal long PartitionSessionCount =>
         _lifecycleReaderSessionCts.IsCancellationRequested ? 0 : _partitionSessions.Count;
-
-    private void ReconnectSession(StatusCode statusCode = StatusCode.Unspecified, bool closedByServer = false) =>
-        base.ReconnectSession(() =>
-        {
-            if (closedByServer)
-            {
-                _metrics.ReportSessionClosed();
-            }
-            else
-            {
-                _metrics.ReportSessionError(statusCode, retry: true);
-            }
-        });
 
     private async Task RunProcessingStreamResponse()
     {
@@ -391,7 +379,7 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
             }
 
             Logger.LogInformation("ReaderSession[{SessionId}]: ResponseStream is closed", SessionId);
-            ReconnectSession(closedByServer: true);
+            ReconnectSession();
         }
         catch (YdbException e)
         {

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using Ydb.Sdk.Ado;
 using Ydb.Sdk.Internal;
 
 namespace Ydb.Sdk.Topic.Reader;
@@ -102,7 +101,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
 
     internal void ReportReceivedBytes(long bytes) => ReceivedBytes.Add(bytes, _commonTags);
 
-    internal void ReportSessionError(YdbException exception, bool retry)
+    internal void ReportSessionError(StatusCode statusCode, bool retry)
     {
         if (!SessionErrors.Enabled)
         {
@@ -112,8 +111,8 @@ internal sealed class ReaderMetricsReporter : IDisposable
         SessionErrors.Add(1, new TagList(_commonTags)
         {
             { "retry_decision", retry ? "retry" : "stop" },
-            { "status_code", exception.Code.ToString() },
-            { "error.type", exception.Code.IsTransportError() ? "transport_error" : "ydb_error" }
+            { "status_code", statusCode.ToString() },
+            { "error.type", statusCode.IsTransportError() ? "transport_error" : "ydb_error" }
         });
     }
 

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -103,6 +103,12 @@ internal sealed class ReaderMetricsReporter : IDisposable
 
     internal void ReportSessionError(StatusCode statusCode, bool retry)
     {
+        if (statusCode == StatusCode.Unspecified)
+        {
+            ReportSessionClosed();
+            return;
+        }
+
         if (!SessionErrors.Enabled)
         {
             return;

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Ydb.Sdk.Ado;
 using Ydb.Sdk.Internal;
 
 namespace Ydb.Sdk.Topic.Reader;
@@ -15,6 +16,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
 
     private static readonly Counter<long> ReceivedMessages;
     private static readonly Counter<long> ReceivedBytes;
+    private static readonly Counter<long> SessionErrors;
     private static readonly Counter<long> DeliveredMessages;
     private static readonly UpDownCounter<long> LocalBufferMessages;
     private static readonly Counter<long> CommitQueued;
@@ -42,6 +44,11 @@ internal sealed class ReaderMetricsReporter : IDisposable
             "ydb.topic.reader.received.bytes",
             unit: "By",
             description: "The protocol bytes_size received in read responses.");
+
+        SessionErrors = meter.CreateCounter<long>(
+            "ydb.topic.reader.session.errors",
+            unit: "{error}",
+            description: "The number of reader stream session errors by retry decision.");
 
         DeliveredMessages = meter.CreateCounter<long>(
             "ydb.topic.reader.delivered.messages",
@@ -95,11 +102,41 @@ internal sealed class ReaderMetricsReporter : IDisposable
 
     internal void ReportReceivedBytes(long bytes) => ReceivedBytes.Add(bytes, _commonTags);
 
+    internal void ReportSessionError(YdbException exception, bool retry)
+    {
+        if (!SessionErrors.Enabled)
+        {
+            return;
+        }
+
+        SessionErrors.Add(1, new TagList(_commonTags)
+        {
+            { "retry_decision", retry ? "retry" : "stop" },
+            { "status_code", exception.Code.ToString() },
+            { "error.type", exception.Code.IsTransportError() ? "transport_error" : "ydb_error" }
+        });
+    }
+
+    internal void ReportSessionClosed()
+    {
+        if (!SessionErrors.Enabled)
+        {
+            return;
+        }
+
+        SessionErrors.Add(1, new TagList(_commonTags)
+        {
+            { "retry_decision", "retry" },
+            { "status_code", "unknown" },
+            { "error.type", "session_closed" }
+        });
+    }
+
     internal void ReportDelivered(long messages, string topic) => Record(DeliveredMessages, messages, topic);
 
     internal void ReportLocalBuffer(long messages, string topic)
     {
-        if (!LocalBufferMessages.Enabled || messages == 0)
+        if (!LocalBufferMessages.Enabled)
         {
             return;
         }

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -101,7 +101,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
 
     internal void ReportReceivedBytes(long bytes) => ReceivedBytes.Add(bytes, _commonTags);
 
-    internal void ReportSessionError(StatusCode statusCode, bool retry)
+    internal void ReportSessionError(StatusCode statusCode, bool retry = true)
     {
         if (!SessionErrors.Enabled)
         {
@@ -111,7 +111,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
         SessionErrors.Add(1, new TagList(_commonTags)
         {
             { "retry_decision", retry ? "retry" : "stop" },
-            { "status_code", statusCode == StatusCode.Unspecified ? "unknown" : statusCode.ToString() },
+            { "status_code", statusCode.ToString() },
             {
                 "error.type", statusCode switch
                 {

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -103,12 +103,6 @@ internal sealed class ReaderMetricsReporter : IDisposable
 
     internal void ReportSessionError(StatusCode statusCode, bool retry)
     {
-        if (statusCode == StatusCode.Unspecified)
-        {
-            ReportSessionClosed();
-            return;
-        }
-
         if (!SessionErrors.Enabled)
         {
             return;
@@ -117,23 +111,15 @@ internal sealed class ReaderMetricsReporter : IDisposable
         SessionErrors.Add(1, new TagList(_commonTags)
         {
             { "retry_decision", retry ? "retry" : "stop" },
-            { "status_code", statusCode.ToString() },
-            { "error.type", statusCode.IsTransportError() ? "transport_error" : "ydb_error" }
-        });
-    }
-
-    internal void ReportSessionClosed()
-    {
-        if (!SessionErrors.Enabled)
-        {
-            return;
-        }
-
-        SessionErrors.Add(1, new TagList(_commonTags)
-        {
-            { "retry_decision", "retry" },
-            { "status_code", "unknown" },
-            { "error.type", "session_closed" }
+            { "status_code", statusCode == StatusCode.Unspecified ? "unknown" : statusCode.ToString() },
+            {
+                "error.type", statusCode switch
+                {
+                    StatusCode.Unspecified => "session_closed",
+                    _ when statusCode.IsTransportError() => "transport_error",
+                    _ => "ydb_error"
+                }
+            }
         });
     }
 

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -6,6 +6,7 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
     IBidirectionalStream<TFromClient, TFromServer> stream,
     ILogger logger,
     string sessionId,
+    Action<StatusCode> internalReconnect,
     string? lastToken
 ) : IAsyncDisposable
 {
@@ -29,10 +30,8 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
 
         Logger.LogDebug("TopicSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
 
-        InternalReconnect(statusCode);
+        internalReconnect(statusCode);
     }
-
-    protected abstract void InternalReconnect(StatusCode statusCode);
 
     protected async Task SendMessage(TFromClient fromClient)
     {

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -6,13 +6,14 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
     IBidirectionalStream<TFromClient, TFromServer> stream,
     ILogger logger,
     string sessionId,
-    Action<StatusCode> internalReconnect,
+    Func<Task> initialize,
     string? lastToken
 ) : IAsyncDisposable
 {
     protected readonly IBidirectionalStream<TFromClient, TFromServer> Stream = stream;
     protected readonly ILogger Logger = logger;
     protected readonly string SessionId = sessionId;
+    protected readonly Func<Task> Initialize = initialize;
 
     private int _isActive = 1;
     private string? _lastToken = lastToken;
@@ -30,8 +31,10 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
 
         Logger.LogDebug("TopicSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
 
-        internalReconnect(statusCode);
+        InternalReconnect(statusCode);
     }
+
+    protected abstract void InternalReconnect(StatusCode statusCode);
 
     protected async Task SendMessage(TFromClient fromClient)
     {

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -19,7 +19,7 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
 
     public bool IsActive => Volatile.Read(ref _isActive) == 1;
 
-    protected void ReconnectSession()
+    protected void ReconnectSession(Action? reportMetric = null)
     {
         if (Interlocked.CompareExchange(ref _isActive, 0, 1) == 0)
         {
@@ -30,6 +30,7 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
 
         Logger.LogDebug("TopicSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
 
+        reportMetric?.Invoke();
         _ = Task.Run(initialize);
     }
 

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -6,14 +6,12 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
     IBidirectionalStream<TFromClient, TFromServer> stream,
     ILogger logger,
     string sessionId,
-    Func<Task> initialize,
     string? lastToken
 ) : IAsyncDisposable
 {
     protected readonly IBidirectionalStream<TFromClient, TFromServer> Stream = stream;
     protected readonly ILogger Logger = logger;
     protected readonly string SessionId = sessionId;
-    protected readonly Func<Task> Initialize = initialize;
 
     private int _isActive = 1;
     private string? _lastToken = lastToken;

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -6,9 +6,8 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
     IBidirectionalStream<TFromClient, TFromServer> stream,
     ILogger logger,
     string sessionId,
-    Func<Task> initialize,
-    string? lastToken,
-    Action<StatusCode, bool>? reportMetric = null
+    Action<StatusCode> internalReconnect,
+    string? lastToken
 ) : IAsyncDisposable
 {
     protected readonly IBidirectionalStream<TFromClient, TFromServer> Stream = stream;
@@ -31,8 +30,7 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
 
         Logger.LogDebug("TopicSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
 
-        reportMetric?.Invoke(statusCode, true);
-        _ = Task.Run(initialize);
+        internalReconnect(statusCode);
     }
 
     protected async Task SendMessage(TFromClient fromClient)

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -6,7 +6,7 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
     IBidirectionalStream<TFromClient, TFromServer> stream,
     ILogger logger,
     string sessionId,
-    Action<StatusCode> internalReconnect,
+    Action<StatusCode> reconnect,
     string? lastToken
 ) : IAsyncDisposable
 {
@@ -30,7 +30,7 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
 
         Logger.LogDebug("TopicSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
 
-        internalReconnect(statusCode);
+        reconnect(statusCode);
     }
 
     protected async Task SendMessage(TFromClient fromClient)

--- a/src/Ydb.Sdk/src/Topic/TopicSession.cs
+++ b/src/Ydb.Sdk/src/Topic/TopicSession.cs
@@ -7,7 +7,8 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
     ILogger logger,
     string sessionId,
     Func<Task> initialize,
-    string? lastToken
+    string? lastToken,
+    Action<StatusCode, bool>? reportMetric = null
 ) : IAsyncDisposable
 {
     protected readonly IBidirectionalStream<TFromClient, TFromServer> Stream = stream;
@@ -19,7 +20,7 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
 
     public bool IsActive => Volatile.Read(ref _isActive) == 1;
 
-    protected void ReconnectSession(Action? reportMetric = null)
+    protected void ReconnectSession(StatusCode statusCode = StatusCode.Unspecified)
     {
         if (Interlocked.CompareExchange(ref _isActive, 0, 1) == 0)
         {
@@ -30,7 +31,7 @@ internal abstract class TopicSession<TFromClient, TFromServer>(
 
         Logger.LogDebug("TopicSession[{SessionId}] has been deactivated, starting to reconnect", SessionId);
 
-        reportMetric?.Invoke();
+        reportMetric?.Invoke(statusCode, true);
         _ = Task.Run(initialize);
     }
 

--- a/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
@@ -209,7 +209,7 @@ internal class Writer<TValue> : IWriter<TValue>
 
     private void WakeUpWorker() => _tcsWakeUp.TrySetResult();
 
-    private void InternalReconnect(StatusCode statusCode) => _ = Task.Run(Initialize);
+    private void Reconnect(StatusCode statusCode) => _ = Task.Run(Initialize);
 
     private async Task Initialize()
     {
@@ -326,7 +326,7 @@ internal class Writer<TValue> : IWriter<TValue>
                     stream: stream,
                     lastSeqNo: lastSeqNo,
                     sessionId: initResponse.SessionId,
-                    internalReconnect: InternalReconnect,
+                    reconnect: Reconnect,
                     await stream.AuthToken().ConfigureAwait(false),
                     logger: _logger,
                     inFlightMessages: _inFlightMessages
@@ -474,7 +474,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         WriterStream stream,
         long lastSeqNo,
         string sessionId,
-        Action<StatusCode> internalReconnect,
+        Action<StatusCode> reconnect,
         string? lastToken,
         ILogger logger,
         ConcurrentQueue<MessageSending> inFlightMessages
@@ -482,7 +482,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         stream,
         logger,
         sessionId,
-        internalReconnect,
+        reconnect,
         lastToken
     )
     {

--- a/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
@@ -209,8 +209,6 @@ internal class Writer<TValue> : IWriter<TValue>
 
     private void WakeUpWorker() => _tcsWakeUp.TrySetResult();
 
-    private void InternalReconnect(StatusCode statusCode) => _ = Task.Run(Initialize);
-
     private async Task Initialize()
     {
         _session = DummyWriterSession.Instance;
@@ -326,7 +324,7 @@ internal class Writer<TValue> : IWriter<TValue>
                     stream: stream,
                     lastSeqNo: lastSeqNo,
                     sessionId: initResponse.SessionId,
-                    internalReconnect: InternalReconnect,
+                    initialize: Initialize,
                     await stream.AuthToken().ConfigureAwait(false),
                     logger: _logger,
                     inFlightMessages: _inFlightMessages
@@ -474,7 +472,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         WriterStream stream,
         long lastSeqNo,
         string sessionId,
-        Action<StatusCode> internalReconnect,
+        Func<Task> initialize,
         string? lastToken,
         ILogger logger,
         ConcurrentQueue<MessageSending> inFlightMessages
@@ -482,7 +480,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         stream,
         logger,
         sessionId,
-        internalReconnect,
+        initialize,
         lastToken
     )
     {
@@ -631,6 +629,8 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
             ReconnectSession();
         }
     }
+
+    protected override void InternalReconnect(StatusCode statusCode) => _ = Task.Run(Initialize);
 
     protected override MessageFromClient GetSendUpdateTokenRequest(string token) =>
         new()

--- a/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
@@ -462,6 +462,7 @@ internal class DummyWriterSession : IWriteSession
 internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer>, IWriteSession
 {
     private readonly WriterConfig _config;
+    private readonly Func<Task> _initialize;
     private readonly ConcurrentQueue<MessageSending> _inFlightMessages;
     private readonly Task _processingResponseStream;
 
@@ -480,11 +481,11 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         stream,
         logger,
         sessionId,
-        initialize,
         lastToken
     )
     {
         _config = config;
+        _initialize = initialize;
         _inFlightMessages = inFlightMessages;
         Volatile.Write(ref _seqNum, lastSeqNo); // happens-before for Volatile.Read
 
@@ -630,7 +631,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         }
     }
 
-    protected override void InternalReconnect(StatusCode statusCode) => _ = Task.Run(Initialize);
+    protected override void InternalReconnect(StatusCode statusCode) => _ = Task.Run(_initialize);
 
     protected override MessageFromClient GetSendUpdateTokenRequest(string token) =>
         new()

--- a/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
@@ -209,6 +209,8 @@ internal class Writer<TValue> : IWriter<TValue>
 
     private void WakeUpWorker() => _tcsWakeUp.TrySetResult();
 
+    private void InternalReconnect(StatusCode statusCode) => _ = Task.Run(Initialize);
+
     private async Task Initialize()
     {
         _session = DummyWriterSession.Instance;
@@ -324,7 +326,7 @@ internal class Writer<TValue> : IWriter<TValue>
                     stream: stream,
                     lastSeqNo: lastSeqNo,
                     sessionId: initResponse.SessionId,
-                    initialize: Initialize,
+                    internalReconnect: InternalReconnect,
                     await stream.AuthToken().ConfigureAwait(false),
                     logger: _logger,
                     inFlightMessages: _inFlightMessages
@@ -472,7 +474,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         WriterStream stream,
         long lastSeqNo,
         string sessionId,
-        Func<Task> initialize,
+        Action<StatusCode> internalReconnect,
         string? lastToken,
         ILogger logger,
         ConcurrentQueue<MessageSending> inFlightMessages
@@ -480,7 +482,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         stream,
         logger,
         sessionId,
-        initialize,
+        internalReconnect,
         lastToken
     )
     {

--- a/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
+++ b/src/Ydb.Sdk/src/Topic/Writer/Writer.cs
@@ -209,6 +209,8 @@ internal class Writer<TValue> : IWriter<TValue>
 
     private void WakeUpWorker() => _tcsWakeUp.TrySetResult();
 
+    private void InternalReconnect(StatusCode statusCode) => _ = Task.Run(Initialize);
+
     private async Task Initialize()
     {
         _session = DummyWriterSession.Instance;
@@ -324,7 +326,7 @@ internal class Writer<TValue> : IWriter<TValue>
                     stream: stream,
                     lastSeqNo: lastSeqNo,
                     sessionId: initResponse.SessionId,
-                    initialize: Initialize,
+                    internalReconnect: InternalReconnect,
                     await stream.AuthToken().ConfigureAwait(false),
                     logger: _logger,
                     inFlightMessages: _inFlightMessages
@@ -462,7 +464,6 @@ internal class DummyWriterSession : IWriteSession
 internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer>, IWriteSession
 {
     private readonly WriterConfig _config;
-    private readonly Func<Task> _initialize;
     private readonly ConcurrentQueue<MessageSending> _inFlightMessages;
     private readonly Task _processingResponseStream;
 
@@ -473,7 +474,7 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         WriterStream stream,
         long lastSeqNo,
         string sessionId,
-        Func<Task> initialize,
+        Action<StatusCode> internalReconnect,
         string? lastToken,
         ILogger logger,
         ConcurrentQueue<MessageSending> inFlightMessages
@@ -481,11 +482,11 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
         stream,
         logger,
         sessionId,
+        internalReconnect,
         lastToken
     )
     {
         _config = config;
-        _initialize = initialize;
         _inFlightMessages = inFlightMessages;
         Volatile.Write(ref _seqNum, lastSeqNo); // happens-before for Volatile.Read
 
@@ -630,8 +631,6 @@ internal class WriterSession : TopicSession<MessageFromClient, MessageFromServer
             ReconnectSession();
         }
     }
-
-    protected override void InternalReconnect(StatusCode statusCode) => _ = Task.Run(_initialize);
 
     protected override MessageFromClient GetSendUpdateTokenRequest(string token) =>
         new()

--- a/src/Ydb.Sdk/src/Tracing/YdbActivitySource.cs
+++ b/src/Ydb.Sdk/src/Tracing/YdbActivitySource.cs
@@ -20,14 +20,7 @@ internal static class YdbActivitySource
         if (exception is YdbException ydbException)
         {
             activity.SetTag("db.response.status_code", ydbException.Code);
-            activity.SetTag("error.type", ydbException.Code
-                is StatusCode.ClientTransportUnknown
-                or StatusCode.ClientTransportUnavailable
-                or StatusCode.ClientTransportTimeout
-                or StatusCode.ClientTransportResourceExhausted
-                or StatusCode.ClientTransportUnimplemented
-                ? "transport_error"
-                : "ydb_error");
+            activity.SetTag("error.type", ydbException.Code.IsTransportError() ? "transport_error" : "ydb_error");
         }
         else
         {

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -233,6 +233,17 @@ public class ReaderMetricsReporterTests
         var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
         var handledEvents = Channel.CreateUnbounded<long>();
         SetupResponseStream(mockStream, responses, handledEvents.Writer);
+        var reconnectStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var initRequests = 0;
+        mockStream.Setup(stream => stream.Write(It.Is<FromClient>(message => message.InitRequest != null)))
+            .Callback(() =>
+            {
+                if (++initRequests == 2)
+                {
+                    reconnectStarted.SetResult();
+                }
+            })
+            .Returns(Task.CompletedTask);
         var reader = new ReaderBuilder<string>(driverFactory)
         {
             ConsumerName = "partition-count-consumer",
@@ -247,9 +258,11 @@ public class ReaderMetricsReporterTests
             await SendResponse(meterProvider, StartPartitionSessionRequest(partitionSessionId: 1), 1, 1);
             await SendResponse(meterProvider, StartPartitionSessionRequest(partitionSessionId: 2), 2, 2);
             await SendResponse(meterProvider, StopPartitionSessionRequest(partitionSessionId: 1), -1, 1);
-            await SendResponse(meterProvider, StopPartitionSessionRequest(partitionSessionId: 2), -2, 0);
             await responses.Writer.WriteAsync((false, null));
+            await reconnectStarted.Task.WaitAsync(timeout);
+            AssertCount(meterProvider, 0);
             await SendResponse(meterProvider, InitResponse, 0, 0);
+            await SendResponse(meterProvider, StartPartitionSessionRequest(partitionSessionId: 3), 3, 1);
         }
         finally
         {
@@ -271,6 +284,11 @@ public class ReaderMetricsReporterTests
         {
             await responses.Writer.WriteAsync((true, response));
             Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
+            AssertCount(provider, expectedCount);
+        }
+
+        void AssertCount(MeterProvider provider, long expectedCount)
+        {
             exportedItems.Clear();
             provider.ForceFlush();
             var point = Assert.Single(GetReaderPoints(exportedItems, PartitionSessionCountMetricName,

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -1,8 +1,10 @@
 using System.Threading.Channels;
+using Grpc.Core;
 using Moq;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using Xunit;
+using Ydb.Sdk.Ado;
 using Ydb.Sdk.OpenTelemetry;
 using Ydb.Sdk.Topic.Reader;
 using Ydb.Topic;
@@ -122,6 +124,101 @@ public class ReaderMetricsReporterTests
             var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName));
             Assert.Equal(expected, point.GetSumLong());
             AssertTags(point, "local-buffer-consumer", readerName, "/topic");
+        }
+    }
+
+    [Fact]
+    public async Task SessionErrors_RecordsOneRetryAndTerminalStop()
+    {
+        const string readerName = "session-errors-reader";
+        const string metricName = "ydb.topic.reader.session.errors";
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+        var firstStream = new Mock<ReaderStream>();
+        var secondStream = new Mock<ReaderStream>();
+        var fail = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseWaiting = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestWaiting = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var transportError = new YdbException(StatusCode.ClientTransportUnavailable, "transport failure");
+
+        firstStream.SetupSequence(stream => stream.MoveNextAsync())
+            .ReturnsAsync(true)
+            .ReturnsAsync(true)
+            .Returns(async () =>
+            {
+                responseWaiting.SetResult();
+                await fail.Task;
+                throw transportError;
+            });
+        firstStream.SetupSequence(stream => stream.Current)
+            .Returns(InitResponse)
+            .Returns(StartPartitionSessionRequest());
+        firstStream.SetupSequence(stream => stream.Write(It.IsAny<FromClient>()))
+            .Returns(Task.CompletedTask)
+            .Returns(Task.CompletedTask)
+            .Returns(async () =>
+            {
+                requestWaiting.SetResult();
+                await fail.Task;
+                throw transportError;
+            });
+        firstStream.Setup(stream => stream.RequestStreamComplete()).Returns(Task.CompletedTask);
+
+        secondStream.Setup(stream => stream.Write(It.IsAny<FromClient>())).Returns(Task.CompletedTask);
+        secondStream.Setup(stream => stream.MoveNextAsync()).ReturnsAsync(true);
+        secondStream.Setup(stream => stream.Current).Returns(new FromServer
+        {
+            Status = StatusIds.Types.StatusCode.Unauthorized
+        });
+
+        var driver = new Mock<IDriver>();
+        driver.SetupSequence(mock => mock.BidirectionalStreamCall(
+                It.IsAny<Method<FromClient, FromServer>>(),
+                It.IsAny<GrpcRequestSettings>()))
+            .ReturnsAsync(firstStream.Object)
+            .ReturnsAsync(secondStream.Object);
+        driver.Setup(mock => mock.LoggerFactory).Returns(Utils.LoggerFactory);
+        await using var reader = new ReaderBuilder<string>(new IDriverFactoryMock(driver, "session-errors"))
+        {
+            ReaderName = readerName,
+            ConsumerName = "session-errors-consumer",
+            SubscribeSettings = { new SubscribeSettings("/topic") }
+        }.Build();
+
+        var timeout = TimeSpan.FromSeconds(5);
+        await Task.WhenAll(responseWaiting.Task, requestWaiting.Task).WaitAsync(timeout);
+        fail.SetResult();
+        await Assert.ThrowsAsync<ReaderException>(async () =>
+            await reader.ReadAsync().AsTask().WaitAsync(timeout));
+
+        meterProvider.ForceFlush();
+        var metric = GetMetric(exportedItems, metricName);
+        Assert.Equal(MetricType.LongSum, metric.MetricType);
+        Assert.Equal("{error}", metric.Unit);
+        var points = GetReaderPoints(exportedItems, metricName, readerName)
+            .ToDictionary(point => ToDictionary(point.Tags)["retry_decision"]!.ToString()!);
+        Assert.Equal(1, points["retry"].GetSumLong());
+        Assert.Equal(1, points["stop"].GetSumLong());
+        AssertSessionErrorTags(points["retry"], "retry", "ClientTransportUnavailable", "transport_error");
+        AssertSessionErrorTags(points["stop"], "stop", "Unauthorized", "ydb_error");
+        return;
+
+        void AssertSessionErrorTags(
+            MetricPoint point,
+            string retryDecision,
+            string statusCode,
+            string errorType)
+        {
+            var tags = ToDictionary(point.Tags);
+            Assert.Equal(7, tags.Count);
+            Assert.Equal("localhost:2136", tags["endpoint"]);
+            Assert.Equal("/local", tags["database"]);
+            Assert.Equal("session-errors-consumer", tags["consumer"]);
+            Assert.Equal(readerName, tags["reader.name"]);
+            Assert.Equal(retryDecision, tags["retry_decision"]);
+            Assert.Equal(statusCode, tags["status_code"]);
+            Assert.Equal(errorType, tags["error.type"]);
+            Assert.DoesNotContain("topic", tags);
         }
     }
 

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -233,17 +233,6 @@ public class ReaderMetricsReporterTests
         var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
         var handledEvents = Channel.CreateUnbounded<long>();
         SetupResponseStream(mockStream, responses, handledEvents.Writer);
-        var reconnectStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var initRequests = 0;
-        mockStream.Setup(stream => stream.Write(It.Is<FromClient>(message => message.InitRequest != null)))
-            .Callback(() =>
-            {
-                if (++initRequests == 2)
-                {
-                    reconnectStarted.SetResult();
-                }
-            })
-            .Returns(Task.CompletedTask);
         var reader = new ReaderBuilder<string>(driverFactory)
         {
             ConsumerName = "partition-count-consumer",
@@ -258,11 +247,9 @@ public class ReaderMetricsReporterTests
             await SendResponse(meterProvider, StartPartitionSessionRequest(partitionSessionId: 1), 1, 1);
             await SendResponse(meterProvider, StartPartitionSessionRequest(partitionSessionId: 2), 2, 2);
             await SendResponse(meterProvider, StopPartitionSessionRequest(partitionSessionId: 1), -1, 1);
+            await SendResponse(meterProvider, StopPartitionSessionRequest(partitionSessionId: 2), -2, 0);
             await responses.Writer.WriteAsync((false, null));
-            await reconnectStarted.Task.WaitAsync(timeout);
-            AssertCount(meterProvider, 0);
             await SendResponse(meterProvider, InitResponse, 0, 0);
-            await SendResponse(meterProvider, StartPartitionSessionRequest(partitionSessionId: 3), 3, 1);
         }
         finally
         {
@@ -284,11 +271,6 @@ public class ReaderMetricsReporterTests
         {
             await responses.Writer.WriteAsync((true, response));
             Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
-            AssertCount(provider, expectedCount);
-        }
-
-        void AssertCount(MeterProvider provider, long expectedCount)
-        {
             exportedItems.Clear();
             provider.ForceFlush();
             var point = Assert.Single(GetReaderPoints(exportedItems, PartitionSessionCountMetricName,

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Threading.Channels;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -37,38 +36,6 @@ public class ReaderUnitTests
 
             return Task.CompletedTask;
         });
-    }
-
-    [Fact]
-    public async Task SessionStart_WhenStreamClosesSynchronously_ReconnectSeesPublishedSession()
-    {
-        _mockStream.Setup(stream => stream.MoveNextAsync()).ReturnsAsync(false);
-        ReaderSession<string>? currentSession = null;
-        ReaderSession<string>? sessionAtReconnect = null;
-        using var metrics = new ReaderMetricsReporter("localhost:2136", "/local", null, null,
-            () => new ReaderStats(0));
-        await using var session = new ReaderSession<string>(
-            new ReaderConfig([], null, null, 200),
-            _mockStream.Object,
-            "session-id",
-            _ =>
-            {
-                sessionAtReconnect = currentSession;
-                currentSession = null;
-            },
-            null,
-            Utils.LoggerFactory.CreateLogger("ReaderSessionTest"),
-            Channel.CreateUnbounded<InternalBatchMessages<string>>().Writer,
-            Mock.Of<IDeserializer<string>>(),
-            metrics);
-
-        _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Never);
-        currentSession = session;
-        session.Start();
-
-        Assert.Same(session, sessionAtReconnect);
-        Assert.Null(currentSession);
-        _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Once);
     }
 
     /*

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Threading.Channels;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -36,6 +37,38 @@ public class ReaderUnitTests
 
             return Task.CompletedTask;
         });
+    }
+
+    [Fact]
+    public async Task SessionStart_WhenStreamClosesSynchronously_ReconnectSeesPublishedSession()
+    {
+        _mockStream.Setup(stream => stream.MoveNextAsync()).ReturnsAsync(false);
+        ReaderSession<string>? currentSession = null;
+        ReaderSession<string>? sessionAtReconnect = null;
+        using var metrics = new ReaderMetricsReporter("localhost:2136", "/local", null, null,
+            () => new ReaderStats(0));
+        await using var session = new ReaderSession<string>(
+            new ReaderConfig([], null, null, 200),
+            _mockStream.Object,
+            "session-id",
+            _ =>
+            {
+                sessionAtReconnect = currentSession;
+                currentSession = null;
+            },
+            null,
+            Utils.LoggerFactory.CreateLogger("ReaderSessionTest"),
+            Channel.CreateUnbounded<InternalBatchMessages<string>>().Writer,
+            Mock.Of<IDeserializer<string>>(),
+            metrics);
+
+        _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Never);
+        currentSession = session;
+        session.Start();
+
+        Assert.Same(session, sessionAtReconnect);
+        Assert.Null(currentSession);
+        _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Once);
     }
 
     /*


### PR DESCRIPTION
## Summary
- add `ydb.topic.reader.session.errors` with retry decision, status code, and bounded error type attributes
- report reconnect-triggering transport/server failures once and distinguish server-closed sessions
- share transport status classification with ADO.NET tracing

## Testing
- `dotnet test src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/Ydb.Sdk.Topic.Tests.csproj --filter "FullyQualifiedName~ReaderMetricsReporterTests|FullyQualifiedName~ReaderUnitTests" --no-restore` (20 passed)

Tracker: https://st.yandex-team.ru/YDBAPPTEAM-1951