### PR TITLE
fix: harden Topic Reader committed offset handling

### DIFF
--- a/src/Ydb.Sdk/CHANGELOG.md
+++ b/src/Ydb.Sdk/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix Topic Reader: do not send redundant commit requests for already committed offsets or closed partition sessions.
 - Fix Topic Reader: close a session that finishes initialization after the reader has been disposed.
 - Dev: bumped the metrics observability-chain minor version in `x-ydb-sdk-build-info` from
   `ydb-sdk-metrics/0.1.0` to `ydb-sdk-metrics/0.2.0`.

--- a/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/PartitionSession.cs
@@ -13,6 +13,7 @@ internal class PartitionSession(
     private readonly ConcurrentQueue<CommitSending> _waitCommitMessages = new();
 
     private volatile bool _isStopped;
+    private long _commitedOffset = commitedOffset;
 
     internal bool IsActive => !_isStopped;
 
@@ -27,30 +28,37 @@ internal class PartitionSession(
 
     internal long PrevEndOffsetMessage { get; set; } = commitedOffset;
 
-    internal long CommitOffsetLag => _waitCommitMessages.LastOrDefault()?.OffsetsRange.End - CommitedOffset ?? 0;
+    internal long CommitOffsetLag =>
+        Math.Max(0, _waitCommitMessages.LastOrDefault()?.OffsetsRange.End - CommitedOffset ?? 0);
 
     // Each offset up to and including (committed_offset - 1) was fully processed.
-    private long CommitedOffset { get; set; } = commitedOffset;
+    private long CommitedOffset
+    {
+        get => Volatile.Read(ref _commitedOffset);
+        set => Volatile.Write(ref _commitedOffset, value);
+    }
 
-    internal void RegisterCommitRequest(CommitSending commitSending)
+    internal bool RegisterCommitRequest(CommitSending commitSending)
     {
         var endOffset = commitSending.OffsetsRange.End;
 
         if (endOffset < CommitedOffset)
         {
             commitSending.TcsCommit.SetResult();
+
+            return false;
         }
-        else
+
+        if (_isStopped)
         {
-            if (_isStopped)
-            {
-                Utils.SetPartitionClosedException(commitSending, PartitionSessionId);
+            Utils.SetPartitionClosedException(commitSending, PartitionSessionId);
 
-                return;
-            }
-
-            _waitCommitMessages.Enqueue(commitSending);
+            return false;
         }
+
+        _waitCommitMessages.Enqueue(commitSending);
+
+        return true;
     }
 
     internal long HandleCommitedOffset(long commitedOffset)

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -554,33 +554,34 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
 
         if (_partitionSessions.TryGetValue(partitionSessionId, out var partitionSession))
         {
-            partitionSession.RegisterCommitRequest(commitSending);
-
-            try
+            if (partitionSession.RegisterCommitRequest(commitSending))
             {
-                await _channelFromClientMessageSending.Writer.WriteAsync(new MessageFromClient
-                    {
-                        CommitOffsetRequest = new StreamReadMessage.Types.CommitOffsetRequest
+                try
+                {
+                    await _channelFromClientMessageSending.Writer.WriteAsync(new MessageFromClient
                         {
-                            CommitOffsets =
+                            CommitOffsetRequest = new StreamReadMessage.Types.CommitOffsetRequest
                             {
-                                new StreamReadMessage.Types.CommitOffsetRequest.Types.PartitionCommitOffset
+                                CommitOffsets =
                                 {
-                                    Offsets = { commitSending.OffsetsRange },
-                                    PartitionSessionId = partitionSessionId
+                                    new StreamReadMessage.Types.CommitOffsetRequest.Types.PartitionCommitOffset
+                                    {
+                                        Offsets = { commitSending.OffsetsRange },
+                                        PartitionSessionId = partitionSessionId
+                                    }
                                 }
                             }
                         }
-                    }
-                ).ConfigureAwait(false);
+                    ).ConfigureAwait(false);
 
-                _metrics.ReportCommitQueued(
-                    commitSending.OffsetsRange.End - commitSending.OffsetsRange.Start,
-                    partitionSession.TopicPath);
-            }
-            catch (ChannelClosedException)
-            {
-                throw new ReaderException("Reader is disposed");
+                    _metrics.ReportCommitQueued(
+                        commitSending.OffsetsRange.End - commitSending.OffsetsRange.Start,
+                        partitionSession.TopicPath);
+                }
+                catch (ChannelClosedException)
+                {
+                    throw new ReaderException("Reader is disposed");
+                }
             }
         }
         else

--- a/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
+++ b/src/Ydb.Sdk/src/Topic/Reader/Reader.cs
@@ -552,36 +552,34 @@ internal class ReaderSession<TValue> : TopicSession<MessageFromClient, MessageFr
 
         var commitSending = new CommitSending(offsetsRange, tcsCommit);
 
-        if (_partitionSessions.TryGetValue(partitionSessionId, out var partitionSession))
+        if (_partitionSessions.TryGetValue(partitionSessionId, out var partitionSession) &&
+            partitionSession.RegisterCommitRequest(commitSending))
         {
-            if (partitionSession.RegisterCommitRequest(commitSending))
+            try
             {
-                try
-                {
-                    await _channelFromClientMessageSending.Writer.WriteAsync(new MessageFromClient
+                await _channelFromClientMessageSending.Writer.WriteAsync(new MessageFromClient
+                    {
+                        CommitOffsetRequest = new StreamReadMessage.Types.CommitOffsetRequest
                         {
-                            CommitOffsetRequest = new StreamReadMessage.Types.CommitOffsetRequest
+                            CommitOffsets =
                             {
-                                CommitOffsets =
+                                new StreamReadMessage.Types.CommitOffsetRequest.Types.PartitionCommitOffset
                                 {
-                                    new StreamReadMessage.Types.CommitOffsetRequest.Types.PartitionCommitOffset
-                                    {
-                                        Offsets = { commitSending.OffsetsRange },
-                                        PartitionSessionId = partitionSessionId
-                                    }
+                                    Offsets = { commitSending.OffsetsRange },
+                                    PartitionSessionId = partitionSessionId
                                 }
                             }
                         }
-                    ).ConfigureAwait(false);
+                    }
+                ).ConfigureAwait(false);
 
-                    _metrics.ReportCommitQueued(
-                        commitSending.OffsetsRange.End - commitSending.OffsetsRange.Start,
-                        partitionSession.TopicPath);
-                }
-                catch (ChannelClosedException)
-                {
-                    throw new ReaderException("Reader is disposed");
-                }
+                _metrics.ReportCommitQueued(
+                    commitSending.OffsetsRange.End - commitSending.OffsetsRange.Start,
+                    partitionSession.TopicPath);
+            }
+            catch (ChannelClosedException)
+            {
+                throw new ReaderException("Reader is disposed");
             }
         }
         else

--- a/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
+++ b/src/Ydb.Sdk/test/Ydb.Sdk.Topic.Tests/ReaderUnitTests.cs
@@ -331,6 +331,51 @@ public class ReaderUnitTests
             msg.CommitOffsetRequest.CommitOffsets[0].Offsets[0].End == 12)));
     }
 
+    [Fact]
+    public async Task CommitAsync_WhenOffsetAlreadyCommitted_DoesNotSendRequest()
+    {
+        var timeout = TimeSpan.FromSeconds(5);
+        var commitResponseReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var commitRequestWritten = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _mockStream.Setup(stream => stream.Write(It.IsAny<FromClient>()))
+            .Callback<FromClient>(message =>
+            {
+                if (message.CommitOffsetRequest != null)
+                {
+                    commitRequestWritten.TrySetResult();
+                }
+            })
+            .Returns(Task.CompletedTask);
+        _mockStream.SetupSequence(stream => stream.MoveNextAsync())
+            .ReturnsAsync(true)
+            .ReturnsAsync(true)
+            .ReturnsAsync(true)
+            .Returns(commitResponseReady.Task)
+            .Returns(_lastMoveNext);
+        _mockStream.SetupSequence(stream => stream.Current)
+            .Returns(InitResponse)
+            .Returns(StartPartitionSessionRequest(10))
+            .Returns(ReadResponse(10, "First"u8.ToArray(), "Second"u8.ToArray()))
+            .Returns(CommitOffsetResponse(12));
+
+        await using var reader = new ReaderBuilder<string>(_driverFactoryMock)
+        {
+            ConsumerName = "Consumer",
+            SubscribeSettings = { new SubscribeSettings("/topic") }
+        }.Build();
+
+        var batch = await reader.ReadBatchAsync();
+        var batchCommit = batch.CommitBatchAsync();
+        await commitRequestWritten.Task.WaitAsync(timeout);
+        commitResponseReady.SetResult(true);
+        await batchCommit.WaitAsync(timeout);
+        await batch.Batch[0].CommitAsync().WaitAsync(timeout);
+
+        _mockStream.Verify(stream => stream.Write(It.Is<FromClient>(message =>
+            message.CommitOffsetRequest != null)), Times.Once);
+    }
+
     /*
      * Performed invocations:
 


### PR DESCRIPTION
## Summary

- publish the committed offset through `Volatile.Read` and `Volatile.Write` in the existing property
- make `RegisterCommitRequest` return whether a request was registered, and skip sending when the offset is already committed or the partition session is stopped
- clamp the best-effort commit offset lag at zero because the pending queue and committed offset are read independently
- avoid locks and combined snapshots

## Validation

- focused already-committed request test: 1 passed
- Reader unit and metrics tests: 26 passed