### PR TITLE
feat: add Topic Reader credit balance metric

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,13 +1,14 @@
 - Dev: bumped the metrics observability-chain minor version in `x-ydb-sdk-build-info` from
   `ydb-sdk-metrics/0.1.0` to `ydb-sdk-metrics/0.2.0`.
-- Feat Topic Reader metrics: added six counters, a local-buffer UpDownCounter, and a partition-session gauge on
-  the `Ydb.Sdk.Topic` meter.
+- Feat Topic Reader metrics: added six counters, a local-buffer UpDownCounter, and partition-session and credit-balance
+  gauges on the `Ydb.Sdk.Topic` meter.
 
   | Metric                                             | Unit        | Description                                                  |
   |----------------------------------------------------|-------------|--------------------------------------------------------------|
   | `ydb.topic.reader.received.messages`               | `{message}` | Messages accepted by the SDK from active partition sessions  |
   | `ydb.topic.reader.received.bytes`                  | `By`        | Protocol `ReadResponse.bytes_size`, counted once per response |
   | `ydb.topic.reader.session.errors`                  | `{error}`   | Reader stream-session retry and terminal failure decisions    |
+  | `ydb.topic.reader.credit_balance_bytes`            | `By`        | Outstanding protocol credit for active read streams          |
   | `ydb.topic.reader.delivered.messages`              | `{message}` | Messages delivered by the SDK to application code            |
   | `ydb.topic.reader.local_buffer.messages`           | `{message}` | Messages currently accepted but not delivered by the SDK      |
   | `ydb.topic.reader.commit.queued`                   | `{message}` | Messages in commit ranges accepted by the SDK                |
@@ -18,9 +19,11 @@
   in every queued range it completes; stale acknowledgements are ignored.
   All Topic Reader metrics have the `endpoint` and `database` attributes, plus `consumer` and `reader.name` when they
   are configured; message and commit counters also have `topic`. The received-bytes counter covers the whole stream
-  without `topic`, including data for unknown partitions. The partition-session gauge is an SDK-local snapshot, not server
-  ownership or processing progress. The session-error counter has `retry_decision`, `status_code`, and `error.type`
-  attributes and does not have `topic`.
+  without `topic`, including data for unknown partitions. The credit-balance gauge has the same stream scope, is updated
+  for queued read-credit requests and read responses, returns zero when its reader session is inactive, and permits
+  negative values for oversized responses. The partition-session gauge is an SDK-local snapshot, not server ownership or
+  processing progress. The session-error counter has `retry_decision`, `status_code`, and `error.type` attributes and does
+  not have `topic`.
   The local-buffer UpDownCounter increments when messages enter the local buffer and decrements when they are delivered.
   Because it is synchronous, a listener attached after a Reader is created is not backfilled with the Reader's
   already-buffered messages.

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -18,7 +18,7 @@ using ReaderStream = IBidirectionalStream<
     StreamReadMessage.Types.FromServer
 >;
 
-internal class Reader<TValue> : IReader<TValue>
+internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
 {
     private readonly IDriverFactory _driverFactory;
     private readonly ReaderConfig _config;
@@ -53,15 +53,12 @@ internal class Reader<TValue> : IReader<TValue>
             _driverFactory.Database,
             _config.ConsumerName,
             _config.ReaderName,
-            GetReaderStats);
+            this);
 
         _ = Initialize();
     }
 
-    /// <summary>
-    /// Returns a diagnostic snapshot for Topic Reader metrics.
-    /// </summary>
-    private ReaderStats GetReaderStats() => new(_currentReaderSession?.PartitionSessionCount ?? 0);
+    long IReaderMetricsSource.PartitionSessionCount => _currentReaderSession?.PartitionSessionCount ?? 0;
 
     public async ValueTask<Message<TValue>> ReadAsync(CancellationToken cancellationToken = default)
     {
@@ -113,6 +110,7 @@ internal class Reader<TValue> : IReader<TValue>
     private void Reconnect(StatusCode statusCode)
     {
         _currentReaderSession = null;
+        _metrics.ResetCreditBalanceBytes();
         _metrics.ReportSessionError(statusCode);
         _ = Task.Run(Initialize, _disposeCts.Token);
     }
@@ -229,6 +227,7 @@ internal class Reader<TValue> : IReader<TValue>
                 _deserializer,
                 _metrics
             );
+            _metrics.ResetCreditBalanceBytes(_config.MemoryUsageMaxBytes);
             _currentReaderSession.Start();
         }
         catch (YdbException e)
@@ -417,6 +416,7 @@ internal class ReaderSession<TValue>(
                 .WriteAsync(new MessageFromClient
                     { ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = readRequestBytes } })
                 .ConfigureAwait(false);
+            metrics.ReportCreditBalanceBytes(readRequestBytes);
         }
     }
 
@@ -556,6 +556,7 @@ internal class ReaderSession<TValue>(
     private async Task HandleReadResponse(StreamReadMessage.Types.ReadResponse readResponse)
     {
         var bytesSize = readResponse.BytesSize;
+        metrics.ReportCreditBalanceBytes(-bytesSize);
         metrics.ReportReceivedBytes(bytesSize);
         var partitionCount = readResponse.PartitionData.Count;
 

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -4,7 +4,10 @@ using Ydb.Sdk.Internal;
 
 namespace Ydb.Sdk.Topic.Reader;
 
-internal readonly record struct ReaderStats(long PartitionSessionCount);
+internal interface IReaderMetricsSource
+{
+    long PartitionSessionCount { get; }
+}
 
 /// <summary>
 /// Topic reader message and commit lifecycle metrics.
@@ -20,9 +23,11 @@ internal sealed class ReaderMetricsReporter : IDisposable
     private static readonly UpDownCounter<long> LocalBufferMessages;
     private static readonly Counter<long> CommitQueued;
     private static readonly Counter<long> CommitAcknowledged;
+    private static readonly ObservableGauge<long> CreditBalanceBytes;
 
     private readonly KeyValuePair<string, object?>[] _commonTags;
-    private readonly Func<ReaderStats> _readerStats;
+    private readonly IReaderMetricsSource _readerMetricsSource;
+    private long _creditBalanceBytes;
 
     static ReaderMetricsReporter()
     {
@@ -33,6 +38,12 @@ internal sealed class ReaderMetricsReporter : IDisposable
             ObservePartitionSessionCount,
             unit: "{session}",
             description: "The number of partition sessions currently in the reader session processing lifecycle.");
+
+        CreditBalanceBytes = meter.CreateObservableGauge(
+            "ydb.topic.reader.credit_balance_bytes",
+            ObserveCreditBalanceBytes,
+            unit: "By",
+            description: "The protocol credit granted to the server and not yet consumed by read responses.");
 
         ReceivedMessages = meter.CreateCounter<long>(
             "ydb.topic.reader.received.messages",
@@ -75,9 +86,9 @@ internal sealed class ReaderMetricsReporter : IDisposable
         string database,
         string? consumer,
         string? readerName,
-        Func<ReaderStats> readerStats)
+        IReaderMetricsSource readerMetricsSource)
     {
-        _readerStats = readerStats;
+        _readerMetricsSource = readerMetricsSource;
         var commonTags = new TagList
         {
             { "endpoint", endpoint },
@@ -100,6 +111,26 @@ internal sealed class ReaderMetricsReporter : IDisposable
     internal void ReportReceived(long messages, string topic) => Record(ReceivedMessages, messages, topic);
 
     internal void ReportReceivedBytes(long bytes) => ReceivedBytes.Add(bytes, _commonTags);
+
+    internal void ReportCreditBalanceBytes(long bytes)
+    {
+        if (!CreditBalanceBytes.Enabled)
+        {
+            return;
+        }
+
+        Interlocked.Add(ref _creditBalanceBytes, bytes);
+    }
+
+    internal void ResetCreditBalanceBytes(long bytes = 0)
+    {
+        if (!CreditBalanceBytes.Enabled)
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref _creditBalanceBytes, bytes);
+    }
 
     internal void ReportSessionError(StatusCode statusCode, bool retry = true)
     {
@@ -173,8 +204,19 @@ internal sealed class ReaderMetricsReporter : IDisposable
         lock (Reporters)
         {
             return Reporters
-                .Select(reader =>
-                    new Measurement<long>(reader._readerStats().PartitionSessionCount, reader._commonTags))
+                .Select(reporter =>
+                    new Measurement<long>(reporter._readerMetricsSource.PartitionSessionCount, reporter._commonTags))
+                .ToArray();
+        }
+    }
+
+    private static IEnumerable<Measurement<long>> ObserveCreditBalanceBytes()
+    {
+        lock (Reporters)
+        {
+            return Reporters
+                .Select(reporter =>
+                    new Measurement<long>(Interlocked.Read(ref reporter._creditBalanceBytes), reporter._commonTags))
                 .ToArray();
         }
     }

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -31,6 +31,75 @@ public class ReaderMetricsReporterTests
     ];
 
     [Fact]
+    public async Task CreditBalance_TracksOutstandingStreamCredit()
+    {
+        const string readerName = "credit-balance-reader";
+        const string metricName = "ydb.topic.reader.credit_balance_bytes";
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+        var mockStream = new Mock<ReaderStream>();
+        var closed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reconnectBlocked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var initializationCount = 0;
+        mockStream.SetupSequence(stream => stream.MoveNextAsync())
+            .ReturnsAsync(true)
+            .ReturnsAsync(true)
+            .ReturnsAsync(true)
+            .Returns(closed.Task)
+            .Returns(reconnectBlocked.Task);
+        mockStream.SetupSequence(stream => stream.Current)
+            .Returns(InitResponse)
+            .Returns(StartPartitionSessionRequest())
+            .Returns(ReadResponse("message"u8.ToArray()));
+        mockStream.Setup(stream => stream.Write(It.IsAny<FromClient>()))
+            .Callback<FromClient>(message =>
+            {
+                if (message.InitRequest is not null && Interlocked.Increment(ref initializationCount) == 2)
+                {
+                    reconnected.TrySetResult();
+                }
+            })
+            .Returns(Task.CompletedTask);
+        mockStream.Setup(stream => stream.RequestStreamComplete()).Returns(() =>
+        {
+            closed.TrySetResult(false);
+            reconnectBlocked.TrySetResult(false);
+            return Task.CompletedTask;
+        });
+        var reader = new ReaderBuilder<string>(CreateDriverFactory(mockStream, readerName))
+        {
+            ReaderName = readerName,
+            ConsumerName = "credit-balance-consumer",
+            MemoryUsageMaxBytes = 1000,
+            SubscribeSettings = { new SubscribeSettings("/topic") }
+        }.Build();
+
+        await reader.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        meterProvider.ForceFlush();
+        var metric = GetMetric(exportedItems, metricName);
+        Assert.Equal(MetricType.LongGauge, metric.MetricType);
+        Assert.Equal("By", metric.Unit);
+        var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName));
+        Assert.Equal(950, point.GetGaugeLastValueLong());
+        AssertTags(point, "credit-balance-consumer", readerName);
+
+        closed.TrySetResult(false);
+        await reconnected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        exportedItems.Clear();
+        meterProvider.ForceFlush();
+        point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName));
+        Assert.Equal(0, point.GetGaugeLastValueLong());
+
+        await reader.DisposeAsync();
+        reconnectBlocked.TrySetResult(false);
+        var afterDisposeItems = new List<Metric>();
+        using var afterDisposeMeterProvider = CreateMeterProvider(afterDisposeItems);
+        afterDisposeMeterProvider.ForceFlush();
+        Assert.Empty(GetReaderPoints(afterDisposeItems, metricName, readerName));
+    }
+
+    [Fact]
     public async Task ReceivedBytes_RecordsResponseSize()
     {
         const string readerName = "received-bytes-reader";


### PR DESCRIPTION
## Summary

- add observable `ydb.topic.reader.credit_balance_bytes` gauge backed by current ReaderSession state
- update the balance for initial credit, queued read-credit requests, and consumed response bytes
- return zero for inactive reader sessions without compensating metric deltas
- read partition-session count through the same direct internal getter model

Tracker: https://st.yandex-team.ru/YDBAPPTEAM-1952

## Tests

- `dotnet build src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/Ydb.Sdk.Topic.Tests.csproj --no-restore -p:UseSharedCompilation=false -m:1`
- `dotnet test src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/Ydb.Sdk.Topic.Tests.csproj --no-build --no-restore --filter FullyQualifiedName!~IntegrationTests -m:1` (41 passed)