### PR TITLE
fix: close Topic Reader session initialized after disposal

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fix Topic Reader: close a session that finishes initialization after the reader has been disposed instead of
+  starting its read loop.
 - Dev: bumped the metrics observability-chain minor version in `x-ydb-sdk-build-info` from
   `ydb-sdk-metrics/0.1.0` to `ydb-sdk-metrics/0.2.0`.
 - Feat Topic Reader metrics: added the following instruments to the `Ydb.Sdk.Topic` meter. Metric names below omit the

--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,5 +1,4 @@
-- Fix Topic Reader: close a session that finishes initialization after the reader has been disposed instead of
-  starting its read loop.
+- Fix Topic Reader: close a session that finishes initialization after the reader has been disposed.
 - Dev: bumped the metrics observability-chain minor version in `x-ydb-sdk-build-info` from
   `ydb-sdk-metrics/0.1.0` to `ydb-sdk-metrics/0.2.0`.
 - Feat Topic Reader metrics: added the following instruments to the `Ydb.Sdk.Topic` meter. Metric names below omit the

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -224,16 +224,19 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = _config.MemoryUsageMaxBytes }
             }).ConfigureAwait(false);
 
-            _currentReaderSession = new ReaderSession<TValue>(
-                _config,
-                stream,
-                initResponse.SessionId,
-                Reconnect,
-                await stream.AuthToken().ConfigureAwait(false),
-                _logger,
-                _receivedMessagesChannel.Writer,
-                _deserializer,
-                _metrics
+            Interlocked.Exchange(
+                ref _currentReaderSession,
+                new ReaderSession<TValue>(
+                    _config,
+                    stream,
+                    initResponse.SessionId,
+                    Reconnect,
+                    await stream.AuthToken().ConfigureAwait(false),
+                    _logger,
+                    _receivedMessagesChannel.Writer,
+                    _deserializer,
+                    _metrics
+                )
             );
             if (_disposeCts.IsCancellationRequested)
             {

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -123,7 +123,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             return;
         }
 
-        _currentReaderSession = null;
+        Interlocked.Exchange(ref _currentReaderSession, null);
         _metrics.ResetCreditBalanceBytes();
         _metrics.ResetLocalBufferMessages();
         _metrics.ReportSessionError(statusCode);

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -224,7 +224,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = _config.MemoryUsageMaxBytes }
             }).ConfigureAwait(false);
 
-            _currentReaderSession = new ReaderSession<TValue>(
+            var readerSession = new ReaderSession<TValue>(
                 _config,
                 stream,
                 initResponse.SessionId,
@@ -235,8 +235,16 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 _deserializer,
                 _metrics
             );
+            _currentReaderSession = readerSession;
+            if (_disposeCts.IsCancellationRequested)
+            {
+                await (Interlocked.Exchange(ref _currentReaderSession, null)?.DisposeAsync() ??
+                       ValueTask.CompletedTask).ConfigureAwait(false);
+                return;
+            }
+
             _metrics.ResetCreditBalanceBytes(_config.MemoryUsageMaxBytes);
-            _currentReaderSession.Start();
+            readerSession.Start();
         }
         catch (YdbException e)
         {
@@ -257,7 +265,8 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
         _disposeCts.Cancel();
         _metrics.Dispose();
 
-        await (_currentReaderSession?.DisposeAsync() ?? ValueTask.CompletedTask).ConfigureAwait(false);
+        await (Interlocked.Exchange(ref _currentReaderSession, null)?.DisposeAsync() ??
+               ValueTask.CompletedTask).ConfigureAwait(false);
         if (_driver != null)
         {
             await _driver.DisposeAsync().ConfigureAwait(false);

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -125,7 +125,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             return;
         }
 
-        Interlocked.Exchange(ref _currentReaderSession, null);
+        Volatile.Write(ref _currentReaderSession, null);
         _metrics.ResetCreditBalanceBytes();
         _metrics.ResetLocalBufferMessages();
         _metrics.ReportSessionError(statusCode);

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -237,8 +237,11 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             );
             if (_disposeCts.IsCancellationRequested)
             {
-                await (Interlocked.Exchange(ref _currentReaderSession, null)?.DisposeAsync() ??
-                       ValueTask.CompletedTask).ConfigureAwait(false);
+                if (Interlocked.Exchange(ref _currentReaderSession, null) is { } readerSession)
+                {
+                    await readerSession.DisposeAsync().ConfigureAwait(false);
+                }
+
                 return;
             }
 

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -226,35 +226,30 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = _config.MemoryUsageMaxBytes }
             }).ConfigureAwait(false);
 
-            Interlocked.Exchange(
-                ref _currentReaderSession,
-                new ReaderSession<TValue>(
-                    _config,
-                    stream,
-                    initResponse.SessionId,
-                    Reconnect,
-                    await stream.AuthToken().ConfigureAwait(false),
-                    _logger,
-                    _receivedMessagesChannel.Writer,
-                    _deserializer,
-                    _metrics
-                )
+            var readerSession = new ReaderSession<TValue>(
+                _config,
+                stream,
+                initResponse.SessionId,
+                Reconnect,
+                await stream.AuthToken().ConfigureAwait(false),
+                _logger,
+                _receivedMessagesChannel.Writer,
+                _deserializer,
+                _metrics
             );
+            Interlocked.Exchange(ref _currentReaderSession, readerSession);
             if (_disposeCts.IsCancellationRequested)
             {
-                if (Interlocked.Exchange(ref _currentReaderSession, null) is { } readerSession)
+                if (Interlocked.Exchange(ref _currentReaderSession, null) is { } sessionToDispose)
                 {
-                    await readerSession.DisposeAsync().ConfigureAwait(false);
+                    await sessionToDispose.DisposeAsync().ConfigureAwait(false);
                 }
 
                 return;
             }
 
             _metrics.ResetCreditBalanceBytes(_config.MemoryUsageMaxBytes);
-            if (Volatile.Read(ref _currentReaderSession) is { } currentReaderSession)
-            {
-                currentReaderSession.Start();
-            }
+            readerSession.Start();
         }
         catch (YdbException e)
         {

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -226,6 +226,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = _config.MemoryUsageMaxBytes }
             }).ConfigureAwait(false);
 
+            _metrics.ResetCreditBalanceBytes(_config.MemoryUsageMaxBytes);
             var readerSession = new ReaderSession<TValue>(
                 _config,
                 stream,
@@ -247,9 +248,6 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
 
                 return;
             }
-
-            _metrics.ResetCreditBalanceBytes(_config.MemoryUsageMaxBytes);
-            readerSession.Start();
         }
         catch (YdbException e)
         {
@@ -302,23 +300,17 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
 /// 5) Let's assume client somehow processes it, and its 200 bytes buffer is free again.
 ///    It should account for excess 10 bytes and send ReadRequest with bytes_size = 210.
 /// </summary>
-internal class ReaderSession<TValue>(
-    ReaderConfig config,
-    ReaderStream stream,
-    string sessionId,
-    Action<StatusCode> reconnect,
-    string? lastToken,
-    ILogger logger,
-    ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
-    IDeserializer<TValue> deserializer,
-    ReaderMetricsReporter metrics
-) : TopicSession<MessageFromClient, MessageFromServer>(stream, logger, sessionId, reconnect, lastToken)
+internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFromServer>
 {
     private const double FreeBufferCoefficient = 0.2;
 
+    private readonly ReaderConfig _config;
+    private readonly ChannelWriter<InternalBatchMessages<TValue>> _channelWriter;
+    private readonly IDeserializer<TValue> _deserializer;
+    private readonly ReaderMetricsReporter _metrics;
     private readonly CancellationTokenSource _lifecycleReaderSessionCts = new();
-    private Task _runProcessingStreamResponse = Task.CompletedTask;
-    private Task _runProcessingStreamRequest = Task.CompletedTask;
+    private readonly Task _runProcessingStreamResponse;
+    private readonly Task _runProcessingStreamRequest;
 
     private readonly Channel<MessageFromClient> _channelFromClientMessageSending =
         Channel.CreateUnbounded<MessageFromClient>(
@@ -333,8 +325,22 @@ internal class ReaderSession<TValue>(
 
     private long _readRequestBytes;
 
-    internal void Start()
+    internal ReaderSession(
+        ReaderConfig config,
+        ReaderStream stream,
+        string sessionId,
+        Action<StatusCode> reconnect,
+        string? lastToken,
+        ILogger logger,
+        ChannelWriter<InternalBatchMessages<TValue>> channelWriter,
+        IDeserializer<TValue> deserializer,
+        ReaderMetricsReporter metrics
+    ) : base(stream, logger, sessionId, reconnect, lastToken)
     {
+        _config = config;
+        _channelWriter = channelWriter;
+        _deserializer = deserializer;
+        _metrics = metrics;
         _runProcessingStreamResponse = RunProcessingStreamResponse();
         _runProcessingStreamRequest = RunProcessingStreamRequest();
     }
@@ -441,7 +447,7 @@ internal class ReaderSession<TValue>(
     {
         var readRequestBytes = Interlocked.Add(ref _readRequestBytes, bytes);
 
-        if (readRequestBytes < FreeBufferCoefficient * config.MemoryUsageMaxBytes)
+        if (readRequestBytes < FreeBufferCoefficient * _config.MemoryUsageMaxBytes)
         {
             return;
         }
@@ -452,7 +458,7 @@ internal class ReaderSession<TValue>(
                 .WriteAsync(new MessageFromClient
                     { ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = readRequestBytes } })
                 .ConfigureAwait(false);
-            metrics.ReportCreditBalanceBytes(readRequestBytes);
+            _metrics.ReportCreditBalanceBytes(readRequestBytes);
         }
     }
 
@@ -491,7 +497,7 @@ internal class ReaderSession<TValue>(
             if (_partitionSessions.TryGetValue(partitionsCommittedOffset.PartitionSessionId,
                     out var partitionSession))
             {
-                metrics.ReportCommitAcknowledged(
+                _metrics.ReportCommitAcknowledged(
                     partitionSession.HandleCommitedOffset(partitionsCommittedOffset.CommittedOffset),
                     partitionSession.TopicPath);
             }
@@ -568,7 +574,7 @@ internal class ReaderSession<TValue>(
                     }
                 ).ConfigureAwait(false);
 
-                metrics.ReportCommitQueued(
+                _metrics.ReportCommitQueued(
                     commitSending.OffsetsRange.End - commitSending.OffsetsRange.Start,
                     partitionSession.TopicPath);
             }
@@ -593,8 +599,8 @@ internal class ReaderSession<TValue>(
     {
         var receivedTimestamp = ReaderMetricsReporter.ReportReadResponseStart();
         var bytesSize = readResponse.BytesSize;
-        metrics.ReportCreditBalanceBytes(-bytesSize);
-        metrics.ReportReceivedBytes(bytesSize);
+        _metrics.ReportCreditBalanceBytes(-bytesSize);
+        _metrics.ReportReceivedBytes(bytesSize);
         var partitionCount = readResponse.PartitionData.Count;
 
         for (var partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++)
@@ -615,7 +621,7 @@ internal class ReaderSession<TValue>(
                 for (var batchIndex = 0; batchIndex < batchCount; batchIndex++)
                 {
                     var batch = batches[batchIndex];
-                    await channelWriter.WriteAsync(
+                    await _channelWriter.WriteAsync(
                         new InternalBatchMessages<TValue>(
                             batch,
                             partitionSession,
@@ -625,13 +631,13 @@ internal class ReaderSession<TValue>(
                                 countParts: batchCount,
                                 currentIndex: batchIndex
                             ),
-                            deserializer,
+                            _deserializer,
                             receivedTimestamp
                         )
                     ).ConfigureAwait(false);
 
-                    metrics.ReportLocalBufferMessages(batch.MessageData.Count);
-                    metrics.ReportReceived(batch.MessageData.Count, partitionSession.TopicPath);
+                    _metrics.ReportLocalBufferMessages(batch.MessageData.Count);
+                    _metrics.ReportReceived(batch.MessageData.Count, partitionSession.TopicPath);
                 }
             }
             else

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -224,7 +224,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 ReadRequest = new StreamReadMessage.Types.ReadRequest { BytesSize = _config.MemoryUsageMaxBytes }
             }).ConfigureAwait(false);
 
-            var readerSession = new ReaderSession<TValue>(
+            _currentReaderSession = new ReaderSession<TValue>(
                 _config,
                 stream,
                 initResponse.SessionId,
@@ -235,7 +235,6 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
                 _deserializer,
                 _metrics
             );
-            _currentReaderSession = readerSession;
             if (_disposeCts.IsCancellationRequested)
             {
                 await (Interlocked.Exchange(ref _currentReaderSession, null)?.DisposeAsync() ??
@@ -244,7 +243,7 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             }
 
             _metrics.ResetCreditBalanceBytes(_config.MemoryUsageMaxBytes);
-            readerSession.Start();
+            _currentReaderSession?.Start();
         }
         catch (YdbException e)
         {

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -227,26 +227,26 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             }).ConfigureAwait(false);
 
             _metrics.ResetCreditBalanceBytes(_config.MemoryUsageMaxBytes);
-            var readerSession = new ReaderSession<TValue>(
-                _config,
-                stream,
-                initResponse.SessionId,
-                Reconnect,
-                await stream.AuthToken().ConfigureAwait(false),
-                _logger,
-                _receivedMessagesChannel.Writer,
-                _deserializer,
-                _metrics
+            Interlocked.Exchange(
+                ref _currentReaderSession,
+                new ReaderSession<TValue>(
+                    _config,
+                    stream,
+                    initResponse.SessionId,
+                    Reconnect,
+                    await stream.AuthToken().ConfigureAwait(false),
+                    _logger,
+                    _receivedMessagesChannel.Writer,
+                    _deserializer,
+                    _metrics
+                )
             );
-            Interlocked.Exchange(ref _currentReaderSession, readerSession);
             if (_disposeCts.IsCancellationRequested)
             {
                 if (Interlocked.Exchange(ref _currentReaderSession, null) is { } sessionToDispose)
                 {
                     await sessionToDispose.DisposeAsync().ConfigureAwait(false);
                 }
-
-                return;
             }
         }
         catch (YdbException e)

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -58,14 +58,16 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
         _ = Initialize();
     }
 
-    long IReaderMetricsSource.PartitionSessionCount => _currentReaderSession?.PartitionSessionCount ?? 0;
+    long IReaderMetricsSource.PartitionSessionCount =>
+        Volatile.Read(ref _currentReaderSession)?.PartitionSessionCount ?? 0;
 
     double IReaderMetricsSource.LocalBufferMessageAgeMax =>
         _receivedMessagesChannel.Reader.TryPeek(out var batch) && batch.ReceivedTimestamp > 0
             ? Stopwatch.GetElapsedTime(batch.ReceivedTimestamp).TotalSeconds
             : 0;
 
-    long IReaderMetricsSource.CommitOffsetLagMax => _currentReaderSession?.CommitOffsetLagMax ?? 0;
+    long IReaderMetricsSource.CommitOffsetLagMax =>
+        Volatile.Read(ref _currentReaderSession)?.CommitOffsetLagMax ?? 0;
 
     public async ValueTask<Message<TValue>> ReadAsync(CancellationToken cancellationToken = default)
     {
@@ -249,7 +251,10 @@ internal class Reader<TValue> : IReader<TValue>, IReaderMetricsSource
             }
 
             _metrics.ResetCreditBalanceBytes(_config.MemoryUsageMaxBytes);
-            _currentReaderSession?.Start();
+            if (Volatile.Read(ref _currentReaderSession) is { } currentReaderSession)
+            {
+                currentReaderSession.Start();
+            }
         }
         catch (YdbException e)
         {

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
@@ -1569,7 +1569,7 @@ public class ReaderUnitTests
     }
 
     [Fact]
-    public async Task DisposeAsync_WhenInitializeContinues_DisposesSession()
+    public async Task DisposeAsync_WhenInitializationContinues_DisposesReader()
     {
         var authTokenRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var authToken = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
@@ -1569,25 +1569,26 @@ public class ReaderUnitTests
     }
 
     [Fact]
-    public async Task DisposeAsync_WhenInitializeContinues_DoesNotStartSession()
+    public async Task DisposeAsync_WhenInitializeContinues_DisposesSession()
     {
         var authTokenRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var authToken = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var disposedBeforeStart = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         _mockStream.Setup(stream => stream.Write(It.IsAny<FromClient>())).Returns(Task.CompletedTask);
         _mockStream.SetupSequence(stream => stream.MoveNextAsync())
             .ReturnsAsync(true)
             .Returns(() =>
             {
-                disposedBeforeStart.TrySetResult(false);
+                sessionStarted.TrySetResult();
                 return _lastMoveNext;
             });
         _mockStream.Setup(stream => stream.Current).Returns(InitResponse);
         _mockStream.Setup(stream => stream.AuthToken())
             .Callback(authTokenRequested.SetResult)
             .Returns(() => new ValueTask<string?>(authToken.Task));
-        _mockStream.Setup(stream => stream.Dispose()).Callback(() => disposedBeforeStart.TrySetResult(true));
+        _mockStream.Setup(stream => stream.Dispose()).Callback(sessionDisposed.SetResult);
 
         var reader = new ReaderBuilder<string>(_driverFactoryMock)
         {
@@ -1599,14 +1600,10 @@ public class ReaderUnitTests
         await reader.DisposeAsync();
         authToken.SetResult(null);
 
-        var wasDisposed = await disposedBeforeStart.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        if (!wasDisposed)
-        {
-            await _mockStream.Object.RequestStreamComplete();
-        }
+        await sessionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await sessionDisposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.True(wasDisposed);
-        _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Once);
+        _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Exactly(2));
         _mockStream.Verify(stream => stream.Dispose(), Times.Once);
     }
 

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
@@ -1568,6 +1568,48 @@ public class ReaderUnitTests
         await reader.DisposeAsync();
     }
 
+    [Fact]
+    public async Task DisposeAsync_WhenInitializeContinues_DoesNotStartSession()
+    {
+        var authTokenRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var authToken = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var disposedBeforeStart = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _mockStream.Setup(stream => stream.Write(It.IsAny<FromClient>())).Returns(Task.CompletedTask);
+        _mockStream.SetupSequence(stream => stream.MoveNextAsync())
+            .ReturnsAsync(true)
+            .Returns(() =>
+            {
+                disposedBeforeStart.TrySetResult(false);
+                return _lastMoveNext;
+            });
+        _mockStream.Setup(stream => stream.Current).Returns(InitResponse);
+        _mockStream.Setup(stream => stream.AuthToken())
+            .Callback(authTokenRequested.SetResult)
+            .Returns(() => new ValueTask<string?>(authToken.Task));
+        _mockStream.Setup(stream => stream.Dispose()).Callback(() => disposedBeforeStart.TrySetResult(true));
+
+        var reader = new ReaderBuilder<string>(_driverFactoryMock)
+        {
+            ConsumerName = "Consumer Tester",
+            SubscribeSettings = { new SubscribeSettings("/topic") }
+        }.Build();
+
+        await authTokenRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await reader.DisposeAsync();
+        authToken.SetResult(null);
+
+        var wasDisposed = await disposedBeforeStart.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        if (!wasDisposed)
+        {
+            await _mockStream.Object.RequestStreamComplete();
+        }
+
+        Assert.True(wasDisposed);
+        _mockStream.Verify(stream => stream.MoveNextAsync(), Times.Once);
+        _mockStream.Verify(stream => stream.Dispose(), Times.Once);
+    }
+
     private class FailDeserializer : IDeserializer<int>
     {
         public int Deserialize(byte[] data) => throw new Exception("Some serialize exception");


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

If `DisposeAsync` runs while a Topic Reader is still initializing, the in-flight initialization can publish and start a new `ReaderSession` after the reader has already been disposed, leaving its read loop and resources alive.

Issue Number: N/A

## What is the new behavior?

After assigning the initialized session, the Reader checks whether disposal has started. The initialization and disposal paths use `Interlocked.Exchange` to clear and claim the current session, so it is closed once and a session completed after disposal is not started.

A deterministic mock test covers the race and verifies that the stream is disposed once and the read loop is not started.

## Other information

Validation:
- `ReaderUnitTests`: 16 passed.
- Reader unit and metrics tests: 25 passed.
- `dotnet build src/YdbSdk.sln --no-restore`: succeeded.
- CI code cleanup completed successfully.