### PR TITLE
feat: add Topic Reader commit offset lag metric

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -34,8 +34,8 @@
   The gauge observes the first batch in the channel, including empty batches and batches from inactive sessions.
   After `ReadAsync` returns a batch's last message, that batch remains visible until the next read removes it.
   `ReadBatchAsync` removes the batch before deserialization, so its deserialization time is not included.
-  The commit-offset lag gauge is grouped by topic and consumer, takes the maximum across matching readers and active
-  partition sessions, and reports zero when a configured topic has no active partition sessions.
+  The commit-offset lag gauge reports one maximum per Reader across all active partition sessions, without `topic`,
+  or zero when the Reader has no active partition sessions.
 - Added `StatusCode.ClientCancelled` to represent a client closing an unfinished query stream.
 - Supported `ydb.query.session.closed` reasons:
 

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -15,6 +15,7 @@
   | `ydb.topic.reader.commit.acknowledged`             | `{message}` | Messages in ranges completed by successful acknowledgements  |
   | `ydb.topic.reader.partition_session.count`         | `{session}` | Active partition sessions in the reader processing lifecycle |
   | `ydb.topic.reader.local_buffer.message_age.max`    | `s`         | Age of the oldest batch retained in the Reader's local buffer |
+  | `ydb.topic.reader.commit_offset.lag.max`           | `{message}` | Maximum requested-to-acknowledged commit offset gap           |
 
   Repeated deliveries and messages in repeated commit ranges are counted again. An acknowledgement counts messages
   in every queued range it completes; stale acknowledgements are ignored.
@@ -33,6 +34,8 @@
   The gauge observes the first batch in the channel, including empty batches and batches from inactive sessions.
   After `ReadAsync` returns a batch's last message, that batch remains visible until the next read removes it.
   `ReadBatchAsync` removes the batch before deserialization, so its deserialization time is not included.
+  The commit-offset lag gauge is grouped by topic and consumer, takes the maximum across matching readers and active
+  partition sessions, and reports zero when a configured topic has no active partition sessions.
 - Added `StatusCode.ClientCancelled` to represent a client closing an unfinished query stream.
 - Supported `ydb.query.session.closed` reasons:
 

--- a/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
@@ -12,9 +12,6 @@ internal class PartitionSession(
 {
     private readonly ConcurrentQueue<CommitSending> _waitCommitMessages = new();
 
-    private long _maxRequestedCommitOffset = commitedOffset;
-    private long _lastAcknowledgedCommittedOffset = commitedOffset;
-
     private volatile bool _isStopped;
 
     internal bool IsActive => !_isStopped;
@@ -30,21 +27,8 @@ internal class PartitionSession(
 
     internal long PrevEndOffsetMessage { get; set; } = commitedOffset;
 
-    internal long CommitOffsetLag
-    {
-        get
-        {
-            long maxRequestedCommitOffset;
-            long lastAcknowledgedCommittedOffset;
-            do
-            {
-                maxRequestedCommitOffset = Volatile.Read(ref _maxRequestedCommitOffset);
-                lastAcknowledgedCommittedOffset = Volatile.Read(ref _lastAcknowledgedCommittedOffset);
-            } while (maxRequestedCommitOffset != Volatile.Read(ref _maxRequestedCommitOffset));
-
-            return Math.Max(0, maxRequestedCommitOffset - lastAcknowledgedCommittedOffset);
-        }
-    }
+    internal long CommitOffsetLag =>
+        _waitCommitMessages.LastOrDefault()?.OffsetsRange.End - CommitedOffset ?? 0;
 
     // Each offset up to and including (committed_offset - 1) was fully processed.
     private long CommitedOffset { get; set; } = commitedOffset;
@@ -70,13 +54,8 @@ internal class PartitionSession(
         }
     }
 
-    internal void RecordCommitRequested(long requestedCommitOffset) =>
-        SetMax(ref _maxRequestedCommitOffset, requestedCommitOffset);
-
     internal long HandleCommitedOffset(long commitedOffset)
     {
-        SetMax(ref _lastAcknowledgedCommittedOffset, commitedOffset);
-
         if (CommitedOffset >= commitedOffset)
         {
             logger.LogError(
@@ -97,21 +76,6 @@ internal class PartitionSession(
         }
 
         return acknowledgedMessages;
-    }
-
-    private static void SetMax(ref long target, long value)
-    {
-        var current = Volatile.Read(ref target);
-        while (value > current)
-        {
-            var observed = Interlocked.CompareExchange(ref target, value, current);
-            if (observed == current)
-            {
-                return;
-            }
-
-            current = observed;
-        }
     }
 
     internal void Stop(long commitedOffset)

--- a/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
@@ -27,8 +27,7 @@ internal class PartitionSession(
 
     internal long PrevEndOffsetMessage { get; set; } = commitedOffset;
 
-    internal long CommitOffsetLag =>
-        _waitCommitMessages.LastOrDefault()?.OffsetsRange.End - CommitedOffset ?? 0;
+    internal long CommitOffsetLag => _waitCommitMessages.LastOrDefault()?.OffsetsRange.End - CommitedOffset ?? 0;
 
     // Each offset up to and including (committed_offset - 1) was fully processed.
     private long CommitedOffset { get; set; } = commitedOffset;

--- a/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
@@ -11,7 +11,6 @@ internal class PartitionSession(
     long commitedOffset)
 {
     private readonly ConcurrentQueue<CommitSending> _waitCommitMessages = new();
-    private readonly object _commitOffsetMetricsLock = new();
 
     private long _maxRequestedCommitOffset = commitedOffset;
     private long _lastAcknowledgedCommittedOffset = commitedOffset;
@@ -35,10 +34,15 @@ internal class PartitionSession(
     {
         get
         {
-            lock (_commitOffsetMetricsLock)
+            long maxRequestedCommitOffset;
+            long lastAcknowledgedCommittedOffset;
+            do
             {
-                return Math.Max(0, _maxRequestedCommitOffset - _lastAcknowledgedCommittedOffset);
-            }
+                maxRequestedCommitOffset = Volatile.Read(ref _maxRequestedCommitOffset);
+                lastAcknowledgedCommittedOffset = Volatile.Read(ref _lastAcknowledgedCommittedOffset);
+            } while (maxRequestedCommitOffset != Volatile.Read(ref _maxRequestedCommitOffset));
+
+            return Math.Max(0, maxRequestedCommitOffset - lastAcknowledgedCommittedOffset);
         }
     }
 
@@ -66,20 +70,12 @@ internal class PartitionSession(
         }
     }
 
-    internal void RecordCommitRequested(long requestedCommitOffset)
-    {
-        lock (_commitOffsetMetricsLock)
-        {
-            _maxRequestedCommitOffset = Math.Max(_maxRequestedCommitOffset, requestedCommitOffset);
-        }
-    }
+    internal void RecordCommitRequested(long requestedCommitOffset) =>
+        SetMax(ref _maxRequestedCommitOffset, requestedCommitOffset);
 
     internal long HandleCommitedOffset(long commitedOffset)
     {
-        lock (_commitOffsetMetricsLock)
-        {
-            _lastAcknowledgedCommittedOffset = Math.Max(_lastAcknowledgedCommittedOffset, commitedOffset);
-        }
+        SetMax(ref _lastAcknowledgedCommittedOffset, commitedOffset);
 
         if (CommitedOffset >= commitedOffset)
         {
@@ -101,6 +97,21 @@ internal class PartitionSession(
         }
 
         return acknowledgedMessages;
+    }
+
+    private static void SetMax(ref long target, long value)
+    {
+        var current = Volatile.Read(ref target);
+        while (value > current)
+        {
+            var observed = Interlocked.CompareExchange(ref target, value, current);
+            if (observed == current)
+            {
+                return;
+            }
+
+            current = observed;
+        }
     }
 
     internal void Stop(long commitedOffset)

--- a/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
@@ -11,6 +11,10 @@ internal class PartitionSession(
     long commitedOffset)
 {
     private readonly ConcurrentQueue<CommitSending> _waitCommitMessages = new();
+    private readonly object _commitOffsetMetricsLock = new();
+
+    private long _maxRequestedCommitOffset = commitedOffset;
+    private long _lastAcknowledgedCommittedOffset = commitedOffset;
 
     private volatile bool _isStopped;
 
@@ -26,6 +30,17 @@ internal class PartitionSession(
     internal long PartitionId => partitionId;
 
     internal long PrevEndOffsetMessage { get; set; } = commitedOffset;
+
+    internal long CommitOffsetLag
+    {
+        get
+        {
+            lock (_commitOffsetMetricsLock)
+            {
+                return Math.Max(0, _maxRequestedCommitOffset - _lastAcknowledgedCommittedOffset);
+            }
+        }
+    }
 
     // Each offset up to and including (committed_offset - 1) was fully processed.
     private long CommitedOffset { get; set; } = commitedOffset;
@@ -51,8 +66,21 @@ internal class PartitionSession(
         }
     }
 
+    internal void RecordCommitRequested(long requestedCommitOffset)
+    {
+        lock (_commitOffsetMetricsLock)
+        {
+            _maxRequestedCommitOffset = Math.Max(_maxRequestedCommitOffset, requestedCommitOffset);
+        }
+    }
+
     internal long HandleCommitedOffset(long commitedOffset)
     {
+        lock (_commitOffsetMetricsLock)
+        {
+            _lastAcknowledgedCommittedOffset = Math.Max(_lastAcknowledgedCommittedOffset, commitedOffset);
+        }
+
         if (CommitedOffset >= commitedOffset)
         {
             logger.LogError(

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -53,6 +53,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             _driverFactory.Database,
             _config.ConsumerName,
             _config.ReaderName,
+            _config.SubscribeSettings.Select(settings => settings.TopicPath),
             this);
 
         _ = Initialize();
@@ -64,6 +65,9 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
         _receivedMessagesChannel.Reader.TryPeek(out var batch) && batch.ReceivedTimestamp > 0
             ? Stopwatch.GetElapsedTime(batch.ReceivedTimestamp).TotalSeconds
             : 0;
+
+    IReadOnlyCollection<PartitionSession> IReaderMetricsSource.PartitionSessions =>
+        _currentReaderSession?.PartitionSessions ?? [];
 
     public async ValueTask<Message<TValue>> ReadAsync(CancellationToken cancellationToken = default)
     {
@@ -324,6 +328,9 @@ internal class ReaderSession<TValue>(
 
     internal long PartitionSessionCount => _partitionSessions.Count;
 
+    internal IReadOnlyCollection<PartitionSession> PartitionSessions =>
+        _lifecycleReaderSessionCts.IsCancellationRequested ? [] : _partitionSessions.Values.ToArray();
+
     private async Task RunProcessingStreamResponse()
     {
         try
@@ -537,6 +544,7 @@ internal class ReaderSession<TValue>(
                     }
                 ).ConfigureAwait(false);
 
+                partitionSession.RecordCommitRequested(commitSending.OffsetsRange.End);
                 metrics.ReportCommitQueued(
                     commitSending.OffsetsRange.End - commitSending.OffsetsRange.Start,
                     partitionSession.TopicPath);

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -330,11 +330,6 @@ internal class ReaderSession<TValue>(
     {
         get
         {
-            if (_lifecycleReaderSessionCts.IsCancellationRequested)
-            {
-                return 0;
-            }
-
             var max = 0L;
             foreach (var (_, partitionSession) in _partitionSessions)
             {

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -66,8 +66,8 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             ? Stopwatch.GetElapsedTime(batch.ReceivedTimestamp).TotalSeconds
             : 0;
 
-    IReadOnlyCollection<PartitionSession> IReaderMetricsSource.PartitionSessions =>
-        _currentReaderSession?.PartitionSessions ?? [];
+    IReadOnlyDictionary<long, PartitionSession>? IReaderMetricsSource.PartitionSessions =>
+        _currentReaderSession?.PartitionSessions;
 
     public async ValueTask<Message<TValue>> ReadAsync(CancellationToken cancellationToken = default)
     {
@@ -328,8 +328,8 @@ internal class ReaderSession<TValue>(
 
     internal long PartitionSessionCount => _partitionSessions.Count;
 
-    internal IReadOnlyCollection<PartitionSession> PartitionSessions =>
-        _lifecycleReaderSessionCts.IsCancellationRequested ? [] : _partitionSessions.Values.ToArray();
+    internal IReadOnlyDictionary<long, PartitionSession>? PartitionSessions =>
+        _lifecycleReaderSessionCts.IsCancellationRequested ? null : _partitionSessions;
 
     private async Task RunProcessingStreamResponse()
     {

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -558,7 +558,6 @@ internal class ReaderSession<TValue>(
                     }
                 ).ConfigureAwait(false);
 
-                partitionSession.RecordCommitRequested(commitSending.OffsetsRange.End);
                 metrics.ReportCommitQueued(
                     commitSending.OffsetsRange.End - commitSending.OffsetsRange.Start,
                     partitionSession.TopicPath);

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -53,7 +53,6 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             _driverFactory.Database,
             _config.ConsumerName,
             _config.ReaderName,
-            _config.SubscribeSettings.Select(settings => settings.TopicPath),
             this);
 
         _ = Initialize();
@@ -66,8 +65,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             ? Stopwatch.GetElapsedTime(batch.ReceivedTimestamp).TotalSeconds
             : 0;
 
-    IReadOnlyDictionary<long, PartitionSession>? IReaderMetricsSource.PartitionSessions =>
-        _currentReaderSession?.PartitionSessions;
+    long IReaderMetricsSource.CommitOffsetLagMax => _currentReaderSession?.CommitOffsetLagMax ?? 0;
 
     public async ValueTask<Message<TValue>> ReadAsync(CancellationToken cancellationToken = default)
     {
@@ -328,8 +326,24 @@ internal class ReaderSession<TValue>(
 
     internal long PartitionSessionCount => _partitionSessions.Count;
 
-    internal IReadOnlyDictionary<long, PartitionSession>? PartitionSessions =>
-        _lifecycleReaderSessionCts.IsCancellationRequested ? null : _partitionSessions;
+    internal long CommitOffsetLagMax
+    {
+        get
+        {
+            if (_lifecycleReaderSessionCts.IsCancellationRequested)
+            {
+                return 0;
+            }
+
+            var max = 0L;
+            foreach (var (_, partitionSession) in _partitionSessions)
+            {
+                max = Math.Max(max, partitionSession.CommitOffsetLag);
+            }
+
+            return max;
+        }
+    }
 
     private async Task RunProcessingStreamResponse()
     {

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -9,6 +9,8 @@ internal interface IReaderMetricsSource
     long PartitionSessionCount { get; }
 
     double LocalBufferMessageAgeMax { get; }
+
+    IReadOnlyCollection<PartitionSession> PartitionSessions { get; }
 }
 
 /// <summary>
@@ -31,6 +33,11 @@ internal sealed class ReaderMetricsReporter : IDisposable
     private readonly KeyValuePair<string, object?>[] _commonTags;
     private readonly IReaderMetricsSource _readerMetricsSource;
     private long _creditBalanceBytes;
+    private readonly string _endpoint;
+    private readonly string _database;
+    private readonly string? _consumer;
+    private readonly string? _readerName;
+    private readonly string[] _topics;
 
     static ReaderMetricsReporter()
     {
@@ -53,6 +60,12 @@ internal sealed class ReaderMetricsReporter : IDisposable
             ObserveLocalBufferMessageAgeMax,
             unit: "s",
             description: "The age of the oldest batch retained in the reader's local buffer.");
+
+        meter.CreateObservableGauge(
+            "ydb.topic.reader.commit_offset.lag.max",
+            ObserveCommitOffsetLag,
+            unit: "{message}",
+            description: "The maximum gap between requested and acknowledged commit offsets.");
 
         ReceivedMessages = meter.CreateCounter<long>(
             "ydb.topic.reader.received.messages",
@@ -95,9 +108,15 @@ internal sealed class ReaderMetricsReporter : IDisposable
         string database,
         string? consumer,
         string? readerName,
+        IEnumerable<string> topics,
         IReaderMetricsSource readerMetricsSource)
     {
         _readerMetricsSource = readerMetricsSource;
+        _endpoint = endpoint;
+        _database = database;
+        _consumer = consumer;
+        _readerName = readerName;
+        _topics = topics.Distinct().ToArray();
         var commonTags = new TagList
         {
             { "endpoint", endpoint },
@@ -240,6 +259,56 @@ internal sealed class ReaderMetricsReporter : IDisposable
                     new Measurement<double>(reporter._readerMetricsSource.LocalBufferMessageAgeMax,
                         reporter._commonTags))
                 .ToArray();
+        }
+    }
+
+    private static IEnumerable<Measurement<long>> ObserveCommitOffsetLag()
+    {
+        lock (Reporters)
+        {
+            var maxByTags = new Dictionary<
+                (string Endpoint, string Database, string Consumer, string? ReaderName, string Topic),
+                long>();
+
+            foreach (var reporter in Reporters)
+            {
+                if (reporter._consumer is null)
+                {
+                    continue;
+                }
+
+                var topicLags = reporter._topics.ToDictionary(topic => topic, _ => 0L);
+                foreach (var partitionSession in reporter._readerMetricsSource.PartitionSessions)
+                {
+                    topicLags[partitionSession.TopicPath] = Math.Max(
+                        topicLags.GetValueOrDefault(partitionSession.TopicPath),
+                        partitionSession.CommitOffsetLag);
+                }
+
+                foreach (var (topic, lag) in topicLags)
+                {
+                    var key = (reporter._endpoint, reporter._database, reporter._consumer,
+                        reporter._readerName, topic);
+                    maxByTags[key] = Math.Max(maxByTags.GetValueOrDefault(key), lag);
+                }
+            }
+
+            return maxByTags.Select(pair =>
+            {
+                var tags = new TagList
+                {
+                    { "endpoint", pair.Key.Endpoint },
+                    { "database", pair.Key.Database },
+                    { "consumer", pair.Key.Consumer }
+                };
+                if (pair.Key.ReaderName is not null)
+                {
+                    tags.Add("reader.name", pair.Key.ReaderName);
+                }
+
+                tags.Add("topic", pair.Key.Topic);
+                return new Measurement<long>(pair.Value, tags.ToArray());
+            }).ToArray();
         }
     }
 }

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -10,7 +10,7 @@ internal interface IReaderMetricsSource
 
     double LocalBufferMessageAgeMax { get; }
 
-    IReadOnlyDictionary<long, PartitionSession>? PartitionSessions { get; }
+    long CommitOffsetLagMax { get; }
 }
 
 /// <summary>
@@ -33,11 +33,6 @@ internal sealed class ReaderMetricsReporter : IDisposable
     private readonly KeyValuePair<string, object?>[] _commonTags;
     private readonly IReaderMetricsSource _readerMetricsSource;
     private long _creditBalanceBytes;
-    private readonly string _endpoint;
-    private readonly string _database;
-    private readonly string? _consumer;
-    private readonly string? _readerName;
-    private readonly string[] _topics;
 
     static ReaderMetricsReporter()
     {
@@ -108,15 +103,9 @@ internal sealed class ReaderMetricsReporter : IDisposable
         string database,
         string? consumer,
         string? readerName,
-        IEnumerable<string> topics,
         IReaderMetricsSource readerMetricsSource)
     {
         _readerMetricsSource = readerMetricsSource;
-        _endpoint = endpoint;
-        _database = database;
-        _consumer = consumer;
-        _readerName = readerName;
-        _topics = topics.Distinct().ToArray();
         var commonTags = new TagList
         {
             { "endpoint", endpoint },
@@ -266,52 +255,10 @@ internal sealed class ReaderMetricsReporter : IDisposable
     {
         lock (Reporters)
         {
-            var maxByTags = new Dictionary<
-                (string Endpoint, string Database, string Consumer, string? ReaderName, string Topic),
-                long>();
-
-            foreach (var reporter in Reporters)
-            {
-                if (reporter._consumer is null)
-                {
-                    continue;
-                }
-
-                var topicLags = reporter._topics.ToDictionary(topic => topic, _ => 0L);
-                if (reporter._readerMetricsSource.PartitionSessions is { } partitionSessions)
-                {
-                    foreach (var (_, partitionSession) in partitionSessions)
-                    {
-                        topicLags[partitionSession.TopicPath] = Math.Max(
-                            topicLags.GetValueOrDefault(partitionSession.TopicPath),
-                            partitionSession.CommitOffsetLag);
-                    }
-                }
-
-                foreach (var (topic, lag) in topicLags)
-                {
-                    var key = (reporter._endpoint, reporter._database, reporter._consumer,
-                        reporter._readerName, topic);
-                    maxByTags[key] = Math.Max(maxByTags.GetValueOrDefault(key), lag);
-                }
-            }
-
-            return maxByTags.Select(pair =>
-            {
-                var tags = new TagList
-                {
-                    { "endpoint", pair.Key.Endpoint },
-                    { "database", pair.Key.Database },
-                    { "consumer", pair.Key.Consumer }
-                };
-                if (pair.Key.ReaderName is not null)
-                {
-                    tags.Add("reader.name", pair.Key.ReaderName);
-                }
-
-                tags.Add("topic", pair.Key.Topic);
-                return new Measurement<long>(pair.Value, tags.ToArray());
-            }).ToArray();
+            return Reporters.Select(reporter =>
+                    new Measurement<long>(reporter._readerMetricsSource.CommitOffsetLagMax,
+                        reporter._commonTags))
+                .ToArray();
         }
     }
 }

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -10,7 +10,7 @@ internal interface IReaderMetricsSource
 
     double LocalBufferMessageAgeMax { get; }
 
-    IReadOnlyCollection<PartitionSession> PartitionSessions { get; }
+    IReadOnlyDictionary<long, PartitionSession>? PartitionSessions { get; }
 }
 
 /// <summary>
@@ -278,11 +278,14 @@ internal sealed class ReaderMetricsReporter : IDisposable
                 }
 
                 var topicLags = reporter._topics.ToDictionary(topic => topic, _ => 0L);
-                foreach (var partitionSession in reporter._readerMetricsSource.PartitionSessions)
+                if (reporter._readerMetricsSource.PartitionSessions is { } partitionSessions)
                 {
-                    topicLags[partitionSession.TopicPath] = Math.Max(
-                        topicLags.GetValueOrDefault(partitionSession.TopicPath),
-                        partitionSession.CommitOffsetLag);
+                    foreach (var (_, partitionSession) in partitionSessions)
+                    {
+                        topicLags[partitionSession.TopicPath] = Math.Max(
+                            topicLags.GetValueOrDefault(partitionSession.TopicPath),
+                            partitionSession.CommitOffsetLag);
+                    }
                 }
 
                 foreach (var (topic, lag) in topicLags)

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -432,92 +432,66 @@ public class ReaderMetricsReporterTests
     }
 
     [Fact]
-    public async Task CommitOffsetLag_TracksMaximumAcrossReaders()
+    public async Task CommitOffsetLag_TracksMaximumAcrossPartitions()
     {
         const string readerName = "commit-offset-lag-reader";
         const string consumer = "commit-offset-lag-consumer";
         var timeout = TimeSpan.FromSeconds(5);
         var exportedItems = new List<Metric>();
         using var meterProvider = CreateMeterProvider(exportedItems);
-        var firstStream = new Mock<ReaderStream>();
-        var secondStream = new Mock<ReaderStream>();
-        var firstResponses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
-        var secondResponses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
-        var firstHandledEvents = Channel.CreateUnbounded<long>();
-        var secondHandledEvents = Channel.CreateUnbounded<long>();
-        var firstCommitWritten = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var secondCommitWritten = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        SetupResponseStream(firstStream, firstResponses, firstHandledEvents.Writer, message =>
+        var stream = new Mock<ReaderStream>();
+        var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
+        var handledEvents = Channel.CreateUnbounded<long>();
+        var commitsWritten = Channel.CreateUnbounded<long>();
+        SetupResponseStream(stream, responses, handledEvents.Writer, message =>
         {
             if (message.CommitOffsetRequest is not null)
             {
-                firstCommitWritten.TrySetResult();
+                commitsWritten.Writer.TryWrite(message.CommitOffsetRequest.CommitOffsets[0].PartitionSessionId);
             }
         });
-        SetupResponseStream(secondStream, secondResponses, secondHandledEvents.Writer, message =>
+        await using var reader = new ReaderBuilder<string>(
+            CreateDriverFactory(stream, "Reader_Commit_Offset_Lag_Metrics"))
         {
-            if (message.CommitOffsetRequest is not null)
-            {
-                secondCommitWritten.TrySetResult();
-            }
-        });
-        var firstReader = BuildReader(firstStream);
-        var secondReader = BuildReader(secondStream);
+            ConsumerName = consumer,
+            ReaderName = readerName,
+            SubscribeSettings = { new SubscribeSettings("/topic") }
+        }.Build();
 
-        try
-        {
-            await SendResponse(firstResponses, firstHandledEvents, InitResponse, 0);
-            await SendResponse(secondResponses, secondHandledEvents, InitResponse, 0);
-            await SendResponse(firstResponses, firstHandledEvents, StartPartitionSessionRequest(10), 1);
-            await SendResponse(secondResponses, secondHandledEvents, StartPartitionSessionRequest(10), 1);
-            AssertLag(0);
+        await SendResponse(InitResponse, 0);
+        await SendResponse(StartPartitionSessionRequest(10), 1);
+        await SendResponse(StartPartitionSessionRequest(10, partitionSessionId: 2), 2);
+        AssertLag(0);
 
-            await firstResponses.Writer.WriteAsync((true, ReadResponse(14, "first"u8.ToArray())));
-            await secondResponses.Writer.WriteAsync((true, ReadResponse(17, "second"u8.ToArray())));
-            var firstMessage = await firstReader.ReadAsync().AsTask().WaitAsync(timeout);
-            var secondMessage = await secondReader.ReadAsync().AsTask().WaitAsync(timeout);
-            var firstCommit = firstMessage.CommitAsync();
-            var secondCommit = secondMessage.CommitAsync();
-            await firstCommitWritten.Task.WaitAsync(timeout);
-            await secondCommitWritten.Task.WaitAsync(timeout);
-            AssertLag(8);
+        await responses.Writer.WriteAsync((true, ReadResponse(14, "first"u8.ToArray())));
+        var secondReadResponse = ReadResponse(17, "second"u8.ToArray());
+        secondReadResponse.ReadResponse.PartitionData[0].PartitionSessionId = 2;
+        await responses.Writer.WriteAsync((true, secondReadResponse));
+        var firstMessage = await reader.ReadAsync().AsTask().WaitAsync(timeout);
+        var secondMessage = await reader.ReadAsync().AsTask().WaitAsync(timeout);
+        var firstCommit = firstMessage.CommitAsync();
+        var secondCommit = secondMessage.CommitAsync();
+        Assert.Equal(1, await commitsWritten.Reader.ReadAsync().AsTask().WaitAsync(timeout));
+        Assert.Equal(2, await commitsWritten.Reader.ReadAsync().AsTask().WaitAsync(timeout));
+        AssertLag(8);
 
-            await secondResponses.Writer.WriteAsync((true, CommitOffsetResponse(18)));
-            await secondCommit.WaitAsync(timeout);
-            AssertLag(5);
+        var secondCommitResponse = CommitOffsetResponse(18);
+        secondCommitResponse.CommitOffsetResponse.PartitionsCommittedOffsets[0].PartitionSessionId = 2;
+        await responses.Writer.WriteAsync((true, secondCommitResponse));
+        await secondCommit.WaitAsync(timeout);
+        AssertLag(5);
 
-            await firstResponses.Writer.WriteAsync((true, CommitOffsetResponse(15)));
-            await firstCommit.WaitAsync(timeout);
-            AssertLag(0);
+        await responses.Writer.WriteAsync((true, CommitOffsetResponse(15)));
+        await firstCommit.WaitAsync(timeout);
+        AssertLag(0);
 
-            await SendResponse(firstResponses, firstHandledEvents, StopPartitionSessionRequest(), -1);
-            await SendResponse(secondResponses, secondHandledEvents, StopPartitionSessionRequest(), -1);
-            AssertLag(0);
-        }
-        finally
-        {
-            await firstReader.DisposeAsync();
-            await secondReader.DisposeAsync();
-        }
+        await SendResponse(StopPartitionSessionRequest(), -1);
+        await SendResponse(StopPartitionSessionRequest(partitionSessionId: 2), -2);
+        AssertLag(0);
 
         return;
 
-        IReader<string> BuildReader(Mock<ReaderStream> stream)
-        {
-            return new ReaderBuilder<string>(
-                CreateDriverFactory(stream, "Reader_Commit_Offset_Lag_Metrics"))
-            {
-                ConsumerName = consumer,
-                ReaderName = readerName,
-                SubscribeSettings = { new SubscribeSettings("/topic") }
-            }.Build();
-        }
-
-        async Task SendResponse(
-            Channel<(bool HasNext, FromServer? Response)> responses,
-            Channel<long> handledEvents,
-            FromServer response,
-            long expectedEvent)
+        async Task SendResponse(FromServer response, long expectedEvent)
         {
             await responses.Writer.WriteAsync((true, response));
             Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
@@ -532,7 +506,7 @@ public class ReaderMetricsReporterTests
             Assert.Equal("{message}", metric.Unit);
             var point = Assert.Single(GetReaderPoints(exportedItems, CommitOffsetLagMetricName, readerName));
             Assert.Equal(expected, point.GetGaugeLastValueLong());
-            AssertTags(point, consumer, readerName, "/topic");
+            AssertTags(point, consumer, readerName);
         }
     }
 

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -21,6 +21,7 @@ public class ReaderMetricsReporterTests
 {
     private const string PartitionSessionCountMetricName = "ydb.topic.reader.partition_session.count";
     private const string PartitionSessionCountReaderName = "partition-count-reader";
+    private const string CommitOffsetLagMetricName = "ydb.topic.reader.commit_offset.lag.max";
     private const string LifecycleReaderName = "reader-lifecycle-metrics";
 
     private static readonly string[] MetricNames =
@@ -431,6 +432,111 @@ public class ReaderMetricsReporterTests
     }
 
     [Fact]
+    public async Task CommitOffsetLag_TracksMaximumAcrossReaders()
+    {
+        const string readerName = "commit-offset-lag-reader";
+        const string consumer = "commit-offset-lag-consumer";
+        var timeout = TimeSpan.FromSeconds(5);
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+        var firstStream = new Mock<ReaderStream>();
+        var secondStream = new Mock<ReaderStream>();
+        var firstResponses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
+        var secondResponses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
+        var firstHandledEvents = Channel.CreateUnbounded<long>();
+        var secondHandledEvents = Channel.CreateUnbounded<long>();
+        var firstCommitWritten = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondCommitWritten = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        SetupResponseStream(firstStream, firstResponses, firstHandledEvents.Writer, message =>
+        {
+            if (message.CommitOffsetRequest is not null)
+            {
+                firstCommitWritten.TrySetResult();
+            }
+        });
+        SetupResponseStream(secondStream, secondResponses, secondHandledEvents.Writer, message =>
+        {
+            if (message.CommitOffsetRequest is not null)
+            {
+                secondCommitWritten.TrySetResult();
+            }
+        });
+        var firstReader = BuildReader(firstStream);
+        var secondReader = BuildReader(secondStream);
+
+        try
+        {
+            await SendResponse(firstResponses, firstHandledEvents, InitResponse, 0);
+            await SendResponse(secondResponses, secondHandledEvents, InitResponse, 0);
+            await SendResponse(firstResponses, firstHandledEvents, StartPartitionSessionRequest(10), 1);
+            await SendResponse(secondResponses, secondHandledEvents, StartPartitionSessionRequest(10), 1);
+            AssertLag(0);
+
+            await firstResponses.Writer.WriteAsync((true, ReadResponse(14, "first"u8.ToArray())));
+            await secondResponses.Writer.WriteAsync((true, ReadResponse(17, "second"u8.ToArray())));
+            var firstMessage = await firstReader.ReadAsync().AsTask().WaitAsync(timeout);
+            var secondMessage = await secondReader.ReadAsync().AsTask().WaitAsync(timeout);
+            var firstCommit = firstMessage.CommitAsync();
+            var secondCommit = secondMessage.CommitAsync();
+            await firstCommitWritten.Task.WaitAsync(timeout);
+            await secondCommitWritten.Task.WaitAsync(timeout);
+            AssertLag(8);
+
+            await secondResponses.Writer.WriteAsync((true, CommitOffsetResponse(18)));
+            await secondCommit.WaitAsync(timeout);
+            AssertLag(5);
+
+            await firstResponses.Writer.WriteAsync((true, CommitOffsetResponse(15)));
+            await firstCommit.WaitAsync(timeout);
+            AssertLag(0);
+
+            await SendResponse(firstResponses, firstHandledEvents, StopPartitionSessionRequest(), -1);
+            await SendResponse(secondResponses, secondHandledEvents, StopPartitionSessionRequest(), -1);
+            AssertLag(0);
+        }
+        finally
+        {
+            await firstReader.DisposeAsync();
+            await secondReader.DisposeAsync();
+        }
+
+        return;
+
+        IReader<string> BuildReader(Mock<ReaderStream> stream)
+        {
+            return new ReaderBuilder<string>(
+                CreateDriverFactory(stream, "Reader_Commit_Offset_Lag_Metrics"))
+            {
+                ConsumerName = consumer,
+                ReaderName = readerName,
+                SubscribeSettings = { new SubscribeSettings("/topic") }
+            }.Build();
+        }
+
+        async Task SendResponse(
+            Channel<(bool HasNext, FromServer? Response)> responses,
+            Channel<long> handledEvents,
+            FromServer response,
+            long expectedEvent)
+        {
+            await responses.Writer.WriteAsync((true, response));
+            Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
+        }
+
+        void AssertLag(long expected)
+        {
+            exportedItems.Clear();
+            meterProvider.ForceFlush();
+            var metric = GetMetric(exportedItems, CommitOffsetLagMetricName);
+            Assert.Equal(MetricType.LongGauge, metric.MetricType);
+            Assert.Equal("{message}", metric.Unit);
+            var point = Assert.Single(GetReaderPoints(exportedItems, CommitOffsetLagMetricName, readerName));
+            Assert.Equal(expected, point.GetGaugeLastValueLong());
+            AssertTags(point, consumer, readerName, "/topic");
+        }
+    }
+
+    [Fact]
     public async Task ReaderLifecycle_RecordsCounters()
     {
         var exportedItems = new List<Metric>();
@@ -527,7 +633,8 @@ public class ReaderMetricsReporterTests
     private static void SetupResponseStream(
         Mock<ReaderStream> stream,
         Channel<(bool HasNext, FromServer? Response)> responses,
-        ChannelWriter<long> handledEvents)
+        ChannelWriter<long> handledEvents,
+        Action<FromClient>? onWrite = null)
     {
         FromServer?[] currentResponse = [null];
         stream.Setup(mock => mock.MoveNextAsync()).Returns(async () =>
@@ -545,6 +652,7 @@ public class ReaderMetricsReporterTests
         stream.Setup(mock => mock.Write(It.IsAny<FromClient>()))
             .Callback<FromClient>(message =>
             {
+                onWrite?.Invoke(message);
                 if (message.ReadRequest != null)
                 {
                     handledEvents.TryWrite(0);


### PR DESCRIPTION
## Summary
- add ydb.topic.reader.commit_offset.lag.max as an ObservableGauge<long> with {message} unit
- track monotonic requested and acknowledged commit frontiers per live partition session
- emit one max observation per identical endpoint/database/consumer/reader.name/topic tag set
- report zero for configured topics without live partition sessions and skip consumerless readers
- document the metric in the changelog

## Tests
- dotnet test src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/Ydb.Sdk.Topic.Tests.csproj --no-restore --filter FullyQualifiedName!~Integration
- dotnet build src/YdbSdk.sln --no-restore
- bash .github/scripts/format-all-dotnet-code.sh ./src/ YdbSdk.sln

## Tracking
- https://st.yandex-team.ru/YDBAPPTEAM-1955