### PR TITLE
feat: add Topic Reader buffered message age metric

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -30,7 +30,9 @@
   already-buffered messages.
   The message-age gauge reports one maximum per Reader across all topics and partitions, without `topic`, or zero
   for an empty buffer. Receive timestamps are only captured while the gauge is enabled; earlier messages have no age.
+  The gauge observes the first batch in the channel, including empty batches and batches from inactive sessions.
   After `ReadAsync` returns a batch's last message, that batch remains visible until the next read removes it.
+  `ReadBatchAsync` removes the batch before deserialization, so its deserialization time is not included.
 - Added `StatusCode.ClientCancelled` to represent a client closing an unfinished query stream.
 - Supported `ydb.query.session.closed` reasons:
 

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,7 +1,7 @@
 - Dev: bumped the metrics observability-chain minor version in `x-ydb-sdk-build-info` from
   `ydb-sdk-metrics/0.1.0` to `ydb-sdk-metrics/0.2.0`.
-- Feat Topic Reader metrics: added six counters, a local-buffer UpDownCounter, and partition-session and credit-balance
-  gauges on the `Ydb.Sdk.Topic` meter.
+- Feat Topic Reader metrics: added six counters, a local-buffer UpDownCounter, and three gauges on
+  the `Ydb.Sdk.Topic` meter.
 
   | Metric                                             | Unit        | Description                                                  |
   |----------------------------------------------------|-------------|--------------------------------------------------------------|
@@ -14,11 +14,12 @@
   | `ydb.topic.reader.commit.queued`                   | `{message}` | Messages in commit ranges accepted by the SDK                |
   | `ydb.topic.reader.commit.acknowledged`             | `{message}` | Messages in ranges completed by successful acknowledgements  |
   | `ydb.topic.reader.partition_session.count`         | `{session}` | Active partition sessions in the reader processing lifecycle |
+  | `ydb.topic.reader.local_buffer.message_age.max`    | `s`         | Maximum age of an undelivered SDK-owned message               |
 
   Repeated deliveries and messages in repeated commit ranges are counted again. An acknowledgement counts messages
   in every queued range it completes; stale acknowledgements are ignored.
   All Topic Reader metrics have the `endpoint` and `database` attributes, plus `consumer` and `reader.name` when they
-  are configured; message and commit counters also have `topic`. The received-bytes counter covers the whole stream
+  are configured; message and commit counters and the message-age gauge also have `topic`. The received-bytes counter covers the whole stream
   without `topic`, including data for unknown partitions. The credit-balance gauge has the same stream scope, is updated
   for queued read-credit requests and read responses, returns zero when its reader session is inactive, and permits
   negative values for oversized responses. The partition-session gauge is an SDK-local snapshot, not server ownership or

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -19,7 +19,7 @@
   Repeated deliveries and messages in repeated commit ranges are counted again. An acknowledgement counts messages
   in every queued range it completes; stale acknowledgements are ignored.
   All Topic Reader metrics have the `endpoint` and `database` attributes, plus `consumer` and `reader.name` when they
-  are configured; message and commit counters and the message-age gauge also have `topic`. The received-bytes counter covers the whole stream
+  are configured; message and commit counters also have `topic`. The received-bytes counter covers the whole stream
   without `topic`, including data for unknown partitions. The credit-balance gauge has the same stream scope, is updated
   for queued read-credit requests and read responses, returns zero when its reader session is inactive, and permits
   negative values for oversized responses. The partition-session gauge is an SDK-local snapshot, not server ownership or
@@ -28,6 +28,8 @@
   The local-buffer UpDownCounter increments when messages enter the local buffer and decrements when they are delivered.
   Because it is synchronous, a listener attached after a Reader is created is not backfilled with the Reader's
   already-buffered messages.
+  The message-age gauge reports one maximum per Reader across all topics and partitions, without `topic`, or zero
+  for an empty buffer. Receive timestamps are only captured while the gauge is enabled; earlier messages have no age.
 - Added `StatusCode.ClientCancelled` to represent a client closing an unfinished query stream.
 - Supported `ydb.query.session.closed` reasons:
 

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -14,7 +14,7 @@
   | `ydb.topic.reader.commit.queued`                   | `{message}` | Messages in commit ranges accepted by the SDK                |
   | `ydb.topic.reader.commit.acknowledged`             | `{message}` | Messages in ranges completed by successful acknowledgements  |
   | `ydb.topic.reader.partition_session.count`         | `{session}` | Active partition sessions in the reader processing lifecycle |
-  | `ydb.topic.reader.local_buffer.message_age.max`    | `s`         | Maximum age of an undelivered SDK-owned message               |
+  | `ydb.topic.reader.local_buffer.message_age.max`    | `s`         | Age of the oldest batch retained in the Reader's local buffer |
 
   Repeated deliveries and messages in repeated commit ranges are counted again. An acknowledgement counts messages
   in every queued range it completes; stale acknowledgements are ignored.
@@ -30,6 +30,7 @@
   already-buffered messages.
   The message-age gauge reports one maximum per Reader across all topics and partitions, without `topic`, or zero
   for an empty buffer. Receive timestamps are only captured while the gauge is enabled; earlier messages have no age.
+  After `ReadAsync` returns a batch's last message, that batch remains visible until the next read removes it.
 - Added `StatusCode.ClientCancelled` to represent a client closing an unfinished query stream.
 - Supported `ydb.query.session.closed` reasons:
 

--- a/src/Ydb.Sdk/src/Topic/Reader/InternalBatchMessages.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/InternalBatchMessages.cs
@@ -15,15 +15,11 @@ internal class InternalBatchMessages<TValue>(
 
     internal long ReceivedTimestamp { get; } = receivedTimestamp;
 
-    internal string Topic => partitionsSession.TopicPath;
-
-    internal bool HasMessages => Volatile.Read(ref _startMessageDataIndex) < OriginalMessageCount;
-
     private int OriginalMessageCount => batch.MessageData.Count;
 
-    private bool IsActive => partitionsSession.IsActive &&
-                             readerSession.IsActive &&
-                             _startMessageDataIndex < OriginalMessageCount;
+    internal bool IsActive => partitionsSession.IsActive &&
+                              readerSession.IsActive &&
+                              _startMessageDataIndex < OriginalMessageCount;
 
     internal bool TryDequeueMessage([MaybeNullWhen(false)] out Message<TValue> message)
     {

--- a/src/Ydb.Sdk/src/Topic/Reader/InternalBatchMessages.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/InternalBatchMessages.cs
@@ -17,9 +17,9 @@ internal class InternalBatchMessages<TValue>(
 
     private int OriginalMessageCount => batch.MessageData.Count;
 
-    internal bool IsActive => partitionsSession.IsActive &&
-                              readerSession.IsActive &&
-                              _startMessageDataIndex < OriginalMessageCount;
+    private bool IsActive => partitionsSession.IsActive &&
+                             readerSession.IsActive &&
+                             _startMessageDataIndex < OriginalMessageCount;
 
     internal bool TryDequeueMessage([MaybeNullWhen(false)] out Message<TValue> message)
     {

--- a/src/Ydb.Sdk/src/Topic/Reader/InternalBatchMessages.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/InternalBatchMessages.cs
@@ -8,9 +8,16 @@ internal class InternalBatchMessages<TValue>(
     PartitionSession partitionsSession,
     ReaderSession<TValue> readerSession,
     long approximatelyBatchSize,
-    IDeserializer<TValue> deserializer)
+    IDeserializer<TValue> deserializer,
+    long receivedTimestamp)
 {
     private int _startMessageDataIndex;
+
+    internal long ReceivedTimestamp { get; } = receivedTimestamp;
+
+    internal string Topic => partitionsSession.TopicPath;
+
+    internal bool HasMessages => Volatile.Read(ref _startMessageDataIndex) < OriginalMessageCount;
 
     private int OriginalMessageCount => batch.MessageData.Count;
 

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
@@ -31,14 +30,13 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
 
     private IDriver? _driver;
     private ReaderSession<TValue>? _currentReaderSession;
-    private volatile InternalBatchMessages<TValue>? _readingBatch;
-    private readonly ConcurrentQueue<InternalBatchMessages<TValue>> _receivedMessages = new();
 
-    private readonly Channel<byte> _receivedMessagesChannel =
-        Channel.CreateUnbounded<byte>(
+    private readonly Channel<InternalBatchMessages<TValue>> _receivedMessagesChannel =
+        Channel.CreateUnbounded<InternalBatchMessages<TValue>>(
             new UnboundedChannelOptions
             {
-                SingleReader = true,
+                // The gauge peeks concurrently with application reads.
+                SingleReader = false,
                 SingleWriter = true,
                 AllowSynchronousContinuations = false
             }
@@ -57,59 +55,24 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             _driverFactory.Database,
             _config.ConsumerName,
             _config.ReaderName,
-            this,
-            GetMessageAges);
+            this);
 
         _ = Initialize();
     }
 
     long IReaderMetricsSource.PartitionSessionCount => _currentReaderSession?.PartitionSessionCount ?? 0;
 
-    private IEnumerable<KeyValuePair<string, double>> GetMessageAges()
-    {
-        var ages = _config.SubscribeSettings.Select(settings => settings.TopicPath).Distinct()
-            .ToDictionary(topic => topic, _ => 0d);
-        foreach (var batch in _receivedMessages)
-        {
-            if (batch.HasMessages || batch == _readingBatch)
-            {
-                ages[batch.Topic] = Math.Max(ages.GetValueOrDefault(batch.Topic),
-                    Stopwatch.GetElapsedTime(batch.ReceivedTimestamp).TotalSeconds);
-            }
-        }
-
-        return ages;
-    }
-
-    private void EnqueueBatch(InternalBatchMessages<TValue> batch)
-    {
-        lock (_receivedMessages)
-        {
-            if (!_receivedMessagesChannel.Writer.TryWrite(0))
-            {
-                throw new ChannelClosedException();
-            }
-
-            _receivedMessages.Enqueue(batch);
-        }
-    }
-
-    private bool TryPeekBatch([MaybeNullWhen(false)] out InternalBatchMessages<TValue> batch)
-    {
-        // The signal can arrive before Enqueue finishes publishing the batch.
-        lock (_receivedMessages)
-        {
-            return _receivedMessages.TryPeek(out batch);
-        }
-    }
+    double IReaderMetricsSource.LocalBufferMessageAgeMax =>
+        _receivedMessagesChannel.Reader.TryPeek(out var batch) && batch.ReceivedTimestamp > 0
+            ? Stopwatch.GetElapsedTime(batch.ReceivedTimestamp).TotalSeconds
+            : 0;
 
     public async ValueTask<Message<TValue>> ReadAsync(CancellationToken cancellationToken = default)
     {
         while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (TryPeekBatch(out var batchInternalMessage))
+            if (_receivedMessagesChannel.Reader.TryPeek(out var batchInternalMessage))
             {
-                _readingBatch = batchInternalMessage.HasMessages ? batchInternalMessage : null;
                 try
                 {
                     if (batchInternalMessage.TryDequeueMessage(out var message))
@@ -121,12 +84,10 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 }
                 finally
                 {
-                    _readingBatch = null;
-                }
-
-                if (!_receivedMessages.TryDequeue(out _) || !_receivedMessagesChannel.Reader.TryRead(out _))
-                {
-                    throw new ReaderException("Detect race condition on ReadAsync operation");
+                    if (!batchInternalMessage.IsActive)
+                    {
+                        _receivedMessagesChannel.Reader.TryRead(out _);
+                    }
                 }
             }
             else
@@ -142,12 +103,11 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
     {
         while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (!TryPeekBatch(out var batchInternalMessage))
+            if (!_receivedMessagesChannel.Reader.TryPeek(out var batchInternalMessage))
             {
                 throw new ReaderException("Detect race condition on ReadBatchAsync operation");
             }
 
-            _readingBatch = batchInternalMessage.HasMessages ? batchInternalMessage : null;
             try
             {
                 if (batchInternalMessage.TryPublicBatch(out var batch))
@@ -159,9 +119,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             }
             finally
             {
-                _receivedMessages.TryDequeue(out _);
                 _receivedMessagesChannel.Reader.TryRead(out _);
-                _readingBatch = null;
             }
         }
 
@@ -284,7 +242,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 Reconnect,
                 await stream.AuthToken().ConfigureAwait(false),
                 _logger,
-                EnqueueBatch,
+                _receivedMessagesChannel.Writer,
                 _deserializer,
                 _metrics
             );
@@ -348,7 +306,7 @@ internal class ReaderSession<TValue>(
     Action<StatusCode> reconnect,
     string? lastToken,
     ILogger logger,
-    Action<InternalBatchMessages<TValue>> enqueueBatch,
+    ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
     IDeserializer<TValue> deserializer,
     ReaderMetricsReporter metrics
 ) : TopicSession<MessageFromClient, MessageFromServer>(stream, logger, sessionId, reconnect, lastToken)
@@ -401,7 +359,7 @@ internal class ReaderSession<TValue>(
                 switch (messageFromServer.ServerMessageCase)
                 {
                     case ServerMessageOneofCase.ReadResponse:
-                        HandleReadResponse(messageFromServer.ReadResponse);
+                        await HandleReadResponse(messageFromServer.ReadResponse).ConfigureAwait(false);
                         break;
                     case ServerMessageOneofCase.StartPartitionSessionRequest:
                         await HandleStartPartitionSessionRequest(messageFromServer.StartPartitionSessionRequest)
@@ -614,9 +572,9 @@ internal class ReaderSession<TValue>(
         await tcsCommit.Task.ConfigureAwait(false);
     }
 
-    private void HandleReadResponse(StreamReadMessage.Types.ReadResponse readResponse)
+    private async Task HandleReadResponse(StreamReadMessage.Types.ReadResponse readResponse)
     {
-        var receivedTimestamp = Stopwatch.GetTimestamp();
+        var receivedTimestamp = ReaderMetricsReporter.ReportReadResponseStart();
         var bytesSize = readResponse.BytesSize;
         metrics.ReportCreditBalanceBytes(-bytesSize);
         metrics.ReportReceivedBytes(bytesSize);
@@ -640,8 +598,13 @@ internal class ReaderSession<TValue>(
                 for (var batchIndex = 0; batchIndex < batchCount; batchIndex++)
                 {
                     var batch = batches[batchIndex];
+                    if (batch.MessageData.Count == 0)
+                    {
+                        continue;
+                    }
+
                     metrics.ReportLocalBuffer(batch.MessageData.Count, partitionSession.TopicPath);
-                    enqueueBatch(new InternalBatchMessages<TValue>(
+                    await channelWriter.WriteAsync(new InternalBatchMessages<TValue>(
                         batch,
                         partitionSession,
                         this,
@@ -652,7 +615,7 @@ internal class ReaderSession<TValue>(
                         ),
                         deserializer,
                         receivedTimestamp
-                    ));
+                    )).ConfigureAwait(false);
 
                     metrics.ReportReceived(batch.MessageData.Count, partitionSession.TopicPath);
                 }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -98,23 +98,16 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
     {
         while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (!_receivedMessagesChannel.Reader.TryPeek(out var batchInternalMessage))
+            if (!_receivedMessagesChannel.Reader.TryRead(out var batchInternalMessage))
             {
                 throw new ReaderException("Detect race condition on ReadBatchAsync operation");
             }
 
-            try
+            if (batchInternalMessage.TryPublicBatch(out var batch))
             {
-                if (batchInternalMessage.TryPublicBatch(out var batch))
-                {
-                    _metrics.ReportLocalBuffer(-batch.Batch.Count, batch.Batch[0].Topic);
-                    _metrics.ReportDelivered(batch.Batch.Count, batch.Batch[0].Topic);
-                    return batch;
-                }
-            }
-            finally
-            {
-                _receivedMessagesChannel.Reader.TryRead(out _);
+                _metrics.ReportLocalBuffer(-batch.Batch.Count, batch.Batch[0].Topic);
+                _metrics.ReportDelivered(batch.Batch.Count, batch.Batch[0].Topic);
+                return batch;
             }
         }
 
@@ -593,24 +586,21 @@ internal class ReaderSession<TValue>(
                 for (var batchIndex = 0; batchIndex < batchCount; batchIndex++)
                 {
                     var batch = batches[batchIndex];
-                    if (batch.MessageData.Count == 0)
-                    {
-                        continue;
-                    }
-
                     metrics.ReportLocalBuffer(batch.MessageData.Count, partitionSession.TopicPath);
-                    await channelWriter.WriteAsync(new InternalBatchMessages<TValue>(
-                        batch,
-                        partitionSession,
-                        this,
-                        Utils.CalculateApproximatelyBytesSize(
-                            bytesSize: approximatelyPartitionBytesSize,
-                            countParts: batchCount,
-                            currentIndex: batchIndex
-                        ),
-                        deserializer,
-                        receivedTimestamp
-                    )).ConfigureAwait(false);
+                    await channelWriter.WriteAsync(
+                        new InternalBatchMessages<TValue>(
+                            batch,
+                            partitionSession,
+                            this,
+                            Utils.CalculateApproximatelyBytesSize(
+                                bytesSize: approximatelyPartitionBytesSize,
+                                countParts: batchCount,
+                                currentIndex: batchIndex
+                            ),
+                            deserializer,
+                            receivedTimestamp
+                        )
+                    ).ConfigureAwait(false);
 
                     metrics.ReportReceived(batch.MessageData.Count, partitionSession.TopicPath);
                 }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -35,8 +35,6 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
         Channel.CreateUnbounded<InternalBatchMessages<TValue>>(
             new UnboundedChannelOptions
             {
-                // The gauge peeks concurrently with application reads.
-                SingleReader = false,
                 SingleWriter = true,
                 AllowSynchronousContinuations = false
             }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
@@ -29,9 +31,11 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
 
     private IDriver? _driver;
     private ReaderSession<TValue>? _currentReaderSession;
+    private volatile InternalBatchMessages<TValue>? _readingBatch;
+    private readonly ConcurrentQueue<InternalBatchMessages<TValue>> _receivedMessages = new();
 
-    private readonly Channel<InternalBatchMessages<TValue>> _receivedMessagesChannel =
-        Channel.CreateUnbounded<InternalBatchMessages<TValue>>(
+    private readonly Channel<byte> _receivedMessagesChannel =
+        Channel.CreateUnbounded<byte>(
             new UnboundedChannelOptions
             {
                 SingleReader = true,
@@ -53,27 +57,74 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             _driverFactory.Database,
             _config.ConsumerName,
             _config.ReaderName,
-            this);
+            this,
+            GetMessageAges);
 
         _ = Initialize();
     }
 
     long IReaderMetricsSource.PartitionSessionCount => _currentReaderSession?.PartitionSessionCount ?? 0;
 
+    private IEnumerable<KeyValuePair<string, double>> GetMessageAges()
+    {
+        var ages = _config.SubscribeSettings.Select(settings => settings.TopicPath).Distinct()
+            .ToDictionary(topic => topic, _ => 0d);
+        foreach (var batch in _receivedMessages)
+        {
+            if (batch.HasMessages || batch == _readingBatch)
+            {
+                ages[batch.Topic] = Math.Max(ages.GetValueOrDefault(batch.Topic),
+                    Stopwatch.GetElapsedTime(batch.ReceivedTimestamp).TotalSeconds);
+            }
+        }
+
+        return ages;
+    }
+
+    private void EnqueueBatch(InternalBatchMessages<TValue> batch)
+    {
+        lock (_receivedMessages)
+        {
+            if (!_receivedMessagesChannel.Writer.TryWrite(0))
+            {
+                throw new ChannelClosedException();
+            }
+
+            _receivedMessages.Enqueue(batch);
+        }
+    }
+
+    private bool TryPeekBatch([MaybeNullWhen(false)] out InternalBatchMessages<TValue> batch)
+    {
+        // The signal can arrive before Enqueue finishes publishing the batch.
+        lock (_receivedMessages)
+        {
+            return _receivedMessages.TryPeek(out batch);
+        }
+    }
+
     public async ValueTask<Message<TValue>> ReadAsync(CancellationToken cancellationToken = default)
     {
         while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (_receivedMessagesChannel.Reader.TryPeek(out var batchInternalMessage))
+            if (TryPeekBatch(out var batchInternalMessage))
             {
-                if (batchInternalMessage.TryDequeueMessage(out var message))
+                _readingBatch = batchInternalMessage.HasMessages ? batchInternalMessage : null;
+                try
                 {
-                    _metrics.ReportLocalBuffer(-1, message.Topic);
-                    _metrics.ReportDelivered(1, message.Topic);
-                    return message;
+                    if (batchInternalMessage.TryDequeueMessage(out var message))
+                    {
+                        _metrics.ReportLocalBuffer(-1, message.Topic);
+                        _metrics.ReportDelivered(1, message.Topic);
+                        return message;
+                    }
+                }
+                finally
+                {
+                    _readingBatch = null;
                 }
 
-                if (!_receivedMessagesChannel.Reader.TryRead(out _))
+                if (!_receivedMessages.TryDequeue(out _) || !_receivedMessagesChannel.Reader.TryRead(out _))
                 {
                     throw new ReaderException("Detect race condition on ReadAsync operation");
                 }
@@ -91,16 +142,26 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
     {
         while (await _receivedMessagesChannel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (!_receivedMessagesChannel.Reader.TryRead(out var batchInternalMessage))
+            if (!TryPeekBatch(out var batchInternalMessage))
             {
                 throw new ReaderException("Detect race condition on ReadBatchAsync operation");
             }
 
-            if (batchInternalMessage.TryPublicBatch(out var batch))
+            _readingBatch = batchInternalMessage.HasMessages ? batchInternalMessage : null;
+            try
             {
-                _metrics.ReportLocalBuffer(-batch.Batch.Count, batch.Batch[0].Topic);
-                _metrics.ReportDelivered(batch.Batch.Count, batch.Batch[0].Topic);
-                return batch;
+                if (batchInternalMessage.TryPublicBatch(out var batch))
+                {
+                    _metrics.ReportLocalBuffer(-batch.Batch.Count, batch.Batch[0].Topic);
+                    _metrics.ReportDelivered(batch.Batch.Count, batch.Batch[0].Topic);
+                    return batch;
+                }
+            }
+            finally
+            {
+                _receivedMessages.TryDequeue(out _);
+                _receivedMessagesChannel.Reader.TryRead(out _);
+                _readingBatch = null;
             }
         }
 
@@ -223,7 +284,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 Reconnect,
                 await stream.AuthToken().ConfigureAwait(false),
                 _logger,
-                _receivedMessagesChannel.Writer,
+                EnqueueBatch,
                 _deserializer,
                 _metrics
             );
@@ -287,7 +348,7 @@ internal class ReaderSession<TValue>(
     Action<StatusCode> reconnect,
     string? lastToken,
     ILogger logger,
-    ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
+    Action<InternalBatchMessages<TValue>> enqueueBatch,
     IDeserializer<TValue> deserializer,
     ReaderMetricsReporter metrics
 ) : TopicSession<MessageFromClient, MessageFromServer>(stream, logger, sessionId, reconnect, lastToken)
@@ -340,7 +401,7 @@ internal class ReaderSession<TValue>(
                 switch (messageFromServer.ServerMessageCase)
                 {
                     case ServerMessageOneofCase.ReadResponse:
-                        await HandleReadResponse(messageFromServer.ReadResponse).ConfigureAwait(false);
+                        HandleReadResponse(messageFromServer.ReadResponse);
                         break;
                     case ServerMessageOneofCase.StartPartitionSessionRequest:
                         await HandleStartPartitionSessionRequest(messageFromServer.StartPartitionSessionRequest)
@@ -553,8 +614,9 @@ internal class ReaderSession<TValue>(
         await tcsCommit.Task.ConfigureAwait(false);
     }
 
-    private async Task HandleReadResponse(StreamReadMessage.Types.ReadResponse readResponse)
+    private void HandleReadResponse(StreamReadMessage.Types.ReadResponse readResponse)
     {
+        var receivedTimestamp = Stopwatch.GetTimestamp();
         var bytesSize = readResponse.BytesSize;
         metrics.ReportCreditBalanceBytes(-bytesSize);
         metrics.ReportReceivedBytes(bytesSize);
@@ -579,19 +641,18 @@ internal class ReaderSession<TValue>(
                 {
                     var batch = batches[batchIndex];
                     metrics.ReportLocalBuffer(batch.MessageData.Count, partitionSession.TopicPath);
-                    await channelWriter.WriteAsync(
-                        new InternalBatchMessages<TValue>(
-                            batch,
-                            partitionSession,
-                            this,
-                            Utils.CalculateApproximatelyBytesSize(
-                                bytesSize: approximatelyPartitionBytesSize,
-                                countParts: batchCount,
-                                currentIndex: batchIndex
-                            ),
-                            deserializer
-                        )
-                    ).ConfigureAwait(false);
+                    enqueueBatch(new InternalBatchMessages<TValue>(
+                        batch,
+                        partitionSession,
+                        this,
+                        Utils.CalculateApproximatelyBytesSize(
+                            bytesSize: approximatelyPartitionBytesSize,
+                            countParts: batchCount,
+                            currentIndex: batchIndex
+                        ),
+                        deserializer,
+                        receivedTimestamp
+                    ));
 
                     metrics.ReportReceived(batch.MessageData.Count, partitionSession.TopicPath);
                 }

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -73,21 +73,16 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
         {
             if (_receivedMessagesChannel.Reader.TryPeek(out var batchInternalMessage))
             {
-                try
+                if (batchInternalMessage.TryDequeueMessage(out var message))
                 {
-                    if (batchInternalMessage.TryDequeueMessage(out var message))
-                    {
-                        _metrics.ReportLocalBuffer(-1, message.Topic);
-                        _metrics.ReportDelivered(1, message.Topic);
-                        return message;
-                    }
+                    _metrics.ReportLocalBuffer(-1, message.Topic);
+                    _metrics.ReportDelivered(1, message.Topic);
+                    return message;
                 }
-                finally
+
+                if (!_receivedMessagesChannel.Reader.TryRead(out _))
                 {
-                    if (!batchInternalMessage.IsActive)
-                    {
-                        _receivedMessagesChannel.Reader.TryRead(out _);
-                    }
+                    throw new ReaderException("Detect race condition on ReadAsync operation");
                 }
             }
             else

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -7,6 +7,8 @@ namespace Ydb.Sdk.Topic.Reader;
 internal interface IReaderMetricsSource
 {
     long PartitionSessionCount { get; }
+
+    double LocalBufferMessageAgeMax { get; }
 }
 
 /// <summary>
@@ -21,6 +23,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
     private static readonly Counter<long> SessionErrors;
     private static readonly Counter<long> DeliveredMessages;
     private static readonly UpDownCounter<long> LocalBufferMessages;
+    private static readonly ObservableGauge<double> LocalBufferMessageAgeMax;
     private static readonly Counter<long> CommitQueued;
     private static readonly Counter<long> CommitAcknowledged;
     private static readonly ObservableGauge<long> CreditBalanceBytes;
@@ -28,7 +31,6 @@ internal sealed class ReaderMetricsReporter : IDisposable
     private readonly KeyValuePair<string, object?>[] _commonTags;
     private readonly IReaderMetricsSource _readerMetricsSource;
     private long _creditBalanceBytes;
-    private readonly Func<IEnumerable<KeyValuePair<string, double>>> _messageAges;
 
     static ReaderMetricsReporter()
     {
@@ -46,7 +48,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
             unit: "By",
             description: "The protocol credit granted to the server and not yet consumed by read responses.");
 
-        meter.CreateObservableGauge(
+        LocalBufferMessageAgeMax = meter.CreateObservableGauge(
             "ydb.topic.reader.local_buffer.message_age.max",
             ObserveLocalBufferMessageAgeMax,
             unit: "s",
@@ -93,11 +95,9 @@ internal sealed class ReaderMetricsReporter : IDisposable
         string database,
         string? consumer,
         string? readerName,
-        IReaderMetricsSource readerMetricsSource,
-        Func<IEnumerable<KeyValuePair<string, double>>> messageAges)
+        IReaderMetricsSource readerMetricsSource)
     {
         _readerMetricsSource = readerMetricsSource;
-        _messageAges = messageAges;
         var commonTags = new TagList
         {
             { "endpoint", endpoint },
@@ -118,6 +118,8 @@ internal sealed class ReaderMetricsReporter : IDisposable
     }
 
     internal void ReportReceived(long messages, string topic) => Record(ReceivedMessages, messages, topic);
+
+    internal static long ReportReadResponseStart() => LocalBufferMessageAgeMax.Enabled ? Stopwatch.GetTimestamp() : 0;
 
     internal void ReportReceivedBytes(long bytes) => ReceivedBytes.Add(bytes, _commonTags);
 
@@ -234,8 +236,8 @@ internal sealed class ReaderMetricsReporter : IDisposable
     {
         lock (Reporters)
         {
-            return Reporters.SelectMany(reporter => reporter._messageAges().Select(age =>
-                    new Measurement<double>(age.Value, new TagList(reporter._commonTags) { { "topic", age.Key } })))
+            return Reporters.Select(reporter =>
+                    new Measurement<double>(reporter._readerMetricsSource.LocalBufferMessageAgeMax, reporter._commonTags))
                 .ToArray();
         }
     }

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -28,6 +28,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
     private readonly KeyValuePair<string, object?>[] _commonTags;
     private readonly IReaderMetricsSource _readerMetricsSource;
     private long _creditBalanceBytes;
+    private readonly Func<IEnumerable<KeyValuePair<string, double>>> _messageAges;
 
     static ReaderMetricsReporter()
     {
@@ -44,6 +45,12 @@ internal sealed class ReaderMetricsReporter : IDisposable
             ObserveCreditBalanceBytes,
             unit: "By",
             description: "The protocol credit granted to the server and not yet consumed by read responses.");
+
+        meter.CreateObservableGauge(
+            "ydb.topic.reader.local_buffer.message_age.max",
+            ObserveLocalBufferMessageAgeMax,
+            unit: "s",
+            description: "The maximum age of messages owned by the SDK but not yet delivered.");
 
         ReceivedMessages = meter.CreateCounter<long>(
             "ydb.topic.reader.received.messages",
@@ -86,9 +93,11 @@ internal sealed class ReaderMetricsReporter : IDisposable
         string database,
         string? consumer,
         string? readerName,
-        IReaderMetricsSource readerMetricsSource)
+        IReaderMetricsSource readerMetricsSource,
+        Func<IEnumerable<KeyValuePair<string, double>>> messageAges)
     {
         _readerMetricsSource = readerMetricsSource;
+        _messageAges = messageAges;
         var commonTags = new TagList
         {
             { "endpoint", endpoint },
@@ -217,6 +226,16 @@ internal sealed class ReaderMetricsReporter : IDisposable
             return Reporters
                 .Select(reporter =>
                     new Measurement<long>(Interlocked.Read(ref reporter._creditBalanceBytes), reporter._commonTags))
+                .ToArray();
+        }
+    }
+
+    private static IEnumerable<Measurement<double>> ObserveLocalBufferMessageAgeMax()
+    {
+        lock (Reporters)
+        {
+            return Reporters.SelectMany(reporter => reporter._messageAges().Select(age =>
+                    new Measurement<double>(age.Value, new TagList(reporter._commonTags) { { "topic", age.Key } })))
                 .ToArray();
         }
     }

--- a/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/ReaderMetricsReporter.cs
@@ -52,7 +52,7 @@ internal sealed class ReaderMetricsReporter : IDisposable
             "ydb.topic.reader.local_buffer.message_age.max",
             ObserveLocalBufferMessageAgeMax,
             unit: "s",
-            description: "The maximum age of messages owned by the SDK but not yet delivered.");
+            description: "The age of the oldest batch retained in the reader's local buffer.");
 
         ReceivedMessages = meter.CreateCounter<long>(
             "ydb.topic.reader.received.messages",
@@ -237,7 +237,8 @@ internal sealed class ReaderMetricsReporter : IDisposable
         lock (Reporters)
         {
             return Reporters.Select(reporter =>
-                    new Measurement<double>(reporter._readerMetricsSource.LocalBufferMessageAgeMax, reporter._commonTags))
+                    new Measurement<double>(reporter._readerMetricsSource.LocalBufferMessageAgeMax,
+                        reporter._commonTags))
                 .ToArray();
         }
     }

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Threading.Channels;
 using Grpc.Core;
 using Moq;
@@ -288,6 +289,56 @@ public class ReaderMetricsReporterTests
             Assert.Equal(statusCode, tags["status_code"]);
             Assert.Equal(errorType, tags["error.type"]);
             Assert.DoesNotContain("topic", tags);
+        }
+    }
+
+    [Fact]
+    public async Task LocalBufferMessageAgeMax_TracksMessageUntilDelivery()
+    {
+        const string readerName = "message-age-reader";
+        const string metricName = "ydb.topic.reader.local_buffer.message_age.max";
+        var timeout = TimeSpan.FromSeconds(5);
+        var exportedItems = new List<Metric>();
+        using var meterProvider = CreateMeterProvider(exportedItems);
+        var mockStream = new Mock<ReaderStream>();
+        var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
+        var handledEvents = Channel.CreateUnbounded<long>();
+        SetupResponseStream(mockStream, responses, handledEvents.Writer);
+        var deserializer = new Mock<IDeserializer<string>>();
+        deserializer.Setup(instance => instance.Deserialize(It.IsAny<byte[]>())).Returns((byte[] data) =>
+        {
+            Assert.True(ObserveAge() > 0);
+            return Encoding.UTF8.GetString(data);
+        });
+        await using var reader = new ReaderBuilder<string>(CreateDriverFactory(mockStream, readerName))
+        {
+            ConsumerName = "message-age-consumer",
+            ReaderName = readerName,
+            Deserializer = deserializer.Object,
+            SubscribeSettings = { new SubscribeSettings("/topic") }
+        }.Build();
+
+        Assert.Equal(0, ObserveAge());
+        Assert.Equal(MetricType.DoubleGauge, GetMetric(exportedItems, metricName).MetricType);
+        Assert.Equal("s", GetMetric(exportedItems, metricName).Unit);
+        await responses.Writer.WriteAsync((true, InitResponse));
+        await responses.Writer.WriteAsync((true, StartPartitionSessionRequest()));
+        await responses.Writer.WriteAsync((true, ReadResponse("first"u8.ToArray(), "second"u8.ToArray())));
+
+        Assert.Equal("first", (await reader.ReadAsync().AsTask().WaitAsync(timeout)).Data);
+        Assert.True(ObserveAge() > 0);
+        var batch = await reader.ReadBatchAsync().AsTask().WaitAsync(timeout);
+        Assert.Equal("second", Assert.Single(batch.Batch).Data);
+        Assert.Equal(0, ObserveAge());
+        return;
+
+        double ObserveAge()
+        {
+            exportedItems.Clear();
+            meterProvider.ForceFlush();
+            var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName));
+            AssertTags(point, "message-age-consumer", readerName, "/topic");
+            return point.GetGaugeLastValueDouble();
         }
     }
 

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -314,6 +314,7 @@ public class ReaderMetricsReporterTests
         var timeout = TimeSpan.FromSeconds(5);
         var exportedItems = new List<Metric>();
         using var meterProvider = CreateMeterProvider(exportedItems);
+        var forceFlush = meterProvider.ForceFlush;
         var mockStream = new Mock<ReaderStream>();
         var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
         var handledEvents = Channel.CreateUnbounded<long>();
@@ -377,7 +378,7 @@ public class ReaderMetricsReporterTests
         double ObserveAge()
         {
             exportedItems.Clear();
-            meterProvider.ForceFlush();
+            forceFlush();
             var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName));
             AssertTags(point, "message-age-consumer", readerName);
             return point.GetGaugeLastValueDouble();

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -292,32 +292,18 @@ public class ReaderMetricsReporterTests
         }
     }
 
-    [Fact]
-    public void ReadResponseStart_CapturesTimestampOnlyWhenAgeGaugeIsEnabled()
-    {
-        Assert.Equal(0, ReaderMetricsReporter.ReportReadResponseStart());
-        using (CreateMeterProvider([]))
-        {
-            Assert.True(ReaderMetricsReporter.ReportReadResponseStart() > 0);
-        }
-
-        Assert.Equal(0, ReaderMetricsReporter.ReportReadResponseStart());
-    }
-
     [Theory]
-    [InlineData(false, false)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(true, true)]
-    public async Task LocalBufferMessageAgeMax_TracksFifoAcrossTopicsUntilBatchRemoval(
-        bool readLastAsBatch,
-        bool appendEmptyBatch)
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task LocalBufferMessageAgeMax_TracksFifoAcrossTopicsUntilBatchRemoval(bool readLastAsBatch)
     {
         const string readerName = "message-age-reader";
         const string metricName = "ydb.topic.reader.local_buffer.message_age.max";
         var timeout = TimeSpan.FromSeconds(5);
         var exportedItems = new List<Metric>();
+        Assert.Equal(0, ReaderMetricsReporter.ReportReadResponseStart());
         using var meterProvider = CreateMeterProvider(exportedItems);
+        Assert.True(ReaderMetricsReporter.ReportReadResponseStart() > 0);
         var forceFlush = meterProvider.ForceFlush;
         var mockStream = new Mock<ReaderStream>();
         var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
@@ -326,17 +312,8 @@ public class ReaderMetricsReporterTests
         var deserializer = new Mock<IDeserializer<string>>();
         deserializer.Setup(instance => instance.Deserialize(It.IsAny<byte[]>())).Returns((byte[] data) =>
         {
-            var value = Encoding.UTF8.GetString(data);
-            if (value == "third" && readLastAsBatch && !appendEmptyBatch)
-            {
-                Assert.Equal(0, ObserveAge());
-            }
-            else
-            {
-                Assert.True(ObserveAge() > 0);
-            }
-
-            return value;
+            Assert.True(ObserveAge() > 0);
+            return Encoding.UTF8.GetString(data);
         });
         await using var reader = new ReaderBuilder<string>(CreateDriverFactory(mockStream, readerName))
         {
@@ -358,11 +335,7 @@ public class ReaderMetricsReporterTests
         var anotherTopicResponse = ReadResponse("third"u8.ToArray());
         anotherTopicResponse.ReadResponse.PartitionData[0].PartitionSessionId = 2;
         await responses.Writer.WriteAsync((true, anotherTopicResponse));
-        if (appendEmptyBatch)
-        {
-            await responses.Writer.WriteAsync((true, ReadResponse()));
-        }
-
+        await responses.Writer.WriteAsync((true, ReadResponse()));
         await responses.Writer.WriteAsync((true, StartPartitionSessionRequest(partitionSessionId: 3)));
         for (var expectedEvent = 0; expectedEvent <= 3; expectedEvent++)
         {
@@ -379,15 +352,12 @@ public class ReaderMetricsReporterTests
             : await reader.ReadAsync().AsTask().WaitAsync(timeout);
         Assert.Equal("third", last.Data);
         Assert.Equal("/another-topic", last.Topic);
-        if (!readLastAsBatch || appendEmptyBatch)
-        {
-            Assert.True(ObserveAge() > 0);
-            using var cancellation = new CancellationTokenSource();
-            var nextRead = reader.ReadAsync(cancellation.Token).AsTask();
-            Assert.Equal(0, ObserveAge());
-            cancellation.Cancel();
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => nextRead);
-        }
+        Assert.True(ObserveAge() > 0);
+        using var cancellation = new CancellationTokenSource();
+        var nextRead = reader.ReadAsync(cancellation.Token).AsTask();
+        Assert.Equal(0, ObserveAge());
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => nextRead);
 
         Assert.Equal(0, ObserveAge());
         return;
@@ -400,99 +370,6 @@ public class ReaderMetricsReporterTests
             AssertTags(point, "message-age-consumer", readerName);
             return point.GetGaugeLastValueDouble();
         }
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task LocalBufferMessageAgeMax_RetainsInactiveBatchesUntilRemoved(bool reconnect)
-    {
-        var timeout = TimeSpan.FromSeconds(5);
-        using var meterProvider = CreateMeterProvider([]);
-        var mockStream = new Mock<ReaderStream>();
-        var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
-        var handledEvents = Channel.CreateUnbounded<long>();
-        SetupResponseStream(mockStream, responses, handledEvents.Writer);
-        await using var reader = new ReaderBuilder<string>(CreateDriverFactory(mockStream, "message-age-inactive"))
-        {
-            SubscribeSettings = { new SubscribeSettings("/topic") }
-        }.Build();
-        var metricsSource = (IReaderMetricsSource)reader;
-
-        await SendResponse(InitResponse, 0);
-        await SendResponse(StartPartitionSessionRequest(), 1);
-        await responses.Writer.WriteAsync((true, ReadResponse("obsolete"u8.ToArray())));
-        await SendResponse(StartPartitionSessionRequest(partitionSessionId: 2), 2);
-        Assert.True(metricsSource.LocalBufferMessageAgeMax > 0);
-
-        if (reconnect)
-        {
-            await responses.Writer.WriteAsync((false, null));
-            await SendResponse(InitResponse, 0);
-        }
-        else
-        {
-            await SendResponse(StopPartitionSessionRequest(), -1);
-        }
-
-        Assert.True(metricsSource.LocalBufferMessageAgeMax > 0);
-        await SendResponse(StartPartitionSessionRequest(partitionSessionId: 3), 3);
-        var freshResponse = ReadResponse("fresh"u8.ToArray());
-        freshResponse.ReadResponse.PartitionData[0].PartitionSessionId = 3;
-        await responses.Writer.WriteAsync((true, freshResponse));
-        await SendResponse(StartPartitionSessionRequest(partitionSessionId: 4), 4);
-
-        Assert.True(metricsSource.LocalBufferMessageAgeMax > 0);
-        Assert.Equal("fresh", Assert.Single((await reader.ReadBatchAsync().AsTask().WaitAsync(timeout)).Batch).Data);
-        Assert.Equal(0, metricsSource.LocalBufferMessageAgeMax);
-        return;
-
-        async Task SendResponse(FromServer response, long expectedEvent)
-        {
-            await responses.Writer.WriteAsync((true, response));
-            Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
-        }
-    }
-
-    [Fact]
-    public async Task LocalBufferMessageAgeMax_DoesNotRetainDequeuedBatchAfterDeserializationFailure()
-    {
-        var timeout = TimeSpan.FromSeconds(5);
-        using var meterProvider = CreateMeterProvider([]);
-        var mockStream = new Mock<ReaderStream>();
-        var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
-        var handledEvents = Channel.CreateUnbounded<long>();
-        SetupResponseStream(mockStream, responses, handledEvents.Writer);
-        var deserializer = new Mock<IDeserializer<string>>();
-        deserializer.Setup(instance => instance.Deserialize(It.IsAny<byte[]>())).Returns((byte[] data) =>
-        {
-            var value = Encoding.UTF8.GetString(data);
-            return value == "bad" ? throw new InvalidOperationException("Invalid data") : value;
-        });
-        await using var reader =
-            new ReaderBuilder<string>(CreateDriverFactory(mockStream, "message-age-deserialization"))
-            {
-                Deserializer = deserializer.Object,
-                SubscribeSettings = { new SubscribeSettings("/topic") }
-            }.Build();
-        var metricsSource = (IReaderMetricsSource)reader;
-
-        await responses.Writer.WriteAsync((true, InitResponse));
-        await responses.Writer.WriteAsync((true, StartPartitionSessionRequest()));
-        await responses.Writer.WriteAsync((true, ReadResponse("bad"u8.ToArray(), "unread"u8.ToArray())));
-        await responses.Writer.WriteAsync((true, ReadResponse(2, "fresh"u8.ToArray())));
-        await responses.Writer.WriteAsync((true, StartPartitionSessionRequest(partitionSessionId: 2)));
-        for (var expectedEvent = 0; expectedEvent <= 2; expectedEvent++)
-        {
-            Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
-        }
-
-        var error = await Assert.ThrowsAsync<ReaderException>(() =>
-            reader.ReadBatchAsync().AsTask().WaitAsync(timeout));
-        Assert.IsType<InvalidOperationException>(error.InnerException);
-        Assert.True(metricsSource.LocalBufferMessageAgeMax > 0);
-        Assert.Equal("fresh", Assert.Single((await reader.ReadBatchAsync().AsTask().WaitAsync(timeout)).Batch).Data);
-        Assert.Equal(0, metricsSource.LocalBufferMessageAgeMax);
     }
 
     [Fact]

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -293,7 +293,21 @@ public class ReaderMetricsReporterTests
     }
 
     [Fact]
-    public async Task LocalBufferMessageAgeMax_TracksMessageUntilDelivery()
+    public void ReadResponseStart_CapturesTimestampOnlyWhenAgeGaugeIsEnabled()
+    {
+        Assert.Equal(0, ReaderMetricsReporter.ReportReadResponseStart());
+        using (CreateMeterProvider([]))
+        {
+            Assert.True(ReaderMetricsReporter.ReportReadResponseStart() > 0);
+        }
+
+        Assert.Equal(0, ReaderMetricsReporter.ReportReadResponseStart());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task LocalBufferMessageAgeMax_TracksFifoAcrossTopicsUntilDelivery(bool readLastAsBatch)
     {
         const string readerName = "message-age-reader";
         const string metricName = "ydb.topic.reader.local_buffer.message_age.max";
@@ -315,7 +329,7 @@ public class ReaderMetricsReporterTests
             ConsumerName = "message-age-consumer",
             ReaderName = readerName,
             Deserializer = deserializer.Object,
-            SubscribeSettings = { new SubscribeSettings("/topic") }
+            SubscribeSettings = { new SubscribeSettings("/topic"), new SubscribeSettings("/another-topic") }
         }.Build();
 
         Assert.Equal(0, ObserveAge());
@@ -323,12 +337,30 @@ public class ReaderMetricsReporterTests
         Assert.Equal("s", GetMetric(exportedItems, metricName).Unit);
         await responses.Writer.WriteAsync((true, InitResponse));
         await responses.Writer.WriteAsync((true, StartPartitionSessionRequest()));
+        var anotherPartition = StartPartitionSessionRequest(partitionSessionId: 2);
+        anotherPartition.StartPartitionSessionRequest.PartitionSession.Path = "/another-topic";
+        await responses.Writer.WriteAsync((true, anotherPartition));
         await responses.Writer.WriteAsync((true, ReadResponse("first"u8.ToArray(), "second"u8.ToArray())));
+        var anotherTopicResponse = ReadResponse("third"u8.ToArray());
+        anotherTopicResponse.ReadResponse.PartitionData[0].PartitionSessionId = 2;
+        await responses.Writer.WriteAsync((true, anotherTopicResponse));
+        await responses.Writer.WriteAsync((true, ReadResponse()));
+        await responses.Writer.WriteAsync((true, StartPartitionSessionRequest(partitionSessionId: 3)));
+        for (var expectedEvent = 0; expectedEvent <= 3; expectedEvent++)
+        {
+            Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
+        }
 
         Assert.Equal("first", (await reader.ReadAsync().AsTask().WaitAsync(timeout)).Data);
         Assert.True(ObserveAge() > 0);
         var batch = await reader.ReadBatchAsync().AsTask().WaitAsync(timeout);
         Assert.Equal("second", Assert.Single(batch.Batch).Data);
+        Assert.True(ObserveAge() > 0);
+        var last = readLastAsBatch
+            ? Assert.Single((await reader.ReadBatchAsync().AsTask().WaitAsync(timeout)).Batch)
+            : await reader.ReadAsync().AsTask().WaitAsync(timeout);
+        Assert.Equal("third", last.Data);
+        Assert.Equal("/another-topic", last.Topic);
         Assert.Equal(0, ObserveAge());
         return;
 
@@ -337,7 +369,7 @@ public class ReaderMetricsReporterTests
             exportedItems.Clear();
             meterProvider.ForceFlush();
             var point = Assert.Single(GetReaderPoints(exportedItems, metricName, readerName));
-            AssertTags(point, "message-age-consumer", readerName, "/topic");
+            AssertTags(point, "message-age-consumer", readerName);
             return point.GetGaugeLastValueDouble();
         }
     }

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -305,9 +305,13 @@ public class ReaderMetricsReporterTests
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task LocalBufferMessageAgeMax_TracksFifoAcrossTopicsUntilBatchRemoval(bool readLastAsBatch)
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task LocalBufferMessageAgeMax_TracksFifoAcrossTopicsUntilBatchRemoval(
+        bool readLastAsBatch,
+        bool appendEmptyBatch)
     {
         const string readerName = "message-age-reader";
         const string metricName = "ydb.topic.reader.local_buffer.message_age.max";
@@ -322,8 +326,17 @@ public class ReaderMetricsReporterTests
         var deserializer = new Mock<IDeserializer<string>>();
         deserializer.Setup(instance => instance.Deserialize(It.IsAny<byte[]>())).Returns((byte[] data) =>
         {
-            Assert.True(ObserveAge() > 0);
-            return Encoding.UTF8.GetString(data);
+            var value = Encoding.UTF8.GetString(data);
+            if (value == "third" && readLastAsBatch && !appendEmptyBatch)
+            {
+                Assert.Equal(0, ObserveAge());
+            }
+            else
+            {
+                Assert.True(ObserveAge() > 0);
+            }
+
+            return value;
         });
         await using var reader = new ReaderBuilder<string>(CreateDriverFactory(mockStream, readerName))
         {
@@ -345,7 +358,11 @@ public class ReaderMetricsReporterTests
         var anotherTopicResponse = ReadResponse("third"u8.ToArray());
         anotherTopicResponse.ReadResponse.PartitionData[0].PartitionSessionId = 2;
         await responses.Writer.WriteAsync((true, anotherTopicResponse));
-        await responses.Writer.WriteAsync((true, ReadResponse()));
+        if (appendEmptyBatch)
+        {
+            await responses.Writer.WriteAsync((true, ReadResponse()));
+        }
+
         await responses.Writer.WriteAsync((true, StartPartitionSessionRequest(partitionSessionId: 3)));
         for (var expectedEvent = 0; expectedEvent <= 3; expectedEvent++)
         {
@@ -362,7 +379,7 @@ public class ReaderMetricsReporterTests
             : await reader.ReadAsync().AsTask().WaitAsync(timeout);
         Assert.Equal("third", last.Data);
         Assert.Equal("/another-topic", last.Topic);
-        if (!readLastAsBatch)
+        if (!readLastAsBatch || appendEmptyBatch)
         {
             Assert.True(ObserveAge() > 0);
             using var cancellation = new CancellationTokenSource();
@@ -383,6 +400,99 @@ public class ReaderMetricsReporterTests
             AssertTags(point, "message-age-consumer", readerName);
             return point.GetGaugeLastValueDouble();
         }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task LocalBufferMessageAgeMax_RetainsInactiveBatchesUntilRemoved(bool reconnect)
+    {
+        var timeout = TimeSpan.FromSeconds(5);
+        using var meterProvider = CreateMeterProvider([]);
+        var mockStream = new Mock<ReaderStream>();
+        var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
+        var handledEvents = Channel.CreateUnbounded<long>();
+        SetupResponseStream(mockStream, responses, handledEvents.Writer);
+        await using var reader = new ReaderBuilder<string>(CreateDriverFactory(mockStream, "message-age-inactive"))
+        {
+            SubscribeSettings = { new SubscribeSettings("/topic") }
+        }.Build();
+        var metricsSource = (IReaderMetricsSource)reader;
+
+        await SendResponse(InitResponse, 0);
+        await SendResponse(StartPartitionSessionRequest(), 1);
+        await responses.Writer.WriteAsync((true, ReadResponse("obsolete"u8.ToArray())));
+        await SendResponse(StartPartitionSessionRequest(partitionSessionId: 2), 2);
+        Assert.True(metricsSource.LocalBufferMessageAgeMax > 0);
+
+        if (reconnect)
+        {
+            await responses.Writer.WriteAsync((false, null));
+            await SendResponse(InitResponse, 0);
+        }
+        else
+        {
+            await SendResponse(StopPartitionSessionRequest(), -1);
+        }
+
+        Assert.True(metricsSource.LocalBufferMessageAgeMax > 0);
+        await SendResponse(StartPartitionSessionRequest(partitionSessionId: 3), 3);
+        var freshResponse = ReadResponse("fresh"u8.ToArray());
+        freshResponse.ReadResponse.PartitionData[0].PartitionSessionId = 3;
+        await responses.Writer.WriteAsync((true, freshResponse));
+        await SendResponse(StartPartitionSessionRequest(partitionSessionId: 4), 4);
+
+        Assert.True(metricsSource.LocalBufferMessageAgeMax > 0);
+        Assert.Equal("fresh", Assert.Single((await reader.ReadBatchAsync().AsTask().WaitAsync(timeout)).Batch).Data);
+        Assert.Equal(0, metricsSource.LocalBufferMessageAgeMax);
+        return;
+
+        async Task SendResponse(FromServer response, long expectedEvent)
+        {
+            await responses.Writer.WriteAsync((true, response));
+            Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
+        }
+    }
+
+    [Fact]
+    public async Task LocalBufferMessageAgeMax_DoesNotRetainDequeuedBatchAfterDeserializationFailure()
+    {
+        var timeout = TimeSpan.FromSeconds(5);
+        using var meterProvider = CreateMeterProvider([]);
+        var mockStream = new Mock<ReaderStream>();
+        var responses = Channel.CreateUnbounded<(bool HasNext, FromServer? Response)>();
+        var handledEvents = Channel.CreateUnbounded<long>();
+        SetupResponseStream(mockStream, responses, handledEvents.Writer);
+        var deserializer = new Mock<IDeserializer<string>>();
+        deserializer.Setup(instance => instance.Deserialize(It.IsAny<byte[]>())).Returns((byte[] data) =>
+        {
+            var value = Encoding.UTF8.GetString(data);
+            return value == "bad" ? throw new InvalidOperationException("Invalid data") : value;
+        });
+        await using var reader =
+            new ReaderBuilder<string>(CreateDriverFactory(mockStream, "message-age-deserialization"))
+            {
+                Deserializer = deserializer.Object,
+                SubscribeSettings = { new SubscribeSettings("/topic") }
+            }.Build();
+        var metricsSource = (IReaderMetricsSource)reader;
+
+        await responses.Writer.WriteAsync((true, InitResponse));
+        await responses.Writer.WriteAsync((true, StartPartitionSessionRequest()));
+        await responses.Writer.WriteAsync((true, ReadResponse("bad"u8.ToArray(), "unread"u8.ToArray())));
+        await responses.Writer.WriteAsync((true, ReadResponse(2, "fresh"u8.ToArray())));
+        await responses.Writer.WriteAsync((true, StartPartitionSessionRequest(partitionSessionId: 2)));
+        for (var expectedEvent = 0; expectedEvent <= 2; expectedEvent++)
+        {
+            Assert.Equal(expectedEvent, await handledEvents.Reader.ReadAsync().AsTask().WaitAsync(timeout));
+        }
+
+        var error = await Assert.ThrowsAsync<ReaderException>(() =>
+            reader.ReadBatchAsync().AsTask().WaitAsync(timeout));
+        Assert.IsType<InvalidOperationException>(error.InnerException);
+        Assert.True(metricsSource.LocalBufferMessageAgeMax > 0);
+        Assert.Equal("fresh", Assert.Single((await reader.ReadBatchAsync().AsTask().WaitAsync(timeout)).Batch).Data);
+        Assert.Equal(0, metricsSource.LocalBufferMessageAgeMax);
     }
 
     [Fact]

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderMetricsReporterTests.cs
@@ -307,7 +307,7 @@ public class ReaderMetricsReporterTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public async Task LocalBufferMessageAgeMax_TracksFifoAcrossTopicsUntilDelivery(bool readLastAsBatch)
+    public async Task LocalBufferMessageAgeMax_TracksFifoAcrossTopicsUntilBatchRemoval(bool readLastAsBatch)
     {
         const string readerName = "message-age-reader";
         const string metricName = "ydb.topic.reader.local_buffer.message_age.max";
@@ -361,6 +361,16 @@ public class ReaderMetricsReporterTests
             : await reader.ReadAsync().AsTask().WaitAsync(timeout);
         Assert.Equal("third", last.Data);
         Assert.Equal("/another-topic", last.Topic);
+        if (!readLastAsBatch)
+        {
+            Assert.True(ObserveAge() > 0);
+            using var cancellation = new CancellationTokenSource();
+            var nextRead = reader.ReadAsync(cancellation.Token).AsTask();
+            Assert.Equal(0, ObserveAge());
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => nextRead);
+        }
+
         Assert.Equal(0, ObserveAge());
         return;
 


### PR DESCRIPTION
## Pull request type

- [x] Feature

## What is the current behavior?

Topic Reader reports the number of locally buffered messages, but not how long they have been waiting for delivery.

Issue: [YDBAPPTEAM-1954](https://st.yandex-team.ru/YDBAPPTEAM-1954)

## What is the new behavior?

- Add `ydb.topic.reader.local_buffer.message_age.max`, an observable gauge in seconds with one maximum per Reader across all topics and partitions, using the existing Reader tags without `topic`.
- Use `Channel.Reader.TryPeek` to read the oldest batch's receive timestamp; report zero for an empty buffer or a batch without a timestamp. No additional queue or in-flight batch field is needed.
- Capture a monotonic timestamp only while the gauge is enabled, following the ADO metrics pattern; otherwise store zero.
- Keep batches visible during deserialization and retain their original timestamp across reconnects until removal. `ReadAsync` removes a batch when `TryDequeueMessage` returns false, so a fully consumed batch remains visible until the next read. `ReadBatchAsync` removes the batch after processing it.
- Extend `IReaderMetricsSource` from `main` for the age gauge; keep batch removal in `ReadAsync` identical to `main`, without an external `IsActive` check.

## Other information

- Rebased onto `main` (`176c53b`), preserving the local-buffer count, session-error, and credit-balance metrics.
- Topic test project builds successfully; all 44 non-integration tests pass, including credit balance, gauge enablement, multiple topics, deserialization, both read APIs, and an empty batch.
- Integration tests were not run (local Docker unavailable).
